### PR TITLE
Prepare autonomous Android implementation handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 | Does online play work? | The online-capable build passes login, matchmaking, a two-player race, results, ratings, and lobby return against a compatible isolated WFC server. As of 1 September 2026, the public Retro WFC service is in maintenance, so live public online play is temporarily unavailable. That external outage does not block Retro Rewind installation or offline play. |
 | Do touch, tilt, and controllers work? | Touch, motion steering, and ordinary GameController-compatible pads are implemented, with general physical acceptance on iPhone and iPad. Direct Wii Remote/Nunchuk pairing is a separate experimental, macOS-only path that still needs external hardware testing. |
 | Can I use a custom Mii? | **Experimentally.** On Mac, iPhone, or iPad, open **Game Data & Saves → Manage Miis…** and import a standard 74-byte `.mii` file. Restart KartPad, then select it in **License Settings → Change Mii**. KartPad does not yet create Miis. |
-| Are Android and Apple TV supported? | Apple TV has an experimental native hardware-bring-up IPA in `v0.4.0`, but it is not accepted as supported until physical testers complete the matrix. Android is documented as a future implementation target, not a supported build. |
+| Are Android and Apple TV supported? | Apple TV has an experimental native hardware-bring-up IPA in `v0.4.0`, but it is not accepted as supported until physical testers complete the matrix. Native Android implementation is now an active, evidence-gated project; no Android APK or runtime claim exists yet. |
 | How much storage does it need? | The app is about 80 MiB and extracted Mario Kart Wii data uses about 2.5 GiB. Retro Rewind downloads an additional 1.72 GiB archive and needs temporary installation space. Keeping the WBFS/ISO on the device requires more space. |
 
 ## Original Mario Kart Wii or Retro Rewind
@@ -569,7 +569,10 @@ Apple Silicon Mac, iPhone, and iPad are supported. An experimental native Apple
 TV tester IPA is included in `v0.4.0`; it has passed build and package
 audits but still needs physical Apple TV acceptance before tvOS can be called
 supported. See [the tvOS implementation and acceptance plan](docs/TVOS.md).
-Android may be investigated later.
+Native Android implementation is now active, beginning with a reproducible
+ARM64 toolchain, JNI shell, and Vulkan fixture. No Android APK or gameplay
+claim exists yet. See the [Android architecture and feasibility plan](docs/ANDROID.md)
+and [autonomous Android goal loop](docs/ANDROID-GOAL-LOOP.md).
 
 ### How much storage does KartPad use?
 

