### PR TITLE
Android A1: stress Vulkan surface lifecycle

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -8,11 +8,14 @@ clear/readback, presents a separate clear through the Android native window,
 and repeats presentation after HOME/foreground surface recreation. The next
 A1 slice reserves a dynamic sparse 4 GiB guest range, maps two shared views,
 and verifies alias visibility and read-only/guard/read-only protection changes
-using the runtime page size. None of these paths use game data or generated
-translated code.
+using the runtime page size. The surface fixture now also retains and
+reconfigures its Dawn surface across a physical flipped-landscape sensor
+transition, then replaces and presents through three consecutive Android
+background/foreground surface generations. None of these paths use game data
+or generated translated code.
 
-Rotation, repeated lifecycle stress, fibers, gameplay, physical-device
-support, performance, and release readiness remain unproven.
+Fibers, gameplay, physical-device support, performance, and release readiness
+remain unproven.
 
 On an Apple Silicon Mac, explicitly install the pinned public toolchain and
 AVDs, then verify it:

--- a/android/app/src/main/cpp/fixture_main.cpp
+++ b/android/app/src/main/cpp/fixture_main.cpp
@@ -31,16 +31,34 @@ struct MapState {
 };
 
 struct LifecycleState {
-  std::atomic_bool recreate_pending = false;
+  std::atomic_bool foreground_pending = false;
+  std::atomic_int orientation_pending = SDL_ORIENTATION_UNKNOWN;
+  std::atomic_int current_orientation = SDL_ORIENTATION_UNKNOWN;
+  std::atomic_int background_count = 0;
 };
 
 bool LifecycleEventFilter(void* userdata, SDL_Event* event) {
   auto* state = static_cast<LifecycleState*>(userdata);
   if (event->type == SDL_EVENT_WILL_ENTER_BACKGROUND) {
+    const int cycle = state->background_count.fetch_add(
+                          1, std::memory_order_acq_rel) +
+                      1;
     __android_log_print(ANDROID_LOG_INFO, kLogTag,
-                        "A1 lifecycle background observed");
+                        "A1 lifecycle background observed cycle=%d", cycle);
   } else if (event->type == SDL_EVENT_DID_ENTER_FOREGROUND) {
-    state->recreate_pending.store(true, std::memory_order_release);
+    state->foreground_pending.store(true, std::memory_order_release);
+  } else if (event->type == SDL_EVENT_DISPLAY_ORIENTATION &&
+             event->display.data1 != SDL_ORIENTATION_UNKNOWN) {
+    const int orientation = event->display.data1;
+    const int previous = state->current_orientation.exchange(
+        orientation, std::memory_order_acq_rel);
+    if (orientation != previous) {
+      state->orientation_pending.store(orientation,
+                                       std::memory_order_release);
+      __android_log_print(ANDROID_LOG_INFO, kLogTag,
+                          "A1 orientation observed orientation=%d previous=%d",
+                          orientation, previous);
+    }
   }
   return true;
 }
