### PR TITLE
Android: prove A1 Vulkan readback and lifecycle

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -1,10 +1,15 @@
 # KartPad Android source-only fixture
 
-This directory currently contains the non-playable A0 Android shell. It proves
+This directory contains the non-playable Android source-only fixture. A0 proves
 the pinned ARM64 toolchain, SDLActivity/JNI entry, SDL Vulkan loader, Dawn
-Vulkan adapter discovery, 4 KiB execution, and 16 KiB execution without game
-data or generated translated code. It does not prove presentation, gameplay,
-physical-device support, or release readiness.
+Vulkan adapter discovery, 4 KiB execution, and 16 KiB execution. The first A1
+slice additionally creates one Dawn device, byte-verifies a deterministic GPU
+clear/readback, presents a separate clear through the Android native window,
+and repeats presentation after HOME/foreground surface recreation. None of
+these paths use game data or generated translated code.
+
+Rotation, guest memory, fibers, gameplay, physical-device support,
+performance, and release readiness remain unproven.
 
 On an Apple Silicon Mac, explicitly install the pinned public toolchain and
 AVDs, then verify it:
@@ -33,6 +38,8 @@ Repeat the same cold-boot lane on the pinned Android 15 / 16 KiB image:
 ```
 
 The runner refuses to start when another Android device or emulator is
-connected, wipes only the named disposable KartPad AVD, stops it on exit, and
-keeps raw emulator output under the ignored `.android-bootstrap/` directory.
-The produced debug APK remains a local audit fixture and must not be published.
+connected, wipes only the named disposable KartPad AVD, settles it in the
+shell's declared landscape orientation, stops it on exit, and keeps raw
+emulator output under the ignored `.android-bootstrap/` directory. It drives
+HOME/foreground and requires the post-recreation presentation marker. The
+produced debug APK remains a local audit fixture and must not be published.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -57,7 +57,7 @@ android {
     }
     lint {
         // A0 deliberately pins this verified wrapper and supports ARM64 Android only.
-        disable += setOf("AndroidGradlePluginVersion", "ChromeOsAbiSupport")
+        disable += setOf("AndroidGradlePluginVersion", "ChromeOsAbiSupport", "DiscouragedApi")
     }
 }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
             android:name=".KartPadActivity"
             android:configChanges="keyboard|keyboardHidden|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode"
             android:exported="true"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:screenOrientation="sensorLandscape">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/android/app/src/main/cpp/fixture_main.cpp
+++ b/android/app/src/main/cpp/fixture_main.cpp
@@ -6,7 +6,13 @@
 #include <dawn/webgpu.h>
 #include <unistd.h>
 
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
 #include <cstddef>
+#include <cstdint>
+#include <thread>
 
 namespace {
 
@@ -17,6 +23,248 @@ void LogError(const char* message) {
                       SDL_GetError());
 }
 
+struct MapState {
+  bool complete = false;
+  WGPUMapAsyncStatus status = WGPUMapAsyncStatus_Error;
+};
+
+struct LifecycleState {
+  std::atomic_bool recreate_pending = false;
+};
+
+bool LifecycleEventFilter(void* userdata, SDL_Event* event) {
+  auto* state = static_cast<LifecycleState*>(userdata);
+  if (event->type == SDL_EVENT_WILL_ENTER_BACKGROUND) {
+    __android_log_print(ANDROID_LOG_INFO, kLogTag,
+                        "A1 lifecycle background observed");
+  } else if (event->type == SDL_EVENT_DID_ENTER_FOREGROUND) {
+    state->recreate_pending.store(true, std::memory_order_release);
+  }
+  return true;
+}
+
+bool RunDeterministicReadback(dawn::native::Instance& instance,
+                              WGPUDevice device) {
+  constexpr uint32_t kWidth = 4;
+  constexpr uint32_t kHeight = 4;
+  constexpr uint32_t kBytesPerRow = 256;
+  constexpr std::array<uint8_t, 4> kExpected = {32, 128, 224, 255};
+
+  WGPUQueue queue = nullptr;
+  WGPUTexture texture = nullptr;
+  WGPUTextureView view = nullptr;
+  WGPUBuffer readback = nullptr;
+  WGPUCommandEncoder encoder = nullptr;
+  WGPURenderPassEncoder pass = nullptr;
+  WGPUCommandBuffer commands = nullptr;
+  MapState map_state;
+  bool passed = false;
+
+  do {
+    queue = wgpuDeviceGetQueue(device);
+    if (queue == nullptr) break;
+
+    WGPUTextureDescriptor texture_desc = WGPU_TEXTURE_DESCRIPTOR_INIT;
+    texture_desc.usage = WGPUTextureUsage_RenderAttachment | WGPUTextureUsage_CopySrc;
+    texture_desc.dimension = WGPUTextureDimension_2D;
+    texture_desc.size = {kWidth, kHeight, 1};
+    texture_desc.format = WGPUTextureFormat_RGBA8Unorm;
+    texture = wgpuDeviceCreateTexture(device, &texture_desc);
+    if (texture == nullptr) break;
+    view = wgpuTextureCreateView(texture, nullptr);
+    if (view == nullptr) break;
+
+    WGPUBufferDescriptor buffer_desc = WGPU_BUFFER_DESCRIPTOR_INIT;
+    buffer_desc.usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_MapRead;
+    buffer_desc.size = kBytesPerRow * kHeight;
+    readback = wgpuDeviceCreateBuffer(device, &buffer_desc);
+    if (readback == nullptr) break;
+
+    encoder = wgpuDeviceCreateCommandEncoder(device, nullptr);
+    if (encoder == nullptr) break;
+    WGPURenderPassColorAttachment color = WGPU_RENDER_PASS_COLOR_ATTACHMENT_INIT;
+    color.view = view;
+    color.loadOp = WGPULoadOp_Clear;
+    color.storeOp = WGPUStoreOp_Store;
+    color.clearValue = {32.0 / 255.0, 128.0 / 255.0, 224.0 / 255.0, 1.0};
+    WGPURenderPassDescriptor pass_desc = WGPU_RENDER_PASS_DESCRIPTOR_INIT;
+    pass_desc.colorAttachmentCount = 1;
+    pass_desc.colorAttachments = &color;
+    pass = wgpuCommandEncoderBeginRenderPass(encoder, &pass_desc);
+    if (pass == nullptr) break;
+    wgpuRenderPassEncoderEnd(pass);
+
+    WGPUTexelCopyTextureInfo source = WGPU_TEXEL_COPY_TEXTURE_INFO_INIT;
+    source.texture = texture;
+    source.aspect = WGPUTextureAspect_All;
+    WGPUTexelCopyBufferInfo destination = WGPU_TEXEL_COPY_BUFFER_INFO_INIT;
+    destination.buffer = readback;
+    destination.layout.bytesPerRow = kBytesPerRow;
+    destination.layout.rowsPerImage = kHeight;
+    WGPUExtent3D copy_size = {kWidth, kHeight, 1};
+    wgpuCommandEncoderCopyTextureToBuffer(encoder, &source, &destination, &copy_size);
+    commands = wgpuCommandEncoderFinish(encoder, nullptr);
+    if (commands == nullptr) break;
+    wgpuQueueSubmit(queue, 1, &commands);
+
+    WGPUBufferMapCallbackInfo callback = WGPU_BUFFER_MAP_CALLBACK_INFO_INIT;
+    callback.mode = WGPUCallbackMode_AllowProcessEvents;
+    callback.userdata1 = &map_state;
+    callback.callback = [](WGPUMapAsyncStatus status, WGPUStringView, void* userdata,
+                           void*) {
+      auto* state = static_cast<MapState*>(userdata);
+      state->status = status;
+      state->complete = true;
+    };
+    wgpuBufferMapAsync(readback, WGPUMapMode_Read, 0, buffer_desc.size, callback);
+    for (int attempt = 0; attempt < 500 && !map_state.complete; ++attempt) {
+      dawn::native::DeviceTick(device);
+      dawn::native::InstanceProcessEvents(instance.Get());
+      std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    if (!map_state.complete || map_state.status != WGPUMapAsyncStatus_Success) break;
+
+    const auto* bytes = static_cast<const uint8_t*>(
+        wgpuBufferGetConstMappedRange(readback, 0, buffer_desc.size));
+    if (bytes == nullptr) break;
+    passed = true;
+    for (uint32_t y = 0; y < kHeight && passed; ++y) {
+      for (uint32_t x = 0; x < kWidth; ++x) {
+        const uint8_t* pixel = bytes + y * kBytesPerRow + x * kExpected.size();
+        if (!std::equal(kExpected.begin(), kExpected.end(), pixel)) {
+          passed = false;
+          break;
+        }
+      }
+    }
+    wgpuBufferUnmap(readback);
+  } while (false);
+
+  if (commands != nullptr) wgpuCommandBufferRelease(commands);
+  if (pass != nullptr) wgpuRenderPassEncoderRelease(pass);
+  if (encoder != nullptr) wgpuCommandEncoderRelease(encoder);
+  if (readback != nullptr) wgpuBufferRelease(readback);
+  if (view != nullptr) wgpuTextureViewRelease(view);
+  if (texture != nullptr) wgpuTextureRelease(texture);
+  if (queue != nullptr) wgpuQueueRelease(queue);
+  return passed;
+}
+
+bool RunSurfacePresent(dawn::native::Instance& instance,
+                       dawn::native::Adapter& adapter, WGPUDevice device,
+                       SDL_Window* window,
+                       int* presented_width, int* presented_height) {
+  void* native_window = SDL_GetPointerProperty(
+      SDL_GetWindowProperties(window), SDL_PROP_WINDOW_ANDROID_WINDOW_POINTER,
+      nullptr);
+  if (native_window == nullptr ||
+      !SDL_GetWindowSizeInPixels(window, presented_width, presented_height) ||
+      *presented_width <= 0 || *presented_height <= 0) {
+    __android_log_print(ANDROID_LOG_ERROR, kLogTag,
+                        "surface step failed: native-window-or-size");
+    return false;
+  }
+
+  WGPUQueue queue = nullptr;
+  WGPUSurface surface = nullptr;
+  WGPUTexture texture = nullptr;
+  WGPUTextureView view = nullptr;
+  WGPUCommandEncoder encoder = nullptr;
+  WGPURenderPassEncoder pass = nullptr;
+  WGPUCommandBuffer commands = nullptr;
+  WGPUSurfaceCapabilities capabilities = WGPU_SURFACE_CAPABILITIES_INIT;
+  bool capabilities_valid = false;
+  bool configured = false;
+  bool passed = false;
+  const char* failed_step = "get-queue";
+  int status_detail = 0;
+
+  do {
+    queue = wgpuDeviceGetQueue(device);
+    if (queue == nullptr) break;
+    WGPUSurfaceSourceAndroidNativeWindow source =
+        WGPU_SURFACE_SOURCE_ANDROID_NATIVE_WINDOW_INIT;
+    source.window = native_window;
+    WGPUSurfaceDescriptor surface_desc = WGPU_SURFACE_DESCRIPTOR_INIT;
+    surface_desc.nextInChain = &source.chain;
+    failed_step = "create-surface";
+    surface = wgpuInstanceCreateSurface(instance.Get(), &surface_desc);
+    if (surface == nullptr) break;
+    failed_step = "surface-capabilities";
+    const WGPUStatus capabilities_status =
+        wgpuSurfaceGetCapabilities(surface, adapter.Get(), &capabilities);
+    status_detail = static_cast<int>(capabilities_status);
+    if (capabilities_status != WGPUStatus_Success || capabilities.formatCount == 0) {
+      break;
+    }
+    capabilities_valid = true;
+
+    WGPUSurfaceConfiguration config = WGPU_SURFACE_CONFIGURATION_INIT;
+    config.device = device;
+    config.format = capabilities.formats[0];
+    config.width = static_cast<uint32_t>(*presented_width);
+    config.height = static_cast<uint32_t>(*presented_height);
+    config.presentMode = WGPUPresentMode_Fifo;
+    wgpuSurfaceConfigure(surface, &config);
+    configured = true;
+
+    failed_step = "current-texture";
+    WGPUSurfaceTexture current = WGPU_SURFACE_TEXTURE_INIT;
+    wgpuSurfaceGetCurrentTexture(surface, &current);
+    status_detail = static_cast<int>(current.status);
+    if ((current.status != WGPUSurfaceGetCurrentTextureStatus_SuccessOptimal &&
+         current.status != WGPUSurfaceGetCurrentTextureStatus_SuccessSuboptimal) ||
+        current.texture == nullptr) {
+      break;
+    }
+    texture = current.texture;
+    failed_step = "texture-view";
+    view = wgpuTextureCreateView(texture, nullptr);
+    if (view == nullptr) break;
+    failed_step = "command-encoder";
+    encoder = wgpuDeviceCreateCommandEncoder(device, nullptr);
+    if (encoder == nullptr) break;
+    WGPURenderPassColorAttachment color = WGPU_RENDER_PASS_COLOR_ATTACHMENT_INIT;
+    color.view = view;
+    color.loadOp = WGPULoadOp_Clear;
+    color.storeOp = WGPUStoreOp_Store;
+    color.clearValue = {0.05, 0.20, 0.24, 1.0};
+    WGPURenderPassDescriptor pass_desc = WGPU_RENDER_PASS_DESCRIPTOR_INIT;
+    pass_desc.colorAttachmentCount = 1;
+    pass_desc.colorAttachments = &color;
+    failed_step = "render-pass";
+    pass = wgpuCommandEncoderBeginRenderPass(encoder, &pass_desc);
+    if (pass == nullptr) break;
+    wgpuRenderPassEncoderEnd(pass);
+    failed_step = "finish-commands";
+    commands = wgpuCommandEncoderFinish(encoder, nullptr);
+    if (commands == nullptr) break;
+    wgpuQueueSubmit(queue, 1, &commands);
+    failed_step = "present";
+    const WGPUStatus present_status = wgpuSurfacePresent(surface);
+    status_detail = static_cast<int>(present_status);
+    if (present_status != WGPUStatus_Success) break;
+    dawn::native::DeviceTick(device);
+    passed = true;
+  } while (false);
+
+  if (commands != nullptr) wgpuCommandBufferRelease(commands);
+  if (pass != nullptr) wgpuRenderPassEncoderRelease(pass);
+  if (encoder != nullptr) wgpuCommandEncoderRelease(encoder);
+  if (view != nullptr) wgpuTextureViewRelease(view);
+  if (texture != nullptr) wgpuTextureRelease(texture);
+  if (configured) wgpuSurfaceUnconfigure(surface);
+  if (capabilities_valid) wgpuSurfaceCapabilitiesFreeMembers(capabilities);
+  if (surface != nullptr) wgpuSurfaceRelease(surface);
+  if (queue != nullptr) wgpuQueueRelease(queue);
+  if (!passed) {
+    __android_log_print(ANDROID_LOG_ERROR, kLogTag,
+                        "surface step failed: %s status=%d", failed_step,
+                        status_detail);
+  }
+  return passed;
+}
+
 }  // namespace
 
 extern "C" __attribute__((visibility("default"))) int SDL_main(int, char**) {
@@ -25,10 +273,8 @@ extern "C" __attribute__((visibility("default"))) int SDL_main(int, char**) {
     LogError("SDL_Init failed");
     return 1;
   }
-
   SDL_Window* window = SDL_CreateWindow(
-      "KartPad", 960, 540,
-      SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY);
+      "KartPad", 960, 540, SDL_WINDOW_VULKAN | SDL_WINDOW_HIGH_PIXEL_DENSITY);
   if (window == nullptr) {
     LogError("SDL_CreateWindow failed");
     SDL_Quit();
@@ -44,7 +290,7 @@ extern "C" __attribute__((visibility("default"))) int SDL_main(int, char**) {
   WGPURequestAdapterOptions options = WGPU_REQUEST_ADAPTER_OPTIONS_INIT;
   options.backendType = WGPUBackendType_Vulkan;
   dawn::native::Instance instance;
-  const auto adapters = instance.EnumerateAdapters(&options);
+  auto adapters = instance.EnumerateAdapters(&options);
   if (adapters.empty()) {
     __android_log_print(ANDROID_LOG_ERROR, kLogTag,
                         "A0 Vulkan fixture failed: Dawn found no Vulkan adapter");
@@ -53,16 +299,83 @@ extern "C" __attribute__((visibility("default"))) int SDL_main(int, char**) {
     SDL_Quit();
     return 4;
   }
-
   __android_log_print(ANDROID_LOG_INFO, kLogTag,
                       "A0 JNI/Vulkan fixture passed abi=arm64-v8a page_size=%ld adapters=%zu",
                       sysconf(_SC_PAGESIZE), adapters.size());
+  WGPUDeviceDescriptor device_desc = WGPU_DEVICE_DESCRIPTOR_INIT;
+  device_desc.uncapturedErrorCallbackInfo.callback =
+      [](WGPUDevice const*, WGPUErrorType type, WGPUStringView message, void*, void*) {
+        __android_log_print(ANDROID_LOG_ERROR, kLogTag,
+                            "Dawn uncaptured error type=%d message=%.*s",
+                            static_cast<int>(type), static_cast<int>(message.length),
+                            message.data == nullptr ? "" : message.data);
+      };
+  WGPUDevice device = adapters.front().CreateDevice(&device_desc);
+  if (device == nullptr) {
+    __android_log_print(ANDROID_LOG_ERROR, kLogTag,
+                        "A1 Vulkan fixture failed: device creation");
+    SDL_Vulkan_UnloadLibrary();
+    SDL_DestroyWindow(window);
+    SDL_Quit();
+    return 5;
+  }
+  if (!RunDeterministicReadback(instance, device)) {
+    __android_log_print(ANDROID_LOG_ERROR, kLogTag,
+                        "A1 Vulkan fixture failed: deterministic clear/readback mismatch");
+    wgpuDeviceRelease(device);
+    SDL_Vulkan_UnloadLibrary();
+    SDL_DestroyWindow(window);
+    SDL_Quit();
+    return 6;
+  }
+
+  __android_log_print(ANDROID_LOG_INFO, kLogTag,
+                      "A1 Vulkan readback passed rgba=20-80-e0-ff "
+                      "abi=arm64-v8a page_size=%ld adapters=%zu",
+                      sysconf(_SC_PAGESIZE), adapters.size());
+  int presented_width = 0;
+  int presented_height = 0;
+  if (!RunSurfacePresent(instance, adapters.front(), device, window,
+                         &presented_width, &presented_height)) {
+    __android_log_print(ANDROID_LOG_ERROR, kLogTag,
+                        "A1 Vulkan fixture failed: surface clear/present");
+    wgpuDeviceRelease(device);
+    SDL_Vulkan_UnloadLibrary();
+    SDL_DestroyWindow(window);
+    SDL_Quit();
+    return 7;
+  }
+  __android_log_print(ANDROID_LOG_INFO, kLogTag,
+                      "A1 Vulkan present passed abi=arm64-v8a page_size=%ld "
+                      "size=%dx%d generation=1",
+                      sysconf(_SC_PAGESIZE), presented_width, presented_height);
+  int exit_code = 0;
+  int presentation_generation = 1;
+  LifecycleState lifecycle;
+  SDL_SetEventFilter(LifecycleEventFilter, &lifecycle);
   SDL_Event event;
   while (SDL_WaitEvent(&event)) {
     if (event.type == SDL_EVENT_QUIT) break;
+    if (lifecycle.recreate_pending.exchange(false, std::memory_order_acq_rel)) {
+      if (!RunSurfacePresent(instance, adapters.front(), device, window,
+                             &presented_width, &presented_height)) {
+        __android_log_print(ANDROID_LOG_ERROR, kLogTag,
+                            "A1 Vulkan fixture failed: foreground surface recreation");
+        exit_code = 8;
+        break;
+      }
+      ++presentation_generation;
+      __android_log_print(ANDROID_LOG_INFO, kLogTag,
+                          "A1 Vulkan recreate passed generation=%d page_size=%ld "
+                          "size=%dx%d",
+                          presentation_generation, sysconf(_SC_PAGESIZE),
+                          presented_width, presented_height);
+    }
   }
+  SDL_SetEventFilter(nullptr, nullptr);
+  wgpuDeviceRelease(device);
   SDL_Vulkan_UnloadLibrary();
   SDL_DestroyWindow(window);
   SDL_Quit();
-  return 0;
+  return exit_code;
 }

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -5,12 +5,14 @@
 - **Assessment updated:** 3 September 2026.
 - **Assessment type:** repository review plus A0 source-only implementation and
   ARM64 emulator execution.
-- **Runtime proof:** the local non-playable A0 APK builds, audits, installs, and
-  runs its SDL/JNI/Dawn-Vulkan adapter fixture on the pinned API 36 / 4 KiB and
-  Android 15 / 16 KiB ARM64 AVDs.
-- **Decision:** A0 passes on the authorized second Apple Silicon host. Proceed
-  to A1 native primitives and deterministic Vulkan presentation before
-  user-interface or private full-game work.
+- **Runtime proof:** A0 passes. The local non-playable source-only APK now also
+  creates one Dawn Vulkan device, byte-verifies a deterministic clear/readback,
+  presents through SDL's Android native window, and presents again after
+  HOME/foreground surface recreation on the pinned API 36 / 4 KiB and Android
+  15 / 16 KiB ARM64 AVDs.
+- **Decision:** A1 renderer bring-up is partially green. Continue rotation and
+  repeated lifecycle stress, guest memory, and ELF AArch64 scheduler fixtures
+  before user-interface or private full-game work.
 
 KartPad can be ported to Android without changing its defining architecture.
 The Android build should contain the same ahead-of-time translated Original
@@ -772,15 +774,16 @@ Before any tester receives an artifact, verify at minimum:
 
 ## Immediate next action
 
-Continue with A1. Extend the source-only fixture to create a Dawn Vulkan device,
-clear/read back/present a deterministic frame, and survive SDL surface
-destruction/recreation, rotation, and background/foreground transitions. Then
-add page-size-aware guest-memory and Android ELF AArch64 scheduler/register
-fixtures and run them on both pinned AVDs.
+Continue A1 by adding explicit rotation/surface-generation observation and
+bounded repeated lifecycle stress. Then add page-size-aware guest-memory and
+Android ELF AArch64 scheduler/register fixtures and run them on both pinned
+AVDs.
 
 The A0 commands and sanitized result are recorded in
 [`android/README.md`](../android/README.md) and
 [`a0-source-only-fixture.md`](artifacts/2026-09-03/android/a0-source-only-fixture.md).
+The first A1 renderer evidence is in
+[`a1-vulkan-readback-present.md`](artifacts/2026-09-03/android/a1-vulkan-readback-present.md).
 Do not begin the touch-UI port or private full-game link until A1 passes. The
 first valuable user-facing proof after that is a controller-driven
 Original-mode race on physical Android hardware; Retro Rewind installation and

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -92,10 +92,11 @@ not block offline Retro Rewind support.
 
 ## Next executable work
 
-1. Continue Android A1 using `docs/ANDROID-GOAL-LOOP.md`: add deterministic
-   Vulkan clear/readback/present and SDL surface lifecycle coverage, then the
-   4 KiB/16 KiB guest-memory and Android ELF scheduler/register fixtures before
-   private game integration. A0 evidence is under
+1. Continue Android A1 using `docs/ANDROID-GOAL-LOOP.md`: deterministic Vulkan
+   clear/readback/present and HOME/foreground surface recreation now pass on
+   both page-size lanes. Add explicit rotation/repeated lifecycle stress, then
+   the 4 KiB/16 KiB guest-memory and Android ELF scheduler/register fixtures
+   before private game integration. Evidence is under
    `docs/artifacts/2026-09-03/android/`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -1629,3 +1629,30 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   URL is disabled; the checkout was intentionally left untouched. This does
   not affect A0, which uses only the independently hash-verified SDL3 and Dawn
   downloads. The SunPad snapshot and repository safety checks pass.
+
+## 2026-09-03 — Android A1 deterministic Vulkan readback and present
+
+- Extended the source-only fixture from adapter discovery to one real Dawn
+  Vulkan device. It clears a 4×4 RGBA8 texture, copies through a WebGPU buffer
+  with the required 256-byte row pitch, maps it, and verifies every pixel as
+  `20-80-e0-ff`.
+- Built a WebGPU surface directly from SDL's Android native-window property,
+  cleared and presented its current texture, drove the app HOME, observed the
+  SDL background boundary through the required event filter, allowed Android
+  surface teardown to settle, resumed, and presented through the replacement
+  surface. The exact run passes on API 36 / 4 KiB and API 35 / 16 KiB ARM64
+  cold-boot AVDs.
+- The initial presentation attempt tried to create a second Dawn device and
+  failed at that exact step. Sharing the intended single device fixed it. A
+  separate startup race came from SDL translating its desktop `RESIZABLE` flag
+  into an Android orientation request; removing that flag keeps SDL aligned
+  with the sensor-landscape manifest. Waiting for `onStop` teardown before
+  foreground avoids a second activity overlap.
+- The audited local debug APK SHA-256 is
+  `151397d104723415d4db9663f4a4566f3d769d42708d600ec417ea5525fa846f`.
+  Classification: **Pass for deterministic Dawn Vulkan GPU clear/readback,
+  Android surface clear/present, and one background/foreground surface
+  recreation on both emulator page sizes.** A1 remains open for rotation,
+  repeated stress, guest memory, and scheduler/register fixtures. No package
+  was hosted or published. Evidence:
+  `docs/artifacts/2026-09-03/android/a1-vulkan-readback-present.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -17,6 +17,14 @@ or AAB was published. Evidence:
 [`docs/artifacts/2026-09-03/android/a0-source-only-fixture.md`](artifacts/2026-09-03/android/a0-source-only-fixture.md).
 The lowest incomplete goal is A1.
 