--- a/docs/ANDROID-GOAL-LOOP.md
+++ b/docs/ANDROID-GOAL-LOOP.md
@@ -1,0 +1,266 @@
+# KartPad Android autonomous goal loop
+
+## Objective
+
+Build KartPad for Android as the same product, not a reduced companion app:
+the existing ahead-of-time ARM64 Original Mario Kart Wii and Retro Rewind
+runtime, Aurora/Dawn rendering, SDL audio/controllers, KartPad setup and data
+management, and the accepted touch experience hosted natively on Android.
+
+Proceed autonomously through the lowest incomplete goal. Continue until the
+Android release-candidate gate passes or progress genuinely requires a human,
+private game input that is not already available, physical Android hardware,
+new legal terms, credentials, payment, or public-release authorization.
+
+This document is the operational loop. [`ANDROID.md`](ANDROID.md) is the
+architecture, risk, and acceptance authority.
+
+## Required reading before changes
+
+Read completely, in this order:
+
+1. repository `AGENTS.md` instructions;
+2. [`ANDROID.md`](ANDROID.md);
+3. this goal loop;
+4. [`STATUS.md`](STATUS.md), [`HANDOFF.md`](HANDOFF.md), and the latest complete
+   entry in [`JOURNAL.md`](JOURNAL.md);
+5. [`PRD.md`](PRD.md), especially architecture, privacy, correctness, mobile,
+   and release gates;
+6. `dependencies.lock.json` and the current Retro Rewind profile in
+   `builder/profiles/mkwii-rmcp01-rev0.json`;
+7. the current iPhone/iPad owner layer, mobile input bridge, tvOS host, and
+   pinned SunPad files named by `ANDROID.md`.
+
+Do not implement from an older branch, preview tag, copied local checkout, or
+the SunPad Android plan. Start from current `origin/main` and record its exact
+commit.
+
+## Standing authorization and boundaries
+
+You are authorized to:
+
+- inventory the machine and network-download the Android/Java build tools
+  required by this work;
+- install a user-local or Android-Studio-managed pinned JDK, SDK command-line
+  tools, SDK platforms, Build Tools, Platform Tools, NDK, CMake/Ninja support,
+  Gradle dependencies, Android Emulator, and ARM64 system images;
+- download repository-authorized dependencies from their official sources,
+  verify them, cache them locally, and add reproducible lock metadata;
+- create AVDs, build/install/debug local APKs, run tests, and use available
+  attached Android hardware within the project scope;
+- create a `codex/` feature branch, commit coherent passing checkpoints, push
+  it, and open focused pull requests.
+
+You are not authorized to:
+
+- download, publish, copy into Git, or expose Mario Kart Wii data, Nintendo
+  assets, saves, NAND data, generated translated shards, signing keys, device
+  identifiers, credentials, or private captures;
+- accept new legal terms, create accounts, bypass CAPTCHA, purchase tools, or
+  publish an APK/AAB without explicit human authorization;
+- replace KartPad with Dolphin, streaming, a PowerPC interpreter/JIT, or
+  executable code downloaded at runtime;
+- rewrite unrelated Apple code or break the stable Apple build to make Android
+  easier;
+- assume an emulator proves physical performance, touch feel, audio latency,
+  OEM lifecycle behavior, or release readiness.
+
+If private generated code or user-owned game data is already present on the
+machine, use it only from ignored private paths and record hashes without
+printing or publishing contents. If it is absent, complete every source-only
+and non-private goal available before asking for it.
+
+## Product parity baseline
+
+Reuse the portable runtime instead of cloning it. Keep one shared C/C++ product
+core and thin platform owners:
+
+- reuse the dual-profile product selection, translated graph, HLE, guest
+  memory contracts, Classic Controller adapter, input state/mixing rules, SDL
+  audio/controller layer, networking semantics, settings meanings, archive
+  validation rules, and diagnostic redaction rules where portable;
+- extract shared C++ only when an Android consumer and regression test justify
+  it; do not perform a speculative cross-platform rewrite;
+- keep Kotlin/JNI/Android Views, content URIs, activity/service lifecycle,
+  sensors, haptics, and system intents under `android/`;
+- treat Objective-C/UIKit as the behavioral oracle, not Android-compilable
+  source. Express shared layout/style/state data once when that reduces drift.
+
+The Android UI must preserve the accepted KartPad behavior:
+
+- an Original Mario Kart Wii / Retro Rewind chooser;
+- a menu titled **KartPad**, with the same consolidated Display, Controls,
+  Touch Control Settings, Game Data & Saves, Multiplayer, Motion Steering, and
+  diagnostics hierarchy; never show the SunPad title or obsolete experimental
+  performance/60 FPS entries;
+- Original 4:3 plus the same clearly labeled experimental aspect choices;
+- A/B/X/Y/Z/Start/L/R, sticks, and grouped D-pad with the same Classic input
+  mapping; the D-pad performs tricks and wheelies;
+- multitouch, controller handoff, held-input clearing, global opacity/size,
+  per-control move/resize/Hide/Show, layout reset, and **Back** returning from
+  the editor to Touch Control Settings;
+- the one-second A acceleration lock enabled by default for touch, cyan locked
+  state, light haptic confirmation, and tap-to-unlock;
+- the accepted compact defaults for untouched phones, while preserving
+  existing customized layouts and using the existing tablet defaults;
+- first-run import, Retro Rewind 6.12.5 install/version handling, Mii
+  management, save-preserving data removal, and bounded diagnostics.
+
+Where Android system UI differs, preserve the product action and outcome while
+using the real platform picker, permission, sharing, and accessibility APIs.
+
+## Goal ladder
+
+Goals are cumulative. A compile is evidence for a build row only; it does not
+complete runtime or hands-on rows.
+
+### A0 — Reproducible toolchain and source-only shell
+
+Deliver the minimal `android/` Gradle/SDLActivity project, pinned wrapper and
+plugin versions, `scripts/check-android-host.sh`, an explicit bootstrap script,
+one ARM64 phone AVD, one 16 KiB AVD where supported, a source-only JNI fixture,
+and locked Dawn Android metadata.
+
+Pass when a clean checkout can run one documented command to verify tools and
+one documented command to build, install, launch, and exercise the JNI fixture
+without private data or undocumented absolute paths.
+
+### A1 — Android native primitives and Vulkan surface
+
+Add the Android CMake shared-library product, PIC/ELF link, Android guest-memory
+and AArch64 fiber implementations, SDL surface lifecycle, Dawn Vulkan device,
+deterministic clear/readback/present fixture, 4 KiB and 16 KiB tests, and an APK
+native-library audit.
+
+Pass only after create/destroy/recreate, rotation, background/foreground, and a
+long scheduler/register stress fixture succeed. Reassess before full-game work
+if the 4 GiB alias model cannot be made safe without writable executable pages
+or device-address hacks.
+
+### A2 — Controller-driven Original game proof
+
+Link the current private dual graph when authorized inputs exist, stage
+validated `RMCP01` data privately, copy packaged runtime resources into
+versioned private storage, and boot the Original profile.
+
+Pass separately on an ARM64 emulator and physical Android hardware after
+title/menu navigation, one complete race, results, save, quit/relaunch,
+pause/resume, surface recreation, audible SDL output, and one controller all
+succeed. Without physical hardware, record the emulator result and keep A2
+open.
+
+### A3 — Retro Rewind 6.12.5 offline proof
+
+Use the current repository profile as the only version/hash authority. Port or
+extract the bounded archive validation, download, free-space preflight,
+staging, atomic activation, rollback, cancellation, and recovery contract.
+
+Pass independently on emulator and physical hardware after a complete Retro
+Rewind race, results, save/relaunch, Original/Retro mode switching, and fault
+tests for corrupt input, mismatched hash, network loss, full disk, process
+death, activity recreation, and an existing valid installation. Never accept
+an accidental fallback to Original.
+
+### A4 — KartPad shell and touch parity
+
+Implement the current first-run flow, menu hierarchy, settings, imports,
+touch overlay/editor, acceleration lock, haptics, controller handoff, motion
+steering, Mii management, data/save actions, and diagnostics.
+
+Pass automated phone/tablet golden images, hit maps, multi-pointer replay,
+accessibility checks, state persistence, and modal/lifecycle input clearing.
+Then require hands-on touch-only races on a physical phone and tablet; leave
+those rows open if hardware is unavailable.
+
+### A5 — Online and device hardening
+
+Implement the native guest TLS backend, deterministic local network fixtures,
+Android-emulator/local-WFC flow, and macOS/Android cross-client play. Add
+Adreno/Mali, controller, audio-route, storage-provider, lifecycle, memory,
+thermal, battery, frame-pacing, reconnect, and upgrade/save-recovery coverage.
+
+Use production Retro WFC only when it is available and a normal test is
+permitted. Never use public infrastructure for stress, malformed traffic, or
+automation volume.
+
+### A6 — Release candidate
+
+Produce deterministic auditable unsigned APK/AAB outputs, verify only intended
+ABIs and 16 KiB alignment, audit permissions/dependencies/symbols/paths/private
+data/notices, sign a designated candidate only when authorized, and prove
+update-in-place and save export/restore on physical devices.
+
+Pass only when mandatory Android rows are green, no P0/P1 defects remain, the
+exact candidate is tested, and hosted/publication authority is explicit. Do
+not publish merely because packaging succeeds.
+
+## The repeated work loop
+
+Repeat until A6 passes or a genuine human-only boundary is reached:
+
+1. **Sync and inspect.** Fetch `origin`, preserve any unrelated dirty work,
+   read the latest Android/status/journal evidence, and select the lowest
+   incomplete goal.
+2. **State one falsifiable subgoal.** Choose the smallest reversible change
+   with a concrete expected result and immediate test.
+3. **Record the baseline.** Note commit, tree state, toolchain/lock digest,
+   ABI, API/page size, AVD/device, renderer, and relevant artifact hashes.
+4. **Implement narrowly.** Reuse existing KartPad/runtime code and add the
+   smallest Android-specific owner. Do not mix unrelated UI, runtime, and
+   performance changes.
+5. **Test immediately.** Run the narrow unit/contract test, then the smallest
+   JNI/app/runtime test capable of disproving the change.
+6. **Run Apple regressions when shared code changes.** At minimum run affected
+   tests, `scripts/verify-sunpad-overlay-snapshot.sh`, source verification, and
+   the smallest applicable Apple build contract.
+7. **Audit boundaries.** Check generated packages and logs for private data,
+   translated shards, absolute user paths, signing material, credentials, and
+   unintended ABIs/dependencies.
+8. **Classify honestly.** Mark Pass, Fail, Regressed, Inconclusive, or Blocked
+   by an external/human prerequisite. Never upgrade build or emulator proof to
+   physical acceptance.
+9. **Capture sanitized evidence.** Store compact logs/reports/screenshots under
+   `docs/artifacts/<date>/android/` and keep raw/private captures ignored.
+10. **Update the record.** Append the command, result, failure signature,
+    evidence, commit, remaining gate, and next smallest step to `JOURNAL.md`;
+    update `STATUS.md` and `ANDROID.md` when reality changes.
+11. **Commit coherent checkpoints.** Run tests, `git diff --check`, repository
+    safety, and source-pin verification. Commit only relevant reviewed files on
+    a `codex/` branch and push/open a focused PR when the checkpoint is real.
+12. **Continue.** Do not stop at scaffolding, a green compile, a blank activity,
+    a clear frame, or first boot while a safe next step remains.
+
+## Failure and anti-stall rules
+
+- Read the complete error and record a stable signature before retrying.
+- Two materially identical failures forbid a third unchanged attempt.
+- Check stale Gradle daemons, CMake caches, AVD snapshots, installed APK/data,
+  generated graphs, dependency archives, and environment paths before changing
+  source.
+- Reduce failures to one boundary: Gradle, JNI load, ELF/PIC, memory mapping,
+  fiber switch, SDL lifecycle, Dawn/Vulkan, audio, input, URI/storage, archive,
+  TLS, or guest behavior.
+- Instrument to distinguish hypotheses; do not guess through broad rewrites.
+- Prefer official Android, SDL, Dawn, CMake, and JDK documentation and pinned
+  upstream source for technical decisions.
+- If one goal is externally blocked, document it once and continue independent
+  source-only work that does not bypass a correctness dependency.
+- Never delete an app/container to fix an update or save bug without first
+  backing it up and proving a restore path.
+
+## Handoff standard
+
+At any stop, leave:
+
+- branch and exact commit;
+- clean/dirty status and every intentional untracked path;
+- completed goal/subgoal and what the evidence actually proves;
+- exact commands and artifact hashes;
+- toolchain versions, SDK/NDK roots, AVD/device/API/ABI/page size, and Vulkan
+  backend;
+- first unresolved failure signature or human prerequisite;
+- private-data locations described only as sanitized placeholders; and
+- one concrete next command or interaction.
+
+A useful handoff lets the next agent continue without repeating discovery or
+mistaking a build, emulator, or screenshot result for Android support.

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -36,7 +36,8 @@ The first serious Android preview should have this deliberately narrow scope:
 - Android 9 / API 28 minimum initially, subject to the first physical-device
   results and the pinned Dawn package's API 28 build baseline.
 - Compile and target SDK 36 for the intended 2026 distribution environment.
