### PR TITLE
Android A1: prove guest-memory aliases

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -5,11 +5,14 @@ the pinned ARM64 toolchain, SDLActivity/JNI entry, SDL Vulkan loader, Dawn
 Vulkan adapter discovery, 4 KiB execution, and 16 KiB execution. The first A1
 slice additionally creates one Dawn device, byte-verifies a deterministic GPU
 clear/readback, presents a separate clear through the Android native window,
-and repeats presentation after HOME/foreground surface recreation. None of
-these paths use game data or generated translated code.
+and repeats presentation after HOME/foreground surface recreation. The next
+A1 slice reserves a dynamic sparse 4 GiB guest range, maps two shared views,
+and verifies alias visibility and read-only/guard/read-only protection changes
+using the runtime page size. None of these paths use game data or generated
+translated code.
 
-Rotation, guest memory, fibers, gameplay, physical-device support,
-performance, and release readiness remain unproven.
+Rotation, repeated lifecycle stress, fibers, gameplay, physical-device
+support, performance, and release readiness remain unproven.
 
 On an Apple Silicon Mac, explicitly install the pinned public toolchain and
 AVDs, then verify it:

--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -18,7 +18,7 @@ if(NOT TARGET dawn::webgpu_dawn)
   message(FATAL_ERROR "Pinned Dawn config did not define dawn::webgpu_dawn")
 endif()
 
-add_library(main SHARED fixture_main.cpp)
+add_library(main SHARED fixture_main.cpp guest_memory_fixture.cpp)
 target_compile_features(main PRIVATE cxx_std_20)
 target_compile_options(main PRIVATE -Wall -Wextra -Werror -fvisibility=hidden)
 target_link_libraries(main PRIVATE SDL3::SDL3 dawn::webgpu_dawn android log dl)

--- a/android/app/src/main/cpp/fixture_main.cpp
+++ b/android/app/src/main/cpp/fixture_main.cpp
@@ -6,6 +6,8 @@
 #include <dawn/webgpu.h>
 #include <unistd.h>
 
+#include "guest_memory_fixture.h"
+
 #include <algorithm>
 #include <array>
 #include <atomic>
@@ -273,18 +275,22 @@ extern "C" __attribute__((visibility("default"))) int SDL_main(int, char**) {
     LogError("SDL_Init failed");
     return 1;
   }
+  if (!RunGuestMemoryFixture()) {
+    SDL_Quit();
+    return 2;
+  }
   SDL_Window* window = SDL_CreateWindow(
       "KartPad", 960, 540, SDL_WINDOW_VULKAN | SDL_WINDOW_HIGH_PIXEL_DENSITY);
   if (window == nullptr) {
     LogError("SDL_CreateWindow failed");
     SDL_Quit();
-    return 2;
+    return 3;
   }
   if (!SDL_Vulkan_LoadLibrary(nullptr) || SDL_Vulkan_GetVkGetInstanceProcAddr() == nullptr) {
     LogError("SDL Vulkan loader unavailable");
     SDL_DestroyWindow(window);
     SDL_Quit();
-    return 3;
+    return 4;
   }
 
   WGPURequestAdapterOptions options = WGPU_REQUEST_ADAPTER_OPTIONS_INIT;