+The first A1 renderer slice passes on both pinned page-size lanes. One Dawn
+Vulkan device performs an exact 16-pixel GPU clear/readback, presents through
+SDL's Android native window, and presents again after an automated
+HOME/foreground surface recreation. A1 remains open for rotation and repeated
+lifecycle stress, guest-memory aliases/protection, and ELF AArch64
+scheduler/register fixtures. Evidence:
+[`docs/artifacts/2026-09-03/android/a1-vulkan-readback-present.md`](artifacts/2026-09-03/android/a1-vulkan-readback-present.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-03/android/a1-vulkan-readback-present.md
+++ b/docs/artifacts/2026-09-03/android/a1-vulkan-readback-present.md
@@ -1,0 +1,54 @@
+# Android A1 Vulkan readback, present, and foreground recreation
+
+## Classification
+
+**Pass for the first A1 renderer slice on both pinned ARM64 emulator lanes.**
+The source-only fixture creates one Dawn Vulkan device, clears a 4×4
+`RGBA8Unorm` texture, copies it to a 256-byte-row mapped buffer, and verifies
+all 16 pixels as `20-80-e0-ff`. It separately creates a WebGPU surface from
+SDL's Android `ANativeWindow`, clears and presents the current surface texture,
+goes HOME, observes the SDL background boundary, resumes after teardown has
+settled, and successfully creates and presents through the replacement surface.
+
+This does not prove visual color through screenshot comparison, translated
+Aurora rendering, rotation, repeated surface stress, guest memory, fibers,
+physical-device Vulkan correctness, gameplay, or performance. A1 remains in
+progress.
+
+## Command and result
+
+```sh
+./scripts/run-android-fixture.sh KartPad_API_36_ARM64
+./scripts/run-android-fixture.sh KartPad_API_35_PS16K_ARM64
+```
+
+| Lane | API | Page size | GPU readback | Surface lifecycle |
+| --- | ---: | ---: | --- | --- |
+| `KartPad_API_36_ARM64` | 36 | 4,096 | 16/16 pixels exact | initial present and post-HOME present pass |
+| `KartPad_API_35_PS16K_ARM64` | 35 | 16,384 | 16/16 pixels exact | initial present and post-HOME present pass |
+
+Both use the emulator's gfxstream path with host lavapipe and guest Vulkan
+`ranchu`. The exact local debug APK is 33,537,851 bytes with SHA-256
+`151397d104723415d4db9663f4a4566f3d769d42708d600ec417ea5525fa846f`.
+It passes the inherited A0 package, ELF, alignment, symbol, permission, and
+privacy audit. No APK/AAB was hosted or published.
+
+## Failure signatures resolved
+
+- The first surface implementation created a second Dawn device from the same
+  native adapter; that returned null after the readback device had completed.
+  Readback and presentation now share one device, matching the product's
+  intended ownership model.
+- SDL's Android window path maps the `RESIZABLE` flag to a new requested
+  orientation. Removing that desktop-oriented flag keeps the manifest and SDL
+  at sensor landscape and eliminates a first-activity recreation race.
+- Relaunching immediately when the background marker was queued could overlap
+  Android's `onStop`/surface teardown and destroy the activity. The runner now
+  waits for teardown to settle before requesting foreground; both cold-boot
+  lanes then pass the replacement-surface presentation.
+
+## Next gate
+
+Add explicit orientation/surface-generation observation and bounded repeated
+recreation stress. Then implement page-size-aware Android guest-memory alias
+and protection fixtures and the ELF AArch64 scheduler/register stress fixture.

--- a/scripts/run-android-fixture.sh
+++ b/scripts/run-android-fixture.sh
@@ -42,6 +42,17 @@ for _ in {1..60}; do
 done
 [[ "$booted" == 1 ]] || { echo "ERROR: emulator did not finish booting" >&2; exit 1; }
 
+# A freshly wiped phone image initially reports portrait even though KartPad is
+# landscape-only. Settle the disposable AVD before launching SDL so Android
+# does not destroy the first activity while its native thread is starting.
+"$adb" shell input keyevent KEYCODE_WAKEUP >/dev/null
+"$adb" shell wm dismiss-keyguard >/dev/null 2>&1 || true
+"$adb" shell settings put system accelerometer_rotation 0
+"$adb" shell settings put system user_rotation 1
+"$adb" shell am start -W -a android.intent.action.MAIN \
+  -c android.intent.category.HOME >/dev/null
+sleep 2
+
 abi="$("$adb" shell getprop ro.product.cpu.abi | tr -d '\r')"
 page_size="$("$adb" shell getconf PAGE_SIZE | tr -d '\r')"
 [[ "$abi" == "arm64-v8a" ]] || { echo "ERROR: unexpected device ABI: $abi" >&2; exit 1; }
@@ -55,19 +66,28 @@ apk="$repo_root/android/app/build/outputs/apk/debug/app-debug.apk"
 "$adb" logcat -c
 "$adb" shell am force-stop dev.kartpad.android
 "$adb" shell am start -W -n dev.kartpad.android/.KartPadActivity >/dev/null
-passed=0
-for _ in {1..60}; do
-  if "$adb" logcat -d -v brief KartPadFixture:I AndroidRuntime:E '*:S' |
-      grep -Fq "A0 JNI/Vulkan fixture passed abi=arm64-v8a page_size=$expected_page_size"; then
-    passed=1
-    break
-  fi
-  sleep 1
-done
-if [[ "$passed" != 1 ]]; then
-  echo "ERROR: fixture pass marker was not observed" >&2
+wait_for_marker() {
+  local marker="$1"
+  for _ in {1..60}; do
+    if "$adb" logcat -d -v brief KartPadFixture:I AndroidRuntime:E '*:S' |
+        grep -Fq "$marker"; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "ERROR: fixture marker was not observed: $marker" >&2
   "$adb" logcat -d -v brief KartPadFixture:V SDL:V AndroidRuntime:E libc:F '*:S' >&2
-  exit 1
-fi
+  return 1
+}
 
-echo "Android A0 fixture passed: avd=$avd api=$("$adb" shell getprop ro.build.version.sdk | tr -d '\r') abi=$abi page_size=$page_size backend=Vulkan adapters=1"
+wait_for_marker \
+  "A1 Vulkan present passed abi=arm64-v8a page_size=$expected_page_size"
+"$adb" shell input keyevent KEYCODE_HOME
+wait_for_marker "A1 lifecycle background observed"
+# Let Android complete onStop/surface teardown before requesting foreground.
+sleep 3
+"$adb" shell am start -W -n dev.kartpad.android/.KartPadActivity >/dev/null
+wait_for_marker \
+  "A1 Vulkan recreate passed generation=2 page_size=$expected_page_size"
+
+echo "Android A1 Vulkan fixture passed: avd=$avd api=$("$adb" shell getprop ro.build.version.sdk | tr -d '\r') abi=$abi page_size=$page_size backend=Vulkan readback_rgba=20-80-e0-ff surface=presented lifecycle=background-foreground-recreated"


### PR DESCRIPTION
## Summary
- create one Dawn Vulkan device and byte-verify a deterministic 4x4 RGBA8 GPU clear/readback
- create a WebGPU surface from the SDL Android native window and present a deterministic clear
- drive HOME/foreground and require a successful presentation through the replacement surface
- stabilize clean cold-boot orientation and document the bounded A1 evidence

## Validation
- scripts/run-android-fixture.sh KartPad_API_36_ARM64
- scripts/run-android-fixture.sh KartPad_API_35_PS16K_ARM64
- Gradle lintDebug and testDebugUnitTest (no unit-test sources yet)
- scripts/audit-android-package.sh
- scripts/check-repo-safety.sh
- scripts/verify-sunpad-overlay-snapshot.sh
- git diff --check

Both page-size lanes pass GPU readback, initial surface presentation, background teardown, and foreground presentation. The audited local debug APK SHA-256 is 151397d104723415d4db9663f4a4566f3d769d42708d600ec417ea5525fa846f. This remains emulator-only source-fixture evidence; rotation stress, guest memory, fibers, physical hardware, gameplay, and release readiness remain open. No APK/AAB is published.

This PR is stacked on the A0 source-only shell in PR #16.