-- Original Mario Kart Wii and Retro Rewind 6.12.4 in the same APK.
+- Original Mario Kart Wii and Retro Rewind 6.12.5 in the same APK, matching
+  KartPad 0.4.0's current dual-profile graph.
 - Offline play first; Retro WFC is an independent acceptance gate.
 - User-provided PAL `RMCP01` revision-0 `.iso` or `.wbfs`, plus the existing
   extracted-folder fallback.
@@ -294,10 +295,10 @@ contract, not merely reproduce the happy-path download.
 
 The selected profile currently pins:
 
-- version `6.12.4`;
-- official archive size `1,844,093,118` bytes;
+- version `6.12.5`;
+- official archive size `1,859,041,899` bytes;
 - archive SHA-256
-  `d2ab1ecfda4c12bb90304897aecd03e2cbfb9a93e353fff928a494aa5d9ec71d`;
+  `d8f7c61636ef76f8a451f4071ec5bbdcfea9d5f2500cfc6c245431f04580f9d9`;
 - maximum expanded size `2,200,000,000` bytes; and
 - exact `Code.pul`, Riivolution XML, and payload sizes/hashes.
 
@@ -321,7 +322,7 @@ only platform downloads, paths, progress, and UI. Shared logic should enforce:
 - retention of the previous complete installation until success; and
 - cleanup/recovery after cancellation, process death, or storage exhaustion.
 