@@ -297,7 +303,7 @@ extern "C" __attribute__((visibility("default"))) int SDL_main(int, char**) {
     SDL_Vulkan_UnloadLibrary();
     SDL_DestroyWindow(window);
     SDL_Quit();
-    return 4;
+    return 5;
   }
   __android_log_print(ANDROID_LOG_INFO, kLogTag,
                       "A0 JNI/Vulkan fixture passed abi=arm64-v8a page_size=%ld adapters=%zu",
@@ -317,7 +323,7 @@ extern "C" __attribute__((visibility("default"))) int SDL_main(int, char**) {
     SDL_Vulkan_UnloadLibrary();
     SDL_DestroyWindow(window);
     SDL_Quit();
-    return 5;
+    return 6;
   }
   if (!RunDeterministicReadback(instance, device)) {
     __android_log_print(ANDROID_LOG_ERROR, kLogTag,
@@ -326,7 +332,7 @@ extern "C" __attribute__((visibility("default"))) int SDL_main(int, char**) {
     SDL_Vulkan_UnloadLibrary();
     SDL_DestroyWindow(window);
     SDL_Quit();
-    return 6;
+    return 7;
   }
 
   __android_log_print(ANDROID_LOG_INFO, kLogTag,
@@ -343,7 +349,7 @@ extern "C" __attribute__((visibility("default"))) int SDL_main(int, char**) {
     SDL_Vulkan_UnloadLibrary();
     SDL_DestroyWindow(window);
     SDL_Quit();
-    return 7;
+    return 8;
   }
   __android_log_print(ANDROID_LOG_INFO, kLogTag,
                       "A1 Vulkan present passed abi=arm64-v8a page_size=%ld "
@@ -361,7 +367,7 @@ extern "C" __attribute__((visibility("default"))) int SDL_main(int, char**) {
                              &presented_width, &presented_height)) {
         __android_log_print(ANDROID_LOG_ERROR, kLogTag,
                             "A1 Vulkan fixture failed: foreground surface recreation");
-        exit_code = 8;
+        exit_code = 9;
         break;
       }
       ++presentation_generation;

--- a/android/app/src/main/cpp/guest_memory_fixture.cpp
+++ b/android/app/src/main/cpp/guest_memory_fixture.cpp
@@ -1,0 +1,131 @@
+#include "guest_memory_fixture.h"
+
+#include <android/log.h>
+#include <android/sharedmem.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+
+namespace {
+
+constexpr char kLogTag[] = "KartPadFixture";
+constexpr size_t kGuestReservationBytes = uint64_t{1} << 32;
+
+bool Fail(const char* step) {
+  __android_log_print(ANDROID_LOG_ERROR, kLogTag,
+                      "A1 guest memory failed step=%s errno=%d", step, errno);
+  return false;
+}
+
+bool FailCheck(const char* step) {
+  __android_log_print(ANDROID_LOG_ERROR, kLogTag,
+                      "A1 guest memory failed step=%s", step);
+  return false;
+}
+
+}  // namespace
+
+bool RunGuestMemoryFixture() {
+  static_assert(sizeof(size_t) == sizeof(uint64_t));
+  const long page_size_raw = sysconf(_SC_PAGESIZE);
+  if (page_size_raw <= 0) return Fail("page-size");
+  const size_t page_size = static_cast<size_t>(page_size_raw);
+  if ((page_size & (page_size - 1)) != 0) {
+    return FailCheck("page-size-power-of-two");
+  }
+  const size_t alias_bytes = page_size * 2;
+
+  int shared_fd = ASharedMemory_create("kartpad-a1-memory", alias_bytes);
+  if (shared_fd < 0) return Fail("shared-memory-create");
+  void* reservation = MAP_FAILED;
+  void* alias = MAP_FAILED;
+  bool passed = false;
+
+  do {
+    if (ASharedMemory_setProt(shared_fd, PROT_READ | PROT_WRITE) != 0) {
+      Fail("shared-memory-protection");
+      break;
+    }
+    reservation = mmap(nullptr, kGuestReservationBytes, PROT_NONE,
+                       MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+    if (reservation == MAP_FAILED) {
+      Fail("reserve-4gib");
+      break;
+    }
+    const uintptr_t reservation_address =
+        reinterpret_cast<uintptr_t>(reservation);
+    if ((reservation_address & (page_size - 1)) != 0) {
+      FailCheck("reservation-alignment");
+      break;
+    }
+
+    auto* primary_address = static_cast<uint8_t*>(reservation) +
+                            (kGuestReservationBytes / 2);
+    void* primary = mmap(primary_address, alias_bytes, PROT_READ | PROT_WRITE,
+                         MAP_SHARED | MAP_FIXED, shared_fd, 0);
+    if (primary != primary_address) {
+      Fail("primary-fixed-alias");
+      break;
+    }
+    alias = mmap(nullptr, alias_bytes, PROT_READ | PROT_WRITE, MAP_SHARED,
+                 shared_fd, 0);
+    if (alias == MAP_FAILED) {
+      Fail("secondary-alias");
+      break;
+    }
+
+    auto* primary_bytes = static_cast<uint8_t*>(primary);
+    auto* alias_data = static_cast<uint8_t*>(alias);
+    for (size_t index = 0; index < alias_bytes; ++index) {
+      primary_bytes[index] = static_cast<uint8_t>((index * 131U + 17U) & 0xffU);
+    }
+    bool alias_matches = true;
+    for (size_t index = 0; index < alias_bytes; ++index) {
+      if (alias_data[index] !=
+          static_cast<uint8_t>((index * 131U + 17U) & 0xffU)) {
+        alias_matches = false;
+        break;
+      }
+    }
+    if (!alias_matches) {
+      FailCheck("alias-read");
+      break;
+    }
+    if (mprotect(primary, alias_bytes, PROT_READ) != 0) {
+      Fail("primary-read-only");
+      break;
+    }
+    alias_data[page_size] = 0x5a;
+    if (primary_bytes[page_size] != 0x5a) {
+      FailCheck("alias-write-visible");
+      break;
+    }
+    if (mprotect(primary, alias_bytes, PROT_NONE) != 0 ||
+        mprotect(primary, alias_bytes, PROT_READ) != 0) {
+      Fail("primary-protection-cycle");
+      break;
+    }
+    if (primary_bytes[page_size] != 0x5a) {
+      FailCheck("protection-cycle-preserved-data");
+      break;
+    }
+    passed = true;
+  } while (false);
+
+  if (alias != MAP_FAILED) munmap(alias, alias_bytes);
+  if (reservation != MAP_FAILED) {
+    munmap(reservation, kGuestReservationBytes);
+  }
+  close(shared_fd);
+  if (passed) {
+    __android_log_print(
+        ANDROID_LOG_INFO, kLogTag,
+        "A1 guest memory passed reserve_bytes=%zu alias_bytes=%zu page_size=%zu "
+        "writable_executable=0",
+        kGuestReservationBytes, alias_bytes, page_size);
+  }
+  return passed;
+}

--- a/android/app/src/main/cpp/guest_memory_fixture.h
+++ b/android/app/src/main/cpp/guest_memory_fixture.h
@@ -1,0 +1,3 @@
+#pragma once
+
+bool RunGuestMemoryFixture();

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -7,12 +7,13 @@
   ARM64 emulator execution.
 - **Runtime proof:** A0 passes. The local non-playable source-only APK now also
   creates one Dawn Vulkan device, byte-verifies a deterministic clear/readback,
-  presents through SDL's Android native window, and presents again after
-  HOME/foreground surface recreation on the pinned API 36 / 4 KiB and Android
-  15 / 16 KiB ARM64 AVDs.
+  presents through SDL's Android native window, presents again after
+  HOME/foreground surface recreation, and proves dynamic 4 GiB guest-memory
+  reservation, shared aliases, and protection changes on the pinned API 36 /
+  4 KiB and Android 15 / 16 KiB ARM64 AVDs.
 - **Decision:** A1 renderer bring-up is partially green. Continue rotation and
-  repeated lifecycle stress, guest memory, and ELF AArch64 scheduler fixtures
-  before user-interface or private full-game work.
+  repeated lifecycle stress and ELF AArch64 scheduler fixtures before
+  user-interface or private full-game work.
 
 KartPad can be ported to Android without changing its defining architecture.
 The Android build should contain the same ahead-of-time translated Original

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -94,9 +94,10 @@ not block offline Retro Rewind support.
 
 1. Continue Android A1 using `docs/ANDROID-GOAL-LOOP.md`: deterministic Vulkan
    clear/readback/present and HOME/foreground surface recreation now pass on
-   both page-size lanes. Add explicit rotation/repeated lifecycle stress, then
-   the 4 KiB/16 KiB guest-memory and Android ELF scheduler/register fixtures
-   before private game integration. Evidence is under
+   both page-size lanes. Dynamic 4 GiB reservation, shared aliases, and
+   protection changes now also pass at both 4 KiB and 16 KiB. Add explicit
+   rotation/repeated lifecycle stress and the Android ELF scheduler/register
+   fixture before private game integration. Evidence is under
    `docs/artifacts/2026-09-03/android/`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -1656,3 +1656,28 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   repeated stress, guest memory, and scheduler/register fixtures. No package
   was hosted or published. Evidence:
   `docs/artifacts/2026-09-03/android/a1-vulkan-readback-present.md`.
+
+## 2026-09-03 — Android A1 dynamic guest-memory aliases
+
+- Added an Android-native, source-only memory fixture using
+  `ASharedMemory_create`. It reserves a dynamic sparse 4 GiB `PROT_NONE`
+  address range without a fixed high-address assumption, replaces a centered
+  two-page span with a shared primary mapping, and creates a second shared
+  alias of the same file descriptor.
+- Filled the primary mapping with deterministic bytes and verified every byte
+  through the secondary alias. Changed the primary to read-only, wrote through
+  the secondary alias, observed the update through the primary, cycled the
+  primary through `PROT_NONE` and back to read-only, and verified that data was
+  preserved. The fixture never requests executable permission.
+- Cold-boot combined runs pass on API 36 / 4,096-byte pages and API 35 /
+  16,384-byte pages while retaining the existing Vulkan readback, initial
+  presentation, and HOME/foreground replacement-surface checks. The audited
+  local debug APK is 33,540,035 bytes with SHA-256
+  `b9401bfb23c50a8256d6ef336c99085159d403873cf508a759d389e7f64e0635`.
+- Classification: **Pass for dynamic 4 GiB reservation, shared alias
+  visibility, and page-size-aware protection changes on both pinned emulator
+  lanes.** This is not the production checked-memory implementation, scheduler
+  evidence, physical-device evidence, gameplay, or performance. A1 remains
+  open for rotation/repeated lifecycle and ELF AArch64 scheduler/register
+  stress. No package was hosted or published. Evidence:
+  `docs/artifacts/2026-09-03/android/a1-guest-memory.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -21,9 +21,13 @@ The first A1 renderer slice passes on both pinned page-size lanes. One Dawn
 Vulkan device performs an exact 16-pixel GPU clear/readback, presents through
 SDL's Android native window, and presents again after an automated
 HOME/foreground surface recreation. A1 remains open for rotation and repeated
-lifecycle stress, guest-memory aliases/protection, and ELF AArch64
-scheduler/register fixtures. Evidence:
-[`docs/artifacts/2026-09-03/android/a1-vulkan-readback-present.md`](artifacts/2026-09-03/android/a1-vulkan-readback-present.md).
+lifecycle stress and ELF AArch64 scheduler/register fixtures. A separate A1
+checkpoint now reserves a dynamic sparse 4 GiB range and proves two shared
+views, cross-alias visibility, and runtime-page-size-aware protection changes
+on both 4 KiB and 16 KiB lanes without writable-executable memory. Evidence:
+[`docs/artifacts/2026-09-03/android/a1-vulkan-readback-present.md`](artifacts/2026-09-03/android/a1-vulkan-readback-present.md)
+and
+[`docs/artifacts/2026-09-03/android/a1-guest-memory.md`](artifacts/2026-09-03/android/a1-guest-memory.md).
 
 ## Native tvOS work
 

--- a/docs/artifacts/2026-09-03/android/a1-guest-memory.md
+++ b/docs/artifacts/2026-09-03/android/a1-guest-memory.md
@@ -1,0 +1,61 @@
+# Android A1 guest-memory alias and protection fixture
+
+## Classification
+
+**Pass for the source-only guest-memory primitive on both pinned ARM64
+emulator lanes.** The fixture reserves a dynamic sparse 4 GiB virtual range,
+maps two runtime-page-sized spans of the same Android shared-memory object,
+verifies deterministic contents through both views, and exercises protection
+changes without ever requesting executable memory.
+
+This proves the Android primitives required by the eventual checked/table
+guest-memory implementation. It does not yet integrate the production
+WiiCompiled memory layer, deliberately fault guarded pages, run translated
+code, or establish physical-device behavior. A1 remains in progress.
+
+## Exact checks
+
+1. Read and validate the runtime page size.
+2. Create a two-page `ASharedMemory` object and restrict its allowed mappings
+   to read/write.
+3. Reserve 4,294,967,296 bytes at a kernel-selected address with `PROT_NONE`,
+   `MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE`.
+4. Replace a centered two-page span with a fixed shared mapping and create a
+   second shared mapping at another kernel-selected address.
+5. Fill the primary view with a deterministic byte pattern and verify every
+   byte through the secondary view.
+6. Make the primary read-only, write through the secondary, and verify
+   cross-alias visibility.
+7. Cycle the primary through `PROT_NONE` and back to read-only, then verify
+   that the shared data remains intact.
+8. Unmap the alias and complete reservation and close the shared-memory file
+   descriptor on every success or failure path.
+
+## Commands and results
+
+```sh
+./scripts/run-android-fixture.sh KartPad_API_36_ARM64
+./scripts/run-android-fixture.sh KartPad_API_35_PS16K_ARM64
+```
+
+| Lane | API | Runtime page | Reservation | Shared span | Result |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `KartPad_API_36_ARM64` | 36 | 4,096 | 4 GiB | 8,192 bytes | pass |
+| `KartPad_API_35_PS16K_ARM64` | 35 | 16,384 | 4 GiB | 32,768 bytes | pass |
+
+Both were wiped cold boots. The combined runner also retained the exact
+Vulkan readback, initial surface presentation, background observation, and
+post-foreground replacement-surface presentation checks.
+
+The exact local debug APK is 33,540,035 bytes with SHA-256
+`b9401bfb23c50a8256d6ef336c99085159d403873cf508a759d389e7f64e0635`.
+It passes the inherited SDK, package, ARM64-only native-library, 16 KiB
+ZIP/ELF alignment, dependency, RELRO, non-executable-stack, exported-symbol,
+permission, and privacy audit. No APK/AAB was hosted or published.
+
+## Next gate
+
+Add explicit orientation/surface-generation observation and bounded repeated
+recreation stress, then implement the ELF AArch64 fiber/register scheduler
+fixture. Integrate production checked memory only after these source-only A1
+primitives remain green together.

--- a/scripts/run-android-fixture.sh
+++ b/scripts/run-android-fixture.sh
@@ -81,6 +81,8 @@ wait_for_marker() {
 }
 
 wait_for_marker \
+  "A1 guest memory passed reserve_bytes=4294967296"
+wait_for_marker \
   "A1 Vulkan present passed abi=arm64-v8a page_size=$expected_page_size"
 "$adb" shell input keyevent KEYCODE_HOME
 wait_for_marker "A1 lifecycle background observed"
@@ -90,4 +92,4 @@ sleep 3
 wait_for_marker \
   "A1 Vulkan recreate passed generation=2 page_size=$expected_page_size"
 
-echo "Android A1 Vulkan fixture passed: avd=$avd api=$("$adb" shell getprop ro.build.version.sdk | tr -d '\r') abi=$abi page_size=$page_size backend=Vulkan readback_rgba=20-80-e0-ff surface=presented lifecycle=background-foreground-recreated"
+echo "Android A1 fixture passed: avd=$avd api=$("$adb" shell getprop ro.build.version.sdk | tr -d '\r') abi=$abi page_size=$page_size guest_memory=4GiB-aliased-protected backend=Vulkan readback_rgba=20-80-e0-ff surface=presented lifecycle=background-foreground-recreated"


### PR DESCRIPTION
## Summary
- reserve a dynamic sparse 4 GiB Android guest range
- prove runtime-page-aware shared aliases and protection transitions
- require the memory pass alongside the existing Vulkan/lifecycle fixture on 4 KiB and 16 KiB ARM64 AVDs
- document the scoped A1 evidence and remaining gates

## Validation
- `./scripts/run-android-fixture.sh KartPad_API_36_ARM64`
- `./scripts/run-android-fixture.sh KartPad_API_35_PS16K_ARM64`
- `./scripts/audit-android-package.sh`
- Android `:app:lintDebug :app:testDebugUnitTest`
- `./scripts/check-repo-safety.sh`
- `./scripts/verify-sunpad-overlay-snapshot.sh`

No APK/AAB was hosted or published.