### PR TITLE
Clarify platform support and acceleration lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # KartPad
 
 <p align="center">
-  <strong>Mario Kart Wii and Retro Rewind on Apple Silicon Mac, iPhone, and iPad.</strong><br>
-  Native static recompilation through Metal, with touch controls, motion steering, controllers, and optional Retro Rewind content.
+  <strong>Mario Kart Wii and Retro Rewind, native for iOS, iPadOS, macOS, and tvOS.</strong><br>
+  Native static recompilation through Metal, with touch controls, motion steering, controllers, and optional Retro Rewind content. tvOS is currently an experimental preview.
 </p>
 
 <p align="center">
@@ -391,9 +391,10 @@ available without a separate controller:
   input.
 - **Mario Kart shoulders:** R is a compact digital control matching L rather
   than SunPad's Sunshine-specific analog-pressure trigger.
-- **Held acceleration:** A stays asserted for the full touch. After one
-  uninterrupted second it turns cyan and adds light haptic feedback, then
-  returns to green and releases acceleration when the finger lifts.
+- **Acceleration lock:** hold A for one uninterrupted second to turn it cyan,
+  add light haptic feedback, and keep accelerating after lifting your finger.
+  Tap A again to unlock it. Opening a modal, hiding touch controls, or handing
+  Player 1 to a controller also clears the lock.
 - **Customize:** move and resize controls independently, save separate phone
   and tablet arrangements, or reset to the exact default layout.
 - **Controller handoff:** the first extended controller takes Player 1, clears

--- a/docs/TVOS.md
+++ b/docs/TVOS.md
@@ -2,11 +2,11 @@
 
 ## Current status
 
-Native tvOS support is under active implementation on the maintainer-owned
-`codex/tvos-retro-rewind` branch. There is no public tvOS build and no accepted
-Apple TV gameplay result yet. Until the physical acceptance matrix below
-passes, the correct claim is **buildable experimental tvOS candidate**, not
-supported Apple TV release.
+Native tvOS support is available as the experimental public
+`v0.4.0-preview.1` hardware-bring-up build. There is still no accepted Apple TV
+gameplay result. Until the physical acceptance matrix below passes, the correct
+claim is **public experimental tvOS preview**, not supported Apple TV
+functionality.
 
 This implementation starts from KartPad `main`, the project's pinned upstream
 sources, and Apple/SDL platform contracts. It does not incorporate code from


### PR DESCRIPTION
## Summary
- describe KartPad as native for iOS, iPadOS, macOS, and experimental tvOS
- document the existing one-second touch acceleration lock accurately
- replace the stale pre-release tvOS status wording

## Verification
- python3 -m unittest tests.test_ios_touch_acceleration_lock_contract tests.test_ios_menu_lifecycle_contract
- git diff --check