-The 1.84 GB archive makes Android lifecycle behavior important. The public
+The 1.86 GB archive makes Android lifecycle behavior important. The public
 quality implementation should use an app-scoped foreground-capable worker or
 service with visible progress and cancellation, so rotating the device or
 recreating the activity does not restart the transfer. The game must not launch
@@ -363,11 +364,13 @@ large hierarchy of buttons. It must implement:
 - deterministic draw order and anti-aliasing choices;
 - stable pointer-ID-to-control ownership for true multitouch;
 - sticks, A/B/X/Y/Z/Start/L/R, and the grouped D-pad;
-- per-control editing and reset;
+- per-control editing, Hide/Show, and reset;
 - global opacity and size;
 - controller hide/restore behavior;
 - modern C-stick horizontal behavior;
 - the one-second A-button lock, locked color, and haptic feedback;
+- the current untouched-iPhone compact defaults, existing-layout preservation,
+  grouped D-pad editing, and the editor's direct **Back** path;
 - pass-through outside active control regions; and
 - virtual accessibility nodes for each control.
 
@@ -454,38 +457,22 @@ automation so stale hidden state cannot turn a broken initialization path green.
 Launch the emulator in its own window for manual multitouch; embedded emulator
 windows have documented multitouch limitations.
 
-## Current development-Mac inventory
+## Authorized clean-machine bootstrap
 