@@ -154,21 +172,17 @@ bool RunDeterministicReadback(dawn::native::Instance& instance,
 
 bool RunSurfacePresent(dawn::native::Instance& instance,
                        dawn::native::Adapter& adapter, WGPUDevice device,
-                       SDL_Window* window,
+                       SDL_Window* window, WGPUSurface* retained_surface,
+                       bool replace_surface,
                        int* presented_width, int* presented_height) {
-  void* native_window = SDL_GetPointerProperty(
-      SDL_GetWindowProperties(window), SDL_PROP_WINDOW_ANDROID_WINDOW_POINTER,
-      nullptr);
-  if (native_window == nullptr ||
-      !SDL_GetWindowSizeInPixels(window, presented_width, presented_height) ||
+  if (!SDL_GetWindowSizeInPixels(window, presented_width, presented_height) ||
       *presented_width <= 0 || *presented_height <= 0) {
     __android_log_print(ANDROID_LOG_ERROR, kLogTag,
-                        "surface step failed: native-window-or-size");
+                        "surface step failed: window-size");
     return false;
   }
 
   WGPUQueue queue = nullptr;
-  WGPUSurface surface = nullptr;
   WGPUTexture texture = nullptr;
   WGPUTextureView view = nullptr;
   WGPUCommandEncoder encoder = nullptr;
@@ -184,17 +198,32 @@ bool RunSurfacePresent(dawn::native::Instance& instance,
   do {
     queue = wgpuDeviceGetQueue(device);
     if (queue == nullptr) break;
-    WGPUSurfaceSourceAndroidNativeWindow source =
-        WGPU_SURFACE_SOURCE_ANDROID_NATIVE_WINDOW_INIT;
-    source.window = native_window;
-    WGPUSurfaceDescriptor surface_desc = WGPU_SURFACE_DESCRIPTOR_INIT;
-    surface_desc.nextInChain = &source.chain;
-    failed_step = "create-surface";
-    surface = wgpuInstanceCreateSurface(instance.Get(), &surface_desc);
-    if (surface == nullptr) break;
+    if (replace_surface && *retained_surface != nullptr) {
+      wgpuSurfaceRelease(*retained_surface);
+      *retained_surface = nullptr;
+    }
+    if (*retained_surface == nullptr) {
+      void* native_window = SDL_GetPointerProperty(
+          SDL_GetWindowProperties(window),
+          SDL_PROP_WINDOW_ANDROID_WINDOW_POINTER, nullptr);
+      if (native_window == nullptr) {
+        failed_step = "native-window";
+        break;
+      }
+      WGPUSurfaceSourceAndroidNativeWindow source =
+          WGPU_SURFACE_SOURCE_ANDROID_NATIVE_WINDOW_INIT;
+      source.window = native_window;
+      WGPUSurfaceDescriptor surface_desc = WGPU_SURFACE_DESCRIPTOR_INIT;
+      surface_desc.nextInChain = &source.chain;
+      failed_step = "create-surface";
+      *retained_surface =
+          wgpuInstanceCreateSurface(instance.Get(), &surface_desc);
+      if (*retained_surface == nullptr) break;
+    }
     failed_step = "surface-capabilities";
     const WGPUStatus capabilities_status =
-        wgpuSurfaceGetCapabilities(surface, adapter.Get(), &capabilities);
+        wgpuSurfaceGetCapabilities(*retained_surface, adapter.Get(),
+                                   &capabilities);
     status_detail = static_cast<int>(capabilities_status);
     if (capabilities_status != WGPUStatus_Success || capabilities.formatCount == 0) {
       break;
@@ -207,12 +236,12 @@ bool RunSurfacePresent(dawn::native::Instance& instance,
     config.width = static_cast<uint32_t>(*presented_width);
     config.height = static_cast<uint32_t>(*presented_height);
     config.presentMode = WGPUPresentMode_Fifo;
-    wgpuSurfaceConfigure(surface, &config);
+    wgpuSurfaceConfigure(*retained_surface, &config);
     configured = true;
 
     failed_step = "current-texture";
     WGPUSurfaceTexture current = WGPU_SURFACE_TEXTURE_INIT;
-    wgpuSurfaceGetCurrentTexture(surface, &current);
+    wgpuSurfaceGetCurrentTexture(*retained_surface, &current);
     status_detail = static_cast<int>(current.status);
     if ((current.status != WGPUSurfaceGetCurrentTextureStatus_SuccessOptimal &&
          current.status != WGPUSurfaceGetCurrentTextureStatus_SuccessSuboptimal) ||
@@ -243,7 +272,7 @@ bool RunSurfacePresent(dawn::native::Instance& instance,
     if (commands == nullptr) break;
     wgpuQueueSubmit(queue, 1, &commands);
     failed_step = "present";
-    const WGPUStatus present_status = wgpuSurfacePresent(surface);
+    const WGPUStatus present_status = wgpuSurfacePresent(*retained_surface);
     status_detail = static_cast<int>(present_status);
     if (present_status != WGPUStatus_Success) break;
     dawn::native::DeviceTick(device);
@@ -255,9 +284,8 @@ bool RunSurfacePresent(dawn::native::Instance& instance,
   if (encoder != nullptr) wgpuCommandEncoderRelease(encoder);
   if (view != nullptr) wgpuTextureViewRelease(view);
   if (texture != nullptr) wgpuTextureRelease(texture);
-  if (configured) wgpuSurfaceUnconfigure(surface);
+  if (configured) wgpuSurfaceUnconfigure(*retained_surface);
   if (capabilities_valid) wgpuSurfaceCapabilitiesFreeMembers(capabilities);
-  if (surface != nullptr) wgpuSurfaceRelease(surface);
   if (queue != nullptr) wgpuQueueRelease(queue);
   if (!passed) {
     __android_log_print(ANDROID_LOG_ERROR, kLogTag,
@@ -341,10 +369,13 @@ extern "C" __attribute__((visibility("default"))) int SDL_main(int, char**) {
                       sysconf(_SC_PAGESIZE), adapters.size());
   int presented_width = 0;
   int presented_height = 0;
-  if (!RunSurfacePresent(instance, adapters.front(), device, window,
+  WGPUSurface surface = nullptr;
+  if (!RunSurfacePresent(instance, adapters.front(), device, window, &surface,
+                         false,
                          &presented_width, &presented_height)) {
     __android_log_print(ANDROID_LOG_ERROR, kLogTag,
                         "A1 Vulkan fixture failed: surface clear/present");
+    if (surface != nullptr) wgpuSurfaceRelease(surface);
     wgpuDeviceRelease(device);
     SDL_Vulkan_UnloadLibrary();
     SDL_DestroyWindow(window);
@@ -358,27 +389,45 @@ extern "C" __attribute__((visibility("default"))) int SDL_main(int, char**) {
   int exit_code = 0;
   int presentation_generation = 1;
   LifecycleState lifecycle;
+  lifecycle.current_orientation.store(
+      SDL_GetCurrentDisplayOrientation(SDL_GetDisplayForWindow(window)),
+      std::memory_order_release);
   SDL_SetEventFilter(LifecycleEventFilter, &lifecycle);
   SDL_Event event;
   while (SDL_WaitEvent(&event)) {
     if (event.type == SDL_EVENT_QUIT) break;
-    if (lifecycle.recreate_pending.exchange(false, std::memory_order_acq_rel)) {
+    const int orientation = lifecycle.orientation_pending.exchange(
+        SDL_ORIENTATION_UNKNOWN, std::memory_order_acq_rel);
+    const bool foreground = lifecycle.foreground_pending.exchange(
+        false, std::memory_order_acq_rel);
+    if (orientation != SDL_ORIENTATION_UNKNOWN || foreground) {
+      // Allow Android's SurfaceView transaction to settle before querying the
+      // replacement ANativeWindow. This is bounded by the runner's marker
+      // timeout and avoids presenting through a transition-era surface.
+      std::this_thread::sleep_for(std::chrono::seconds(3));
       if (!RunSurfacePresent(instance, adapters.front(), device, window,
+                             &surface, foreground,
                              &presented_width, &presented_height)) {
         __android_log_print(ANDROID_LOG_ERROR, kLogTag,
-                            "A1 Vulkan fixture failed: foreground surface recreation");
+                            "A1 Vulkan fixture failed: surface recreation");
         exit_code = 9;
         break;
       }
       ++presentation_generation;
       __android_log_print(ANDROID_LOG_INFO, kLogTag,
-                          "A1 Vulkan recreate passed generation=%d page_size=%ld "
-                          "size=%dx%d",
-                          presentation_generation, sysconf(_SC_PAGESIZE),
+                          "A1 Vulkan recreate passed generation=%d reason=%s "
+                          "orientation=%d page_size=%ld size=%dx%d",
+                          presentation_generation,
+                          orientation != SDL_ORIENTATION_UNKNOWN ? "orientation"
+                                                                 : "foreground",
+                          lifecycle.current_orientation.load(
+                              std::memory_order_acquire),
+                          sysconf(_SC_PAGESIZE),
                           presented_width, presented_height);
     }
   }
   SDL_SetEventFilter(nullptr, nullptr);
+  if (surface != nullptr) wgpuSurfaceRelease(surface);
   wgpuDeviceRelease(device);
   SDL_Vulkan_UnloadLibrary();
   SDL_DestroyWindow(window);

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -8,12 +8,14 @@
 - **Runtime proof:** A0 passes. The local non-playable source-only APK now also
   creates one Dawn Vulkan device, byte-verifies a deterministic clear/readback,
   presents through SDL's Android native window, presents again after
-  HOME/foreground surface recreation, and proves dynamic 4 GiB guest-memory
-  reservation, shared aliases, and protection changes on the pinned API 36 /
-  4 KiB and Android 15 / 16 KiB ARM64 AVDs.
-- **Decision:** A1 renderer bring-up is partially green. Continue rotation and
-  repeated lifecycle stress and ELF AArch64 scheduler fixtures before
-  user-interface or private full-game work.
+  HOME/foreground surface recreation, survives a physical flipped-landscape
+  sensor transition and three consecutive replacement-surface cycles, and
+  proves dynamic 4 GiB guest-memory reservation, shared aliases, and
+  protection changes on the pinned API 36 / 4 KiB and Android 15 / 16 KiB
+  ARM64 AVDs.
+- **Decision:** A1 renderer, lifecycle, and memory bring-up are green. Continue
+  the ELF AArch64 scheduler/register fixture before user-interface or private
+  full-game work.
 
 KartPad can be ported to Android without changing its defining architecture.
 The Android build should contain the same ahead-of-time translated Original

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -95,9 +95,10 @@ not block offline Retro Rewind support.
 1. Continue Android A1 using `docs/ANDROID-GOAL-LOOP.md`: deterministic Vulkan
    clear/readback/present and HOME/foreground surface recreation now pass on
    both page-size lanes. Dynamic 4 GiB reservation, shared aliases, and
-   protection changes now also pass at both 4 KiB and 16 KiB. Add explicit
-   rotation/repeated lifecycle stress and the Android ELF scheduler/register
-   fixture before private game integration. Evidence is under
+   protection changes now also pass at both 4 KiB and 16 KiB. A physical
+   flipped-landscape transition plus three consecutive surface teardown/
+   foreground/recreate/present cycles pass on both lanes. Add the Android ELF
+   scheduler/register fixture before private game integration. Evidence is under
    `docs/artifacts/2026-09-03/android/`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -1681,3 +1681,30 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   open for rotation/repeated lifecycle and ELF AArch64 scheduler/register
   stress. No package was hosted or published. Evidence:
   `docs/artifacts/2026-09-03/android/a1-guest-memory.md`.
+
+## 2026-09-03 — Android A1 rotation and repeated surface lifecycle
+
+- Changed the Vulkan fixture to retain and reconfigure its Dawn surface when
+  Android changes the existing `SurfaceView`, and to release/create a new Dawn
+  surface only after Android has actually destroyed and recreated the native
+  surface. This matches the ownership boundary needed by the product.
+- The runner enables the physical emulator accelerometer, sets an absolute
+  flipped-landscape gravity vector, and requires SDL's exact orientation
+  transition from landscape `1` to flipped landscape `2`. It then requires a
+  successful retained-surface presentation followed by three separate HOME /
+  foreground replacement-surface presentations. Every pass marker is rejected
+  if the fixture emitted any error-level line.
+- A naive user-rotation setting produced no sensor event and was rejected. The
+  first physical-sensor implementation attempted to create a new Dawn surface
+  from a `SurfaceView` changed in place; Dawn rejected its capabilities. The
+  retained-surface model fixes that ownership error and passes cold boots on
+  API 36 / 4 KiB and API 35 / 16 KiB.
+- The audited local debug APK is 33,545,363 bytes with SHA-256
+  `f2efa7efd850d41fe5bb4b19e0d2d448ade8ee3a4f82f58397c63665cdfe2e70`.
+  Classification: **Pass for flipped-landscape reconfiguration and three
+  consecutive background/foreground native-surface replacements on both
+  pinned emulator page sizes.** Physical OEM lifecycle behavior, gameplay,
+  performance, and long-session stability remain open. A1 now requires only
+  the ELF AArch64 scheduler/register stress fixture. No package was hosted or
+  published. Evidence:
+  `docs/artifacts/2026-09-03/android/a1-lifecycle-stress.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -20,12 +20,17 @@ The lowest incomplete goal is A1.
 The first A1 renderer slice passes on both pinned page-size lanes. One Dawn
 Vulkan device performs an exact 16-pixel GPU clear/readback, presents through
 SDL's Android native window, and presents again after an automated
-HOME/foreground surface recreation. A1 remains open for rotation and repeated
-lifecycle stress and ELF AArch64 scheduler/register fixtures. A separate A1
-checkpoint now reserves a dynamic sparse 4 GiB range and proves two shared
+HOME/foreground surface recreation. It now also observes an exact physical
+landscape-to-flipped-landscape sensor transition, reconfigures the retained
+Dawn surface, and replaces/presents through three consecutive
+background/foreground surface generations on both lanes. A1 remains open for
+the ELF AArch64 scheduler/register fixture. A separate A1 checkpoint reserves
+a dynamic sparse 4 GiB range and proves two shared
 views, cross-alias visibility, and runtime-page-size-aware protection changes
 on both 4 KiB and 16 KiB lanes without writable-executable memory. Evidence:
 [`docs/artifacts/2026-09-03/android/a1-vulkan-readback-present.md`](artifacts/2026-09-03/android/a1-vulkan-readback-present.md)
+and
+[`docs/artifacts/2026-09-03/android/a1-lifecycle-stress.md`](artifacts/2026-09-03/android/a1-lifecycle-stress.md)
 and
 [`docs/artifacts/2026-09-03/android/a1-guest-memory.md`](artifacts/2026-09-03/android/a1-guest-memory.md).
 

--- a/docs/artifacts/2026-09-03/android/a1-lifecycle-stress.md
+++ b/docs/artifacts/2026-09-03/android/a1-lifecycle-stress.md
@@ -1,0 +1,58 @@
+# Android A1 rotation and repeated Vulkan surface lifecycle
+
+## Classification
+
+**Pass for deterministic flipped-landscape handling and three consecutive
+background/foreground surface replacements on both pinned ARM64 emulator
+lanes.** SDL observes the physical sensor transition, Dawn reconfigures and
+presents through the retained Android surface, and then releases/replaces the
+surface after each actual Android teardown.
+
+This is bounded source-only emulator evidence. It is not physical-OEM
+lifecycle, foldable/multi-window, long-session, gameplay, or performance
+evidence. A1 remains open for the ELF AArch64 scheduler/register stress gate.
+
+## Ownership model
+
+- Android `surfaceChanged`: retain the existing `WGPUSurface`, configure it for
+  the current pixel size, acquire, clear, and present.
+- Android background/foreground: allow `onStop` and `surfaceDestroyed` to
+  finish, release the Dawn surface after foreground, acquire SDL's replacement
+  `ANativeWindow`, create a replacement `WGPUSurface`, and present.
+- Final shutdown: release the retained surface before the shared Dawn device.
+
+The distinction matters. A rejected intermediate implementation attempted to
+create a brand-new Dawn surface from a `SurfaceView` that Android had changed
+in place during 180-degree rotation; Dawn correctly rejected that transition-
+era surface at capability lookup. Retaining the owning surface across
+`surfaceChanged` and replacing it only across true destruction is stable.
+
+## Commands and exact results
+
+```sh
+./scripts/run-android-fixture.sh KartPad_API_36_ARM64
+./scripts/run-android-fixture.sh KartPad_API_35_PS16K_ARM64
+```
+
+| Lane | API | Page size | Rotation | Replacement cycles | Result |
+| --- | ---: | ---: | --- | ---: | --- |
+| `KartPad_API_36_ARM64` | 36 | 4,096 | SDL `1 → 2`, present | 3/3 | pass |
+| `KartPad_API_35_PS16K_ARM64` | 35 | 16,384 | SDL `1 → 2`, present | 3/3 | pass |
+
+Each was a wiped cold boot. The runner pins an absolute emulator acceleration
+vector rather than relying on relative emulator orientation state. It requires
+surface presentation generations 1 through 5: initial, flipped orientation,
+and three foreground replacements. It also fails if any `KartPadFixture` error
+line exists after all positive markers.
+
+The combined run retains the exact GPU readback and guest-memory checks. The
+exact local debug APK is 33,545,363 bytes with SHA-256
+`f2efa7efd850d41fe5bb4b19e0d2d448ade8ee3a4f82f58397c63665cdfe2e70`.
+It passes the inherited Android package, ELF, 16 KiB alignment, symbol,
+permission, and privacy audit. No APK/AAB was hosted or published.
+
+## Next gate
+
+Implement the Android ELF AArch64 cooperative scheduler fixture and prove
+start/yield/sleep/wake/join/cancel plus callee-saved general/SIMD register
+preservation under a long bounded stress run on both page-size lanes.

--- a/scripts/run-android-fixture.sh
+++ b/scripts/run-android-fixture.sh
@@ -84,12 +84,30 @@ wait_for_marker \
   "A1 guest memory passed reserve_bytes=4294967296"
 wait_for_marker \
   "A1 Vulkan present passed abi=arm64-v8a page_size=$expected_page_size"
-"$adb" shell input keyevent KEYCODE_HOME
-wait_for_marker "A1 lifecycle background observed"
-# Let Android complete onStop/surface teardown before requesting foreground.
-sleep 3
-"$adb" shell am start -W -n dev.kartpad.android/.KartPadActivity >/dev/null
-wait_for_marker \
-  "A1 Vulkan recreate passed generation=2 page_size=$expected_page_size"
 
-echo "Android A1 fixture passed: avd=$avd api=$("$adb" shell getprop ro.build.version.sdk | tr -d '\r') abi=$abi page_size=$page_size guest_memory=4GiB-aliased-protected backend=Vulkan readback_rgba=20-80-e0-ff surface=presented lifecycle=background-foreground-recreated"
+# Exercise the other allowed landscape orientation and require SDL to observe
+# it before accepting a newly created Dawn surface presentation.
+"$adb" shell settings put system accelerometer_rotation 1
+"$adb" emu sensor set acceleration -9.81:0:0 >/dev/null
+wait_for_marker "A1 orientation observed orientation=2 previous=1"
+wait_for_marker \
+  "A1 Vulkan recreate passed generation=2 reason=orientation orientation=2 page_size=$expected_page_size"
+
+for cycle in 1 2 3; do
+  generation=$((cycle + 2))
+  "$adb" shell input keyevent KEYCODE_HOME
+  wait_for_marker "A1 lifecycle background observed cycle=$cycle"
+  # Let Android complete onStop/surface teardown before requesting foreground.
+  sleep 3
+  "$adb" shell am start -W -n dev.kartpad.android/.KartPadActivity >/dev/null
+  wait_for_marker \
+    "A1 Vulkan recreate passed generation=$generation reason=foreground orientation=2 page_size=$expected_page_size"
+done
+
+if "$adb" logcat -d -v brief KartPadFixture:E '*:S' | grep -q .; then
+  echo "ERROR: fixture emitted an error despite reaching all pass markers" >&2
+  "$adb" logcat -d -v brief KartPadFixture:V '*:S' >&2
+  exit 1
+fi
+
+echo "Android A1 fixture passed: avd=$avd api=$("$adb" shell getprop ro.build.version.sdk | tr -d '\r') abi=$abi page_size=$page_size guest_memory=4GiB-aliased-protected backend=Vulkan readback_rgba=20-80-e0-ff surface=presented lifecycle=orientation-plus-3-background-foreground-recreations"


### PR DESCRIPTION
## Summary
- retain/reconfigure Dawn surface across Android `surfaceChanged`
- replace the Dawn surface only after actual native-surface teardown/recreation
- prove physical landscape-to-flipped-landscape rotation and three consecutive HOME/foreground cycles
- reject runs containing any fixture error even when positive markers appear

## Validation
- `./scripts/run-android-fixture.sh KartPad_API_36_ARM64`
- `./scripts/run-android-fixture.sh KartPad_API_35_PS16K_ARM64`
- `./scripts/audit-android-package.sh`
- Android `:app:lintDebug :app:testDebugUnitTest`
- `./scripts/check-repo-safety.sh`
- `./scripts/verify-sunpad-overlay-snapshot.sh`

No APK/AAB was hosted or published.