### PR TITLE
Document Preview 2 release verification

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -2,18 +2,18 @@
 
 ## Current state
 
-KartPad `v0.4.0-preview.1` is published from
-`4d32dfac683966ea1cb4f72963deffbe936404da`. The release adds an
-independent native arm64 tvOS 17 target, a three-layer original Apple TV icon,
-safe private-data staging, durable save/configuration storage, purgeable game
-and Retro Rewind caches, controller-only gameplay, backup, and bounded
-diagnostics. Its separate unsigned iPhone/iPad and tvOS IPAs were each packaged
-twice byte-identically, and the freshly downloaded hosted artifacts match and
-re-audit. Their SHA-256 values are respectively
-`5b959d7a6abba43db3d557bbba3dc3a1ab913650f0717cdf8600afa06fcb32c1`
-and `78dcdf28c947330d480fcc789f0b81b95bafe94497c56f9c26bb6249c5362df1`.
-No physical Apple TV has run this implementation, so tvOS remains an explicitly
-unaccepted tester path.
+KartPad `v0.4.0-preview.2` is published from
+`e9fa6058ee09fff0b16481ebe4a78d61cea69c87`. It updates both Apple-platform
+artifacts for Retro Rewind 6.12.5, repairs the universal iPhone/iPad three-dot
+menu refresh, and adds a daily upstream-version watcher plus deterministic
+profile updater. Its separate unsigned iPhone/iPad and tvOS IPAs were each
+packaged twice byte-identically, and the freshly downloaded hosted artifacts
+match and re-audit. Their SHA-256 values are respectively
+`a796cd0e29bfd47d78afc50989a959803f9eff434252a3a455af85308b380fe6`
+and `3f8f529a93cc3f1ddfe9e9b71171ba56ead5a49ae3598c449a42f00eed6c5a9a`.
+The signed iPhone build 14 was installed in place, launched, and preserved the
+pre-install configuration, identity, preferences, NAND, and saves byte-for-
+byte. Physical 6.12.5 gameplay and Apple TV remain external acceptance gates.
 
 KartPad `v0.3.0-preview.5` is published from
 `8e57ac49c161ff576d6eff198ade2ee9b21f575e`. Its unsigned app 0.3.0 build 12
@@ -59,8 +59,8 @@ The full device build, app audit, deterministic packaging, hosted checksum,
 and fresh hosted re-audit pass. Issue #1 remains open for reporter confirmation
 on the exact affected iPad and Files provider.
 
-The preview offers Original Mario Kart Wii or optional Retro Rewind 6.12.4.
-A physical iPad completed the official pack download, verification,
+The preview offers Original Mario Kart Wii or optional Retro Rewind 6.12.5.
+The preceding 6.12.4 build completed physical iPad pack download, verification,
 installation, launch, and a playable single-player match. General physical
 execution is accepted on iPad and iPhone. Retro WFC remains unavailable during
 external service maintenance; live public online play is not claimed and does
@@ -68,7 +68,7 @@ not block offline Retro Rewind support.
 
 ## Next executable work
 
-1. Collect the first physical Apple TV report against `v0.4.0-preview.1` using
+1. Collect the first physical Apple TV report against `v0.4.0-preview.2` using
    `docs/TVOS-TESTING.md`.
 2. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook
    Air cursor/settings retest requested against Preview 5.

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -26,10 +26,16 @@ limitations when its exact artifact passes every preview gate below.
 - [x] Kamek v2/v3 parser keeps file and command bounds validation
 - [x] Universal iPhone/iPad menu refresh cannot restore the SunPad menu
 - [x] Daily upstream-version check and deterministic profile updater
-- [ ] Exact merged source produces iPhone/iPad build 14 and tvOS build 2
-- [ ] Both IPAs package twice byte-identically and pass fresh extraction audits
-- [ ] Release tag, hosted assets, checksums, and hosted re-audits match locally
+- [x] Exact merged source produces iPhone/iPad build 14 and tvOS build 2
+- [x] Both IPAs package twice byte-identically and pass fresh extraction audits
+- [x] Release tag, hosted assets, checksums, and hosted re-audits match locally
 - [ ] Physical testers accept the 6.12.5 flow and the Apple TV matrix
+
+Published source: `e9fa6058ee09fff0b16481ebe4a78d61cea69c87`.
+iPhone/iPad IPA SHA-256:
+`a796cd0e29bfd47d78afc50989a959803f9eff434252a3a455af85308b380fe6`.
+tvOS IPA SHA-256:
+`3f8f529a93cc3f1ddfe9e9b71171ba56ead5a49ae3598c449a42f00eed6c5a9a`.
 
 ## 0.4.0 Preview 1 candidate
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -15,7 +15,7 @@ paired with the current Mac, so signing, installation, execution, gameplay,
 performance, and save recovery remain untested. Apple TV support is therefore
 not accepted. The candidate includes an original three-layer tvOS icon and Top
 Shelf image compiled into its audited asset catalog. It is published as the
-explicitly experimental `v0.4.0-preview.1` hardware-bring-up build. The next
+explicitly experimental `v0.4.0-preview.2` hardware-bring-up build. The next
 gate is a small outside cohort using the exact audited candidate and tester
 checklist. The
 authoritative scope, build procedure, storage boundary, and external-testing
@@ -24,13 +24,18 @@ gate are in
 
 ## Current goal
 
-**0.4.0 Preview 2 is the current release candidate.** It advances the pinned
-Retro Rewind input and translated graph to 6.12.5, adds a daily upstream
-version watcher and deterministic profile updater, and repairs the universal
-iPhone/iPad three-dot menu after inherited settings refreshes. The candidate
-is app 0.4.0 build 14 on iPhone/iPad and build 2 on tvOS. Translation and source
-contracts pass; exact merged-source platform builds, deterministic packages,
-hosted comparison, and physical 6.12.5/tvOS acceptance remain separate gates.
+**0.4.0 Preview 2 is published.** `v0.4.0-preview.2` points to source commit
+`e9fa6058ee09fff0b16481ebe4a78d61cea69c87`. Its app 0.4.0 build 14
+iPhone/iPad IPA has SHA-256
+`a796cd0e29bfd47d78afc50989a959803f9eff434252a3a455af85308b380fe6`;
+its app 0.4.0 build 2 tvOS IPA has SHA-256
+`3f8f529a93cc3f1ddfe9e9b71171ba56ead5a49ae3598c449a42f00eed6c5a9a`.
+It advances the pinned Retro Rewind input and translated graph to 6.12.5, adds
+a daily upstream version watcher and deterministic profile updater, and repairs
+the universal iPhone/iPad three-dot menu after inherited settings refreshes.
+Exact merged-source builds, deterministic double packages, hosted byte
+comparison, checksums, fresh hosted audits, and the daily workflow pass.
+Physical 6.12.5 gameplay and tvOS acceptance remain separate gates.
 The established physical 6.12.4 iPad result is not relabeled as 6.12.5 proof.
 
 **0.4.0 Preview 1 is published.** `v0.4.0-preview.1` points to source commit

--- a/docs/releases/NEXT.md
+++ b/docs/releases/NEXT.md
@@ -43,15 +43,18 @@ Apple TV acceptance.
 
 ## Release gates
 
-- [ ] Merge and verify the complete source on `main`.
-- [ ] Rebuild exact merged source as iOS 0.4.0 build 14 and tvOS 0.4.0 build 2.
-- [ ] Pass full tests, source/safety checks, patch verification, app audits, and
+- [x] Merge and verify the complete source on `main`.
+- [x] Rebuild exact merged source as iOS 0.4.0 build 14 and tvOS 0.4.0 build 2.
+- [x] Pass full tests, source/safety checks, patch verification, app audits, and
       Objective-C++ analysis.
-- [ ] Package each IPA twice deterministically and compare bytes.
-- [ ] Audit exact IPAs and embedded provenance/notices.
-- [ ] Tag the audited source and publish both IPAs plus `SHA256SUMS`.
-- [ ] Download hosted assets, byte-compare, checksum-verify, and re-audit.
-- [ ] Verify remote `main` and the dereferenced tag, then request device tests.
+- [x] Package each IPA twice deterministically and compare bytes.
+- [x] Audit exact IPAs and embedded provenance/notices.
+- [x] Tag the audited source and publish both IPAs plus `SHA256SUMS`.
+- [x] Download hosted assets, byte-compare, checksum-verify, and re-audit.
+- [x] Verify remote `main` and the dereferenced tag, then request device tests.
 
-Published source and artifact hashes are recorded here only after the hosted
-assets pass the same checks as the local candidates.
+- Published source: `e9fa6058ee09fff0b16481ebe4a78d61cea69c87`
+- iPhone/iPad IPA SHA-256:
+  `a796cd0e29bfd47d78afc50989a959803f9eff434252a3a455af85308b380fe6`
+- tvOS IPA SHA-256:
+  `3f8f529a93cc3f1ddfe9e9b71171ba56ead5a49ae3598c449a42f00eed6c5a9a`


### PR DESCRIPTION
Records the completed v0.4.0-preview.2 release chain: exact merged-source builds, deterministic iOS/tvOS packages, hosted byte comparisons and re-audits, release hashes, and the preserved iPhone data boundary. Physical Retro Rewind 6.12.5 gameplay and Apple TV acceptance remain explicitly open.