-As of this assessment, the current Apple Silicon Mac has:
+The implementation machine's starting inventory is intentionally treated as
+unknown. The Android agent is authorized to download and install the Android
+and Java build tools required for this port, including the SDK command-line
+tools, pinned JDK, SDK platforms, Build Tools, NDK, CMake/Ninja support,
+Gradle dependencies, emulator, and the minimum ARM64 system images. It may also
+download hash-pinned source or binary dependencies already authorized by this
+repository. This authorization does not include game data, saves, credentials,
+signing keys, or arbitrary executable game updates.
 
-- Android Studio installed;
-- Android Emulator `36.4.10`;
-- working Hypervisor.framework acceleration;
-- Android SDK platforms 34, 35, and 36;
-- Build Tools through `36.0.0`;
-- Platform Tools / `adb` `37.0.0`;
-- an ARM64 API-34 Google APIs AVD named
-  `Pixel_3a_API_34_extension_level_7_arm64-v8a`;
-- CMake `4.4.2` and Ninja `1.13.2`; and
-- Apple Clang 21.
-
-It does not currently have:
-
-- Android SDK command-line tools exposed through `sdkmanager`;
-- an Android NDK;
-- the dedicated ARM64 16 KiB Android system image;
-- a project-pinned Gradle/JDK environment; or
-- an attached Android device.
-
-The only system Java installation discovered was Temurin JDK 24. Pin a JDK 17
-runtime for an Android Gradle Plugin 8.x build instead of assuming that every
-developer's newest system JDK is compatible.
-
-### Toolchain bootstrap to automate
-
-The repository should eventually provide `scripts/check-android-host.sh` and a
-documented bootstrap command. The check should print versions and fail with an
-actionable message; it should not modify global shell profiles.
+The first implementation milestone must provide `scripts/check-android-host.sh`
+and a documented bootstrap command. Installation is an explicit operation in
+the Android goal loop, not a hidden side effect of a normal build. Prefer
+Android Studio's configured SDK or a user-local SDK root; do not rewrite global
+shell profiles, replace unrelated system toolchains, or assume Homebrew exists.
 
 Pin at least:
 
@@ -501,9 +488,11 @@ Use `local.properties` only for the machine-local SDK path and keep it ignored.
 Build scripts should accept `ANDROID_SDK_ROOT` and discover the NDK through the
 SDK, while rejecting an unpinned version for release builds.
 
-Do not install these tools as a side effect of an ordinary build. Installation
-should be an explicit maintainer bootstrap step; validation should remain
-read-only.
+Do not install these tools as a side effect of an ordinary build. The dedicated
+bootstrap command may install missing pinned components and accept paths through
+arguments or environment variables; the validation command remains read-only.
+If a download requires new legal terms, an account, a CAPTCHA, payment, or
+credentials, stop at that boundary and request the human action once.
 
 ## Working on a different Mac
 
@@ -609,7 +598,7 @@ Deliver:
 - portable archive validation/install core;
 - Android manifest check, resumable/cancellable download, free-space preflight,
   staging, atomic activation, rollback, and recovery;
-- exact 6.12.4 profile selection and no accidental Original fallback;
+- exact 6.12.5 profile selection and no accidental Original fallback;
 - complete offline Retro Rewind race, results, save, relaunch, and mode switch;
   and
 - interruption tests for rotation, process death, network loss, corrupt ZIP,
@@ -780,10 +769,11 @@ Before any tester receives an artifact, verify at minimum:
 
 ## Immediate next action
 
-Implement A0 only. Install and pin the missing JDK/SDK command-line
-tools/NDK/system image, add the minimal Android SDL shell, sanitize and lock the
-Dawn Android dependency, and prove a source-only JNI/Vulkan fixture on the
-existing API-34 AVD plus a new 16 KiB AVD.
+Begin with A0. Follow [`ANDROID-GOAL-LOOP.md`](ANDROID-GOAL-LOOP.md): inventory
+the new machine, install and pin the missing JDK/SDK command-line
+tools/NDK/system images, add the minimal Android SDL shell, sanitize and lock
+the Dawn Android dependency, and prove a source-only JNI/Vulkan fixture on one
+ARM64 phone AVD plus a 16 KiB AVD.
 
 Do not begin the touch-UI port or full private game link until the shell,
 toolchain, page-size, and Dawn configuration gates are reproducible on a clean

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -92,19 +92,22 @@ not block offline Retro Rewind support.
 
 ## Next executable work
 
-1. Collect the first physical Apple TV report against `v0.4.0` using
+1. Begin Android A0 on the authorized second machine using
+   `docs/ANDROID-GOAL-LOOP.md`: bootstrap pinned tools and prove the source-only
+   ARM64 SDL/JNI/Vulkan fixture before private game integration.
+2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
-2. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook
+3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook
    Air cursor/settings retest requested against Preview 5.
-3. Keep Mii and physical Wii Remote/Nunchuk acceptance open until the Issue #5
+4. Keep Mii and physical Wii Remote/Nunchuk acceptance open until the Issue #5
    reporter can reach the settings and returns real hardware results.
-4. Continue representative performance and frame-pacing work without changing
+5. Continue representative performance and frame-pacing work without changing
    the accepted 0.3.0 release baseline.
-5. Complete the remaining three- and four-player, touch, motion, controller,
+6. Complete the remaining three- and four-player, touch, motion, controller,
    audio, thermal, lifecycle, and long-soak rows in `docs/PRD.md`.
-6. When Retro WFC returns, retest production login, matchmaking, a complete
+7. When Retro WFC returns, retest production login, matchmaking, a complete
    race, results, reconnect, and physical-device online play.
-7. Follow `docs/UPSTREAM_UPDATES.md` whenever WiiCompiled or Retro Rewind
+8. Follow `docs/UPSTREAM_UPDATES.md` whenever WiiCompiled or Retro Rewind
    advances; never accept an unpinned pack or `Code.pul`.
 
 ## Operating constraints

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,6 +2,17 @@
 
 Updated: 2026-09-03
 
+## Native Android work
+
+Android implementation is authorized to begin on a separate machine using the
+evidence-gated architecture in [`docs/ANDROID.md`](ANDROID.md) and the
+autonomous execution contract in
+[`docs/ANDROID-GOAL-LOOP.md`](ANDROID-GOAL-LOOP.md). The agent may explicitly
+bootstrap pinned Android/Java tools and official repository dependencies. The
+current target is an ARM64 source-only SDL/JNI/Vulkan fixture before private
+full-game integration. No Android library, APK, installation, frame, gameplay,
+or physical-device result exists yet.
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first


### PR DESCRIPTION
## Summary\n- update the Android plan to the current Retro Rewind 6.12.5 and KartPad 0.4.0 baseline\n- authorize an explicit clean-machine Android/JDK/SDK/NDK bootstrap while preserving private-data and release boundaries\n- define the accepted current iPhone touch/menu behavior as Android's parity target\n- add an autonomous A0-A6 goal loop with evidence, anti-stall, regression, and handoff rules\n- make README, status, and handoff documents point to active Android implementation\n\n## Validation\n- 51 tests pass\n- all 335 patch hunks and source pins verify\n- pinned SunPad overlay remains byte-identical\n- repository safety and diff checks pass\n- referenced handoff files resolve