### PR TITLE
Document KartPad 0.4.0 release verification

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -2,6 +2,17 @@
 
 ## Current state
 
+KartPad `v0.4.0` is published as the second stable community release from
+`369159153bef0d045edf5cc1cf3b1b444b36a284`. The iPhone/iPad app 0.4.0 build
+15 IPA has SHA-256
+`af80c2bc6fcabdb4eee84aed05254eccef76d7e6bbf83f2c7f21101168c665c8`;
+the experimental tvOS app 0.4.0 build 3 IPA has SHA-256
+`9ee2a9b05bff56261d4d4986eca54840e98ade8ae0abd3ac623c1f2393dcf5cc`.
+Both exact-main builds and two independent packages per platform pass. Fresh
+anonymous downloads match the local bytes, checksums, provenance, and audits.
+GitHub marks this non-prerelease as **Latest**. Physical Apple TV acceptance
+remains open.
+
 The `codex/iphone-touch-layout-editor` candidate captures the maintainer's
 current physical-iPhone control positions as the default for untouched iPhone
 installs only. Existing custom layouts and every iPad layout remain unchanged.

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -25,10 +25,16 @@ limitations when its exact artifact passes every preview gate below.
 - [x] Physical iPhone accepts per-control Hide/Show and the editor Back path
 - [x] Untouched-iPhone default seeding preserves custom iPhone and iPad layouts
 - [x] Full tests, source pins, repository safety, and SunPad snapshot pass
-- [ ] Exact merged source produces iPhone/iPad build 15 and tvOS build 3
-- [ ] Both IPAs package twice byte-identically and pass extraction audits
-- [ ] Stable tag, hosted assets, checksums, and hosted re-audits match locally
-- [ ] Remote `main` and dereferenced `v0.4.0` match the audited source
+- [x] Exact merged source produces iPhone/iPad build 15 and tvOS build 3
+- [x] Both IPAs package twice byte-identically and pass extraction audits
+- [x] Stable tag, hosted assets, checksums, and hosted re-audits match locally
+- [x] Remote `main` and dereferenced `v0.4.0` match the audited source
+
+Published source: `369159153bef0d045edf5cc1cf3b1b444b36a284`.
+iPhone/iPad IPA SHA-256:
+`af80c2bc6fcabdb4eee84aed05254eccef76d7e6bbf83f2c7f21101168c665c8`.
+tvOS IPA SHA-256:
+`9ee2a9b05bff56261d4d4986eca54840e98ade8ae0abd3ac623c1f2393dcf5cc`.
 
 ## 0.4.0 Preview 2 candidate
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -24,16 +24,18 @@ gate are in
 
 ## Current goal
 
-**The next iPhone touch-layout candidate passed maintainer testing.**
-It seeds the maintainer's captured compact layout only on untouched iPhone
-installs, leaves existing custom layouts and all iPad layouts unchanged, lets
-users hide or restore individual controls (including the D-pad as one group),
-and returns from layout editing to Touch Control Settings with **Back**. The
-D-pad remains visible by default because it performs tricks and wheelies. The
-source and pinned-overlay contracts, full test suite, device build, package
-audit, signed in-place install, launch, and save/preferences preservation pass.
-The physical iPhone also passed Retro Rewind launch, per-control hiding, and
-the editor's Back path. The stable 0.4.0 build/package/publish chain is next.
+**0.4.0 is published as KartPad's second stable community release.** The
+`v0.4.0` tag points to source commit
+`369159153bef0d045edf5cc1cf3b1b444b36a284`. Its iPhone/iPad app 0.4.0 build
+15 IPA has SHA-256
+`af80c2bc6fcabdb4eee84aed05254eccef76d7e6bbf83f2c7f21101168c665c8`;
+its experimental tvOS app 0.4.0 build 3 IPA has SHA-256
+`9ee2a9b05bff56261d4d4986eca54840e98ade8ae0abd3ac623c1f2393dcf5cc`.
+The physical iPhone passed Retro Rewind 6.12.5 launch, per-control hiding, and
+the editor's Back path. Exact merged-source builds, double deterministic
+packages, local and fresh hosted audits, hosted byte comparison, checksums,
+and remote tag/main verification pass. Physical Apple TV acceptance remains
+open, so that included artifact is still explicitly experimental.
 
 **0.4.0 Preview 2 is published.** `v0.4.0-preview.2` points to source commit
 `e9fa6058ee09fff0b16481ebe4a78d61cea69c87`. Its app 0.4.0 build 14

--- a/docs/releases/NEXT.md
+++ b/docs/releases/NEXT.md
@@ -38,12 +38,18 @@ retaining the existing app container, preferences, game data, and saves.
 
 ## Release gates
 
-- [ ] Merge and verify the complete source on `main`.
-- [ ] Rebuild exact merged source as iOS 0.4.0 build 15 and tvOS build 3.
+- [x] Merge and verify the complete source on `main`.
+- [x] Rebuild exact merged source as iOS 0.4.0 build 15 and tvOS build 3.
 - [x] Pass full tests, source/safety checks, patch verification, app audits, and
       physical iPhone touch-editor acceptance.
-- [ ] Package each IPA twice deterministically and compare bytes.
-- [ ] Audit exact IPAs and embedded provenance/notices.
-- [ ] Tag the audited source and publish both IPAs plus `SHA256SUMS`.
-- [ ] Download hosted assets, byte-compare, checksum-verify, and re-audit.
-- [ ] Verify remote `main` and the dereferenced tag.
+- [x] Package each IPA twice deterministically and compare bytes.
+- [x] Audit exact IPAs and embedded provenance/notices.
+- [x] Tag the audited source and publish both IPAs plus `SHA256SUMS`.
+- [x] Download hosted assets, byte-compare, checksum-verify, and re-audit.
+- [x] Verify remote `main` and the dereferenced tag.
+
+- Published source: `369159153bef0d045edf5cc1cf3b1b444b36a284`
+- iPhone/iPad IPA SHA-256:
+  `af80c2bc6fcabdb4eee84aed05254eccef76d7e6bbf83f2c7f21101168c665c8`
+- tvOS IPA SHA-256:
+  `9ee2a9b05bff56261d4d4986eca54840e98ade8ae0abd3ac623c1f2393dcf5cc`


### PR DESCRIPTION
Records the published stable source commit, platform build numbers, deterministic package results, hosted artifact checksums, fresh hosted audits, and remaining physical Apple TV acceptance boundary.