### PR TITLE
Fix tvOS storage permission failures

### DIFF
--- a/apple/tvos/KartPadTVRuntimeHost.mm
+++ b/apple/tvos/KartPadTVRuntimeHost.mm
@@ -22,16 +22,16 @@ NSString *const kKartPadSupportedDOLHash =
 BOOL gKartPadTVRuntimeActive = NO;
 BOOL gKartPadTVRetroRewindSelected = NO;
 
-NSString *KartPadTVSupportRoot() {
-  return [[NSSearchPathForDirectoriesInDomains(
-      NSApplicationSupportDirectory, NSUserDomainMask, YES) firstObject]
-      stringByAppendingPathComponent:@"KartPad"];
-}
-
 NSString *KartPadTVCacheRoot() {
   return [[NSSearchPathForDirectoriesInDomains(
       NSCachesDirectory, NSUserDomainMask, YES) firstObject]
       stringByAppendingPathComponent:@"KartPad"];
+}
+
+NSString *KartPadTVSupportRoot() {
+  // tvOS permits only purgeable local files outside its small preferences
+  // allowance. Keep all filesystem-backed runtime state in Library/Caches.
+  return KartPadTVCacheRoot();
 }
 
 NSString *KartPadTVGameDataRoot() {
@@ -109,9 +109,12 @@ BOOL KartPadTVWriteRuntimePaths(NSError **error) {
   NSFileManager *files = NSFileManager.defaultManager;
   NSString *support = KartPadTVSupportRoot();
   NSString *cache = KartPadTVCacheRoot();
+  NSString *logs = [support stringByAppendingPathComponent:@"Logs"];
   if (![files createDirectoryAtPath:support withIntermediateDirectories:YES
                          attributes:nil error:error] ||
       ![files createDirectoryAtPath:cache withIntermediateDirectories:YES
+                         attributes:nil error:error] ||
+      ![files createDirectoryAtPath:logs withIntermediateDirectories:YES
                          attributes:nil error:error]) {
     return NO;
   }
@@ -147,8 +150,18 @@ BOOL KartPadTVWriteRuntimePaths(NSError **error) {
   } else {
     config = [config stringByAppendingString:paths];
   }
-  return [config writeToFile:configPath atomically:YES
-                    encoding:NSUTF8StringEncoding error:error];
+  NSError *atomicError = nil;
+  if ([config writeToFile:configPath atomically:YES
+                 encoding:NSUTF8StringEncoding error:&atomicError]) {
+    return YES;
+  }
+  NSError *directError = nil;
+  if ([config writeToFile:configPath atomically:NO
+                 encoding:NSUTF8StringEncoding error:&directError]) {
+    return YES;
+  }
+  if (error != nullptr) *error = directError ?: atomicError;
+  return NO;
 }
 
 BOOL KartPadTVHasExtendedController() {
@@ -450,6 +463,9 @@ UIButton *KartPadTVButton(NSString *title, UIColor *color,
 - (BOOL)run {
   NSError *error = nil;
   [NSFileManager.defaultManager createDirectoryAtPath:KartPadTVSupportRoot()
+      withIntermediateDirectories:YES attributes:nil error:&error];
+  [NSFileManager.defaultManager createDirectoryAtPath:
+      [KartPadTVSupportRoot() stringByAppendingPathComponent:@"Logs"]
       withIntermediateDirectories:YES attributes:nil error:&error];
   [NSFileManager.defaultManager createDirectoryAtPath:KartPadTVCacheRoot()
       withIntermediateDirectories:YES attributes:nil error:&error];

--- a/apple/tvos/KartPadTVSunPadDiagnostics.mm
+++ b/apple/tvos/KartPadTVSunPadDiagnostics.mm
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+// Keep the pinned SunPad snapshot byte-identical. Foundation is imported before
+// this narrow substitution so only the downstream implementation's directory
+// request changes for tvOS.
+#define NSApplicationSupportDirectory NSCachesDirectory
+#include "../third_party/sunpad/SunPadDiagnostics.mm"

--- a/docs/INSTALL_TVOS.md
+++ b/docs/INSTALL_TVOS.md
@@ -1,12 +1,14 @@
 # Install the experimental KartPad Apple TV build
 
-KartPad `v0.4.0` includes an unsigned ARM64 tvOS IPA for hardware
-bring-up. It has passed compilation and package audits but has not run on the
-maintainer's Apple TV hardware. Treat it as an experimental tester build, not
-supported Apple TV functionality.
+KartPad `v0.4.1` is a tvOS-only storage hotfix with an unsigned ARM64 IPA for
+hardware bring-up. A reporter's equivalent cache-root build reached playable
+Original Mario Kart Wii and Retro Rewind on Apple TV 4K hardware. The exact
+public hotfix still needs tester acceptance, so treat it as an experimental
+build, not supported Apple TV functionality.
 
-1. Download `KartPad-v0.4.0-tvos-unsigned.ipa` and `SHA256SUMS` from
-   the release and verify the checksum.
+1. Download `KartPad-v0.4.1-tvos-unsigned.ipa` and `SHA256SUMS` from
+   the [0.4.1 release](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.1)
+   and verify the checksum.
 2. Re-sign the IPA with your own Apple development identity and bundle
    identifier, then install it on a paired Apple TV through Xcode or a
    compatible tvOS signing workflow.
@@ -22,7 +24,10 @@ Nintendo assets, Retro Rewind pack, saves, signing identity, provisioning
 profile, or Wii banner artwork. KartPad downloads and hash-verifies the pinned
 official Retro Rewind pack only after the tester selects that mode.
 
-Update in place with the same signing identity and bundle identifier. Back up
-Application Support before deleting the app or changing signing identities.
-Never attach game data, Retro Rewind files, saves, signing material, device
-identifiers, or a complete app container to a public report.
+Update in place with the same signing identity and bundle identifier. KartPad's
+tvOS config, NAND, saves, logs, game data, and downloaded pack live under
+`Library/Caches`; tvOS may purge them under storage pressure. Run
+`scripts/backup-tvos-state.sh` before and after meaningful testing and before
+deleting the app or changing signing identities. Never attach game data, Retro
+Rewind files, saves, signing material, device identifiers, or a complete app
+container to a public report.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -108,10 +108,12 @@ The default release model is:
 A public prebuilt `.app` or `.ipa` is a separate legal and provenance gate. Do not describe one as releasable merely because a package audit finds no ISO file.
 
 **Current preview decision:** the maintainer separately authorized the free
-unsigned `v0.4.0` iPhone/iPad and tvOS community IPAs under the narrow,
-unresolved-rights boundary in `RIGHTS_AND_LICENSES.md`. The tvOS artifact is an
-explicitly unaccepted hardware-bring-up build. This decision does not mark the
-full PRD matrix complete or authorize paid or official-store distribution.
+unsigned `v0.4.0` iPhone/iPad community IPA and the tvOS-only `v0.4.1` storage
+hotfix IPA under the narrow, unresolved-rights boundary in
+`RIGHTS_AND_LICENSES.md`. The tvOS artifact remains an experimental
+hardware-bring-up build pending exact-artifact reporter acceptance. This
+decision does not mark the full PRD matrix complete or authorize paid or
+official-store distribution.
 
 ### 3.3 Native tvOS extension
 

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -10,7 +10,7 @@
       completes the physical Apple TV matrix.
 - [ ] Prove Original and Retro Rewind gameplay separately with an Extended
       Gamepad; do not infer Retro WFC acceptance from offline play.
-- [ ] Back up and rehearse restore of Application Support/NAND before asking a
+- [ ] Back up and rehearse restore of Caches/KartPad before asking a
       tester to risk saved progress.
 - [ ] Re-audit the exact signed tester artifact for private game data, Retro
       Rewind content, derived game artwork, signing material, and local paths.
@@ -18,6 +18,17 @@
 The exact 67-row matrix in `docs/PRD.md` remains the authority for full
 engineering completion. A community preview may ship with narrower, explicit
 limitations when its exact artifact passes every preview gate below.
+
+## 0.4.1 tvOS storage hotfix candidate
+
+- [x] Redirect tvOS config, NAND, saves, and logs from Application Support to Caches
+- [x] Keep iOS and macOS Application Support behavior unchanged
+- [x] Add atomic-write fallback and explicit runtime log-directory creation
+- [x] Update cache-first backup and diagnostic collection with legacy log fallback
+- [ ] Build and audit exact merged-source tvOS app 0.4.1 build 4
+- [ ] Package twice byte-identically and pass fresh extraction audits
+- [ ] Publish tag, IPA, checksum, and verify a fresh hosted download
+- [ ] Receive reporter acceptance on the exact signed hotfix artifact
 
 ## 0.4.0 stable candidate
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -15,25 +15,33 @@ or physical-device result exists yet.
 
 ## Native tvOS work
 
-The maintainer-owned `codex/tvos-retro-rewind` branch contains the first
-independent native tvOS implementation slice: a `KartPadDual` tvOS build graph,
+The repository contains an independent native tvOS implementation slice: a
+`KartPadDual` tvOS build graph,
 focus-driven setup host, Extended Gamepad requirement, Mac-side private game
 data staging, official hash-verified Retro Rewind installation, and a fail-closed
 artifact audit. The complete dual Original/Retro Rewind graph now compiles and
 links as an unsigned arm64 tvOS 17 app, and that app passes the native bundle,
-platform, dependency, symbol, privacy, and private-data audit. No Apple TV is
-paired with the current Mac, so signing, installation, execution, gameplay,
-performance, and save recovery remain untested. Apple TV support is therefore
-not accepted. The candidate includes an original three-layer tvOS icon and Top
-Shelf image compiled into its audited asset catalog. It remains explicitly
-experimental in the `v0.4.0` hardware-bring-up build. The next
-gate is a small outside cohort using the exact audited candidate and tester
-checklist. The
+platform, dependency, symbol, privacy, and private-data audit. An external Apple
+TV 4K (3rd generation) run on tvOS 26.5/26.6 accepted playable Original and
+Retro Rewind video, audio, menus, and Extended Gamepad input after moving the
+runtime from unwritable Application Support to Caches. The `v0.4.1` tvOS-only
+hotfix incorporates that path correction; exact public-artifact retesting,
+save recovery, sleep/wake, multi-controller, and sustained performance remain
+open. Apple TV support is therefore still experimental. The candidate includes
+an original three-layer tvOS icon and Top Shelf image compiled into its audited
+asset catalog. The
 authoritative scope, build procedure, storage boundary, and external-testing
 gate are in
 [`docs/TVOS.md`](TVOS.md).
 
 ## Current goal
+
+**0.4.1 tvOS storage hotfix is in release validation.** It moves tvOS config,
+NAND, saves, runtime logs, and controller diagnostics to purgeable Caches,
+retains cache-first diagnostics with a legacy Application Support fallback,
+and adds a non-atomic config write fallback for the physical error-513 path.
+The iPhone/iPad 0.4.0 release is unchanged. The exact tvOS build, deterministic
+package, hosted comparison, and reporter retest remain open.
 
 **0.4.0 is published as KartPad's second stable community release.** The
 `v0.4.0` tag points to source commit

--- a/docs/TVOS-TESTING.md
+++ b/docs/TVOS-TESTING.md
@@ -1,9 +1,10 @@
 # KartPad Apple TV bring-up test
 
-This candidate has passed an arm64 tvOS build and static audit, but it has never
-run on physical Apple TV hardware. Treat it as an engineering bring-up build,
-not a supported release. Do not use an Apple TV container that holds valuable
-KartPad saves.
+An externally built cache-root candidate has reached playable Original Mario
+Kart Wii and Retro Rewind on physical Apple TV 4K hardware. The exact public
+`v0.4.1` hotfix still needs a signed-container retest. Treat it as an
+engineering bring-up build, not a supported release, and do not rely on its
+purgeable local storage for valuable saves.
 
 ## What the tester needs
 
@@ -20,8 +21,9 @@ an issue.
 ## Install and stage data
 
 Install the signed candidate using Xcode Device Hub or Apple Configurator. Do
-not uninstall an existing KartPad build unless its Application Support has been
-backed up first.
+not uninstall an existing KartPad build unless its `Library/Caches/KartPad`
+state has been backed up first. tvOS may purge this directory under storage
+pressure even when the app remains installed.
 
 The repository scripts default to the `dev.kartpad.tv` app container. If the
 candidate was signed with a different bundle identifier, set it before any

--- a/docs/TVOS.md
+++ b/docs/TVOS.md
@@ -2,10 +2,14 @@
 
 ## Current status
 
-Native tvOS support is available as the experimental public
-`v0.4.0` hardware-bring-up build. There is still no accepted Apple TV
-gameplay result. Until the physical acceptance matrix below passes, the correct
-claim is **public experimental tvOS preview**, not supported Apple TV
+Native tvOS support is available as an experimental public hardware-bring-up
+path. An external Apple TV 4K (3rd generation) tester reached playable Original
+Mario Kart Wii and Retro Rewind on tvOS 26.5/26.6 with an Extended Gamepad, but
+the public `v0.4.0` build could not write config, NAND, saves, or logs under
+Application Support. The `v0.4.1` hotfix moves all filesystem-backed tvOS state
+to Caches, matching the successful physical workaround. Until the remaining
+physical acceptance matrix passes on the exact hotfix artifact, the correct
+claim is **public experimental tvOS build**, not supported Apple TV
 functionality.
 
 This implementation starts from KartPad `main`, the project's pinned upstream
@@ -53,14 +57,17 @@ it can be reconstructed:
 | --- | --- | --- |
 | Extracted RMCP01 data | `Library/Caches/KartPad/GameData` | Restage from the user's Mac |
 | Retro Rewind pack | `Library/Caches/KartPad/RetroRewind` | Download and verify again |
-| Config, NAND, saves, runtime logs | `Library/Application Support/KartPad` | Back up to the user's Mac before testing |
-| Controller diagnostics | `Library/Application Support/SunPad/Logs` | Collect separately with the diagnostics script |
+| Config, NAND, saves, runtime logs | `Library/Caches/KartPad` | Back up to the user's Mac before and after testing |
+| Controller diagnostics | `Library/Caches/SunPad/Logs` | Collect separately with the diagnostics script |
 
-Application Support is not treated as a permanent guarantee on Apple TV. The
-developer preview includes a Mac-side backup command, and testers must back up
-before replacing or deleting the app. A later broadly supported release needs
-a tested durable sync/restore design, such as an appropriately entitled
-CloudKit container, before it can promise durable saves.
+[Apple documents](https://developer.apple.com/library/archive/documentation/General/Conceptual/AppleTV_PG/)
+tvOS local files outside the small preferences allowance as purgeable. The
+developer build therefore keeps every writable filesystem path under Caches and
+includes a Mac-side backup command. Testers must assume config, saves, game
+data, and logs can disappear under storage pressure and must back up before
+replacing or deleting the app. A later broadly supported release needs a tested
+durable sync/restore design, such as an appropriately entitled CloudKit
+container, before it can promise durable saves.
 
 ## Building the first candidate
 
@@ -154,9 +161,14 @@ commit, binary SHA-256, and whether the run used Original or Retro Rewind.
 
 ## External hardware bring-up
 
-The maintainer does not currently have physical Apple TV hardware, so a small
-outside cohort will perform the first physical acceptance pass. This is a
-hardware bring-up build, not a supported release.
+The maintainer does not currently have physical Apple TV hardware, so an
+outside cohort performs physical acceptance. The first report confirms both
+modes can reach smooth playable gameplay with audio, 3D rendering, menus, and
+wireless gamepad input. It also exposed error 513 on Application Support; the
+reporter's cache-root workaround succeeded and is the basis of `v0.4.1`.
+Save/relaunch, sleep/wake, multi-controller, purge recovery, and an exact public
+hotfix retest remain open. This is still a hardware bring-up build, not a
+supported release.
 
 Before sending it, package and audit one exact candidate. Testers must have a
 paired Apple TV, a Mac with Xcode, an Extended Gamepad, their own supported game

--- a/docs/releases/v0.4.1.md
+++ b/docs/releases/v0.4.1.md
@@ -1,0 +1,36 @@
+# KartPad v0.4.1 tvOS storage hotfix
+
+KartPad 0.4.1 is a tvOS-only maintenance release for
+[Issue #17](https://github.com/chrissotraidis/kartpad/issues/17). The iPhone and
+iPad release remains 0.4.0.
+
+## Apple TV fix
+
+- Moves tvOS config, NAND, saves, runtime logs, and controller diagnostics from
+  `Library/Application Support` to `Library/Caches`.
+- Creates the runtime log directory before launch.
+- Retries `Config.toml` with a direct write if the atomic replacement path is
+  denied by the tvOS sandbox.
+- Updates backup and diagnostic scripts for the cache-root layout while keeping
+  a diagnostic fallback for logs created by older builds.
+
+An external tester identified Cocoa error 513 on Apple TV 4K (3rd generation)
+and confirmed that an equivalent cache-root build reaches playable Original
+Mario Kart Wii and Retro Rewind on tvOS 26.5/26.6 with an Extended Gamepad. The
+exact public 0.4.1 artifact still requires their signed-container retest.
+
+## Storage warning
+
+Apple may purge tvOS cache files under storage pressure. That includes this
+build's config, NAND, saves, logs, staged game data, and downloaded Retro Rewind
+pack. Run `scripts/backup-tvos-state.sh` before and after meaningful testing.
+KartPad cannot promise durable Apple TV saves until a separately tested sync or
+restore design exists.
+
+## Installation and boundaries
+
+The IPA is unsigned and must be re-signed locally. Supply your own legally
+obtained PAL `RMCP01`, revision-0 game data. The artifact includes translated
+code but no disc image, extracted game assets, Retro Rewind content, saves,
+signing material, or provisioning profile. It remains an experimental tvOS
+tester build, not a supported-platform claim.

--- a/patches/wiicompiled-tvos-runtime.patch
+++ b/patches/wiicompiled-tvos-runtime.patch
@@ -43,9 +43,9 @@
 +
 +set(MKW_KARTPAD_MINIZIP_SOURCE_DIR "" CACHE PATH
 +    "Pinned minizip-ng source used by KartPad's tvOS Retro Rewind installer")
-+set(KARTPAD_TVOS_MARKETING_VERSION "0.4.0" CACHE STRING
++set(KARTPAD_TVOS_MARKETING_VERSION "0.4.1" CACHE STRING
 +    "KartPad tvOS marketing version")
-+set(KARTPAD_TVOS_BUILD_NUMBER "3" CACHE STRING
++set(KARTPAD_TVOS_BUILD_NUMBER "4" CACHE STRING
 +    "KartPad tvOS bundle build number")
 +set(KARTPAD_TVOS_BUNDLE_IDENTIFIER "dev.kartpad.tv" CACHE STRING
 +    "KartPad tvOS product bundle identifier")
@@ -89,7 +89,7 @@
 +        "${MKW_KARTPAD_SUNPAD_DIR}/SunPadControllerMapping.mm"
 +        "${MKW_KARTPAD_SUNPAD_DIR}/SunPadInputMixer.mm"
 +        "${MKW_KARTPAD_SUNPAD_DIR}/SunPadSettings.mm"
-+        "${MKW_KARTPAD_SUNPAD_DIR}/SunPadDiagnostics.mm")
++        "${MKW_KARTPAD_TVOS_DIR}/KartPadTVSunPadDiagnostics.mm")
 +    foreach(source IN LISTS MKW_KARTPAD_TVOS_SOURCES)
 +        if(NOT EXISTS "${source}")
 +            message(FATAL_ERROR "Missing KartPad tvOS host source: ${source}")
@@ -163,6 +163,37 @@
      add_dependencies(mkw_release KartPadDual)
  endif()
  
+--- a/include/runtime_config.h
++++ b/include/runtime_config.h
+@@ -21,6 +21,7 @@
+ #ifdef __APPLE__
+ #include <mach-o/dyld.h>
+ #include <pwd.h>
++#include <TargetConditionals.h>
+ #include <unistd.h>
+ #endif
+ #ifdef _WIN32
+@@ -217,12 +218,18 @@
+     // logs into its signed resources. HOME is container-aware for a future
+     // sandboxed build; the account database is a defensive non-sandboxed
+     // fallback for unusual launch environments that omit HOME.
++    const char* libraryDirectory =
++#if TARGET_OS_TV
++        "Caches";
++#else
++        "Application Support";
++#endif
+     if (const char* home = std::getenv("HOME"); home && *home) {
+-        return std::filesystem::path(home) / "Library" / "Application Support" / "KartPad";
++        return std::filesystem::path(home) / "Library" / libraryDirectory / "KartPad";
+     }
+     if (const passwd* account = getpwuid(getuid());
+         account && account->pw_dir && *account->pw_dir) {
+-        return std::filesystem::path(account->pw_dir) / "Library" / "Application Support" / "KartPad";
++        return std::filesystem::path(account->pw_dir) / "Library" / libraryDirectory / "KartPad";
+     }
+ #endif
+     return std::filesystem::current_path() / kApplicationDirectoryName;
 --- a/src/main.cpp
 +++ b/src/main.cpp
 @@ -63,7 +63,7 @@

--- a/scripts/audit-public-unsigned-tvos-ipa.py
+++ b/scripts/audit-public-unsigned-tvos-ipa.py
@@ -12,9 +12,9 @@ import zipfile
 from pathlib import Path, PurePosixPath
 
 
-RELEASE_TAG = "v0.4.0"
-APP_VERSION = "0.4.0"
-APP_BUILD = "3"
+RELEASE_TAG = "v0.4.1"
+APP_VERSION = "0.4.1"
+APP_BUILD = "4"
 FORBIDDEN_SUFFIXES = {
     ".iso", ".gcm", ".gcz", ".ciso", ".wbfs", ".wia", ".rvz",
     ".gci", ".sav", ".log", ".mobileprovision", ".p12", ".p8",

--- a/scripts/backup-tvos-state.sh
+++ b/scripts/backup-tvos-state.sh
@@ -14,7 +14,7 @@ if [[ -e "${destination}" ]]; then
 fi
 mkdir -p "${destination}"
 xcrun devicectl device copy from --device "${device}" \
-  --source "Library/Application Support/KartPad" \
+  --source "Library/Caches/KartPad" \
   --destination "${destination}" \
   --domain-type appDataContainer \
   --domain-identifier "${bundle_identifier}"

--- a/scripts/collect-tvos-diagnostics.sh
+++ b/scripts/collect-tvos-diagnostics.sh
@@ -14,19 +14,23 @@ if [[ -e "${destination}" ]]; then
 fi
 mkdir -p "${destination}/KartPad" "${destination}/Controller"
 
-copied=0
-if xcrun devicectl device copy from --device "${device}" \
-    --source "Library/Application Support/KartPad/Logs" \
-    --destination "${destination}/KartPad" \
+copy_logs() {
+  local source="$1"
+  local output="$2"
+  xcrun devicectl device copy from --device "${device}" \
+    --source "${source}" \
+    --destination "${output}" \
     --domain-type appDataContainer \
-    --domain-identifier "${bundle_identifier}"; then
+    --domain-identifier "${bundle_identifier}"
+}
+
+copied=0
+if copy_logs "Library/Caches/KartPad/Logs" "${destination}/KartPad" ||
+   copy_logs "Library/Application Support/KartPad/Logs" "${destination}/KartPad"; then
   copied=1
 fi
-if xcrun devicectl device copy from --device "${device}" \
-    --source "Library/Application Support/SunPad/Logs" \
-    --destination "${destination}/Controller" \
-    --domain-type appDataContainer \
-    --domain-identifier "${bundle_identifier}"; then
+if copy_logs "Library/Caches/SunPad/Logs" "${destination}/Controller" ||
+   copy_logs "Library/Application Support/SunPad/Logs" "${destination}/Controller"; then
   copied=1
 fi
 if [[ "${copied}" == 0 ]]; then

--- a/scripts/package-public-unsigned-tvos-ipa.py
+++ b/scripts/package-public-unsigned-tvos-ipa.py
@@ -8,9 +8,9 @@ import sys
 from pathlib import Path
 
 
-RELEASE_TAG = "v0.4.0"
-APP_VERSION = "0.4.0"
-APP_BUILD = "3"
+RELEASE_TAG = "v0.4.1"
+APP_VERSION = "0.4.1"
+APP_BUILD = "4"
 
 
 def fail(message: str) -> None:
@@ -26,7 +26,7 @@ def main() -> int:
         "output",
         type=Path,
         nargs="?",
-        help="Output IPA path (defaults to artifacts/KartPad-v0.4.0-tvos-unsigned.ipa)",
+        help="Output IPA path (defaults to artifacts/KartPad-v0.4.1-tvos-unsigned.ipa)",
     )
     args = parser.parse_args()
 
@@ -38,7 +38,7 @@ def main() -> int:
     output = (
         args.output.resolve()
         if args.output
-        else repo / "artifacts/KartPad-v0.4.0-tvos-unsigned.ipa"
+        else repo / "artifacts/KartPad-v0.4.1-tvos-unsigned.ipa"
     )
     if subprocess.check_output(
         ["git", "-C", str(repo), "status", "--porcelain", "--untracked-files=all"],
@@ -71,7 +71,7 @@ def main() -> int:
     xcode_build = app.parents[1]
     additional_entries = {
         "INSTALL_TVOS.md": repo / "docs/INSTALL_TVOS.md",
-        "RELEASE_NOTES.md": repo / "docs/releases/v0.4.0.md",
+        "RELEASE_NOTES.md": repo / "docs/releases/v0.4.1.md",
         "TVOS_TESTING.md": repo / "docs/TVOS-TESTING.md",
         "LICENSES/GPL-3.0.txt": repo / "LICENSES/GPL-3.0.txt",
         "RIGHTS_AND_LICENSES.md": repo / "RIGHTS_AND_LICENSES.md",

--- a/tests/test_tvos_contract.py
+++ b/tests/test_tvos_contract.py
@@ -28,13 +28,24 @@ class TvOSContractTests(unittest.TestCase):
         self.assertIn("MINIZIP::minizip", patch)
         self.assertIn("KARTPAD_TVOS_BUNDLE_IDENTIFIER", patch)
 
-    def test_tvos_host_keeps_rebuildable_and_durable_state_separate(self):
+    def test_tvos_host_uses_purgeable_cache_storage(self):
         host = (ROOT / "apple/tvos/KartPadTVRuntimeHost.mm").read_text()
-        self.assertIn("NSApplicationSupportDirectory", host)
         self.assertIn("NSCachesDirectory", host)
+        self.assertNotIn("NSApplicationSupportDirectory", host)
+        self.assertIn("return KartPadTVCacheRoot();", host)
         self.assertIn('@"GameData"', host)
+        self.assertIn('@"Logs"', host)
         self.assertIn("KartPadRetroRewindInstaller.installedRootPath", host)
         self.assertIn("KartPadTVWriteRuntimePaths", host)
+        self.assertIn("atomically:NO", host)
+        runtime_patch = (ROOT / "patches/wiicompiled-tvos-runtime.patch").read_text()
+        self.assertIn("#if TARGET_OS_TV", runtime_patch)
+        self.assertIn('"Caches";', runtime_patch)
+        diagnostics = (ROOT / "apple/tvos/KartPadTVSunPadDiagnostics.mm").read_text()
+        self.assertIn(
+            "#define NSApplicationSupportDirectory NSCachesDirectory", diagnostics
+        )
+        self.assertIn("SunPadDiagnostics.mm", diagnostics)
 
     def test_extended_gamepad_is_explicit_and_siri_remote_is_not_gameplay(self):
         with (ROOT / "apple/tvos/RuntimeInfo.plist").open("rb") as handle:
@@ -119,30 +130,36 @@ class TvOSContractTests(unittest.TestCase):
         self.assertIn("80d18895b39c63bd80f457398bfcbb91", stage)
         for script in (build, stage, backup, diagnostics):
             self.assertIn("KARTPAD_TVOS_BUNDLE_IDENTIFIER", script)
-        self.assertIn("Application Support/KartPad/Logs", diagnostics)
-        self.assertIn("Application Support/SunPad/Logs", diagnostics)
+        self.assertIn("Library/Caches/KartPad", backup)
+        self.assertIn("Library/Caches/KartPad/Logs", diagnostics)
+        self.assertIn("Library/Caches/SunPad/Logs", diagnostics)
+        self.assertIn("Library/Application Support/KartPad/Logs", diagnostics)
+        self.assertIn("Library/Application Support/SunPad/Logs", diagnostics)
         self.assertIn("<app-container>", diagnostics)
         self.assertIn("<user-home>", diagnostics)
         self.assertNotIn("GameData", diagnostics)
 
-    def test_stable_release_contracts_cover_ios_and_tvos(self):
+    def test_release_contracts_cover_ios_and_tvos(self):
         ios_package = (ROOT / "scripts/package-public-unsigned-ipa.py").read_text()
         ios_audit = (ROOT / "scripts/audit-public-unsigned-ipa.py").read_text()
         tvos_package = (
             ROOT / "scripts/package-public-unsigned-tvos-ipa.py"
         ).read_text()
         tvos_audit = (ROOT / "scripts/audit-public-unsigned-tvos-ipa.py").read_text()
-        for script in (ios_package, ios_audit, tvos_package, tvos_audit):
+        for script in (ios_package, ios_audit):
             self.assertIn('RELEASE_TAG = "v0.4.0"', script)
             self.assertIn('APP_VERSION = "0.4.0"', script)
+        for script in (tvos_package, tvos_audit):
+            self.assertIn('RELEASE_TAG = "v0.4.1"', script)
+            self.assertIn('APP_VERSION = "0.4.1"', script)
         self.assertIn('APP_BUILD = "15"', ios_package)
         self.assertIn('APP_BUILD = "15"', ios_audit)
-        self.assertIn('APP_BUILD = "3"', tvos_package)
-        self.assertIn('APP_BUILD = "3"', tvos_audit)
+        self.assertIn('APP_BUILD = "4"', tvos_package)
+        self.assertIn('APP_BUILD = "4"', tvos_audit)
         self.assertIn('"physicalAppleTVAcceptance": False', tvos_package)
         self.assertIn('"physicalAppleTVAcceptance": False', tvos_audit)
         self.assertTrue((ROOT / "docs/INSTALL_TVOS.md").is_file())
-        self.assertTrue((ROOT / "docs/releases/v0.4.0.md").is_file())
+        self.assertTrue((ROOT / "docs/releases/v0.4.1.md").is_file())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- move tvOS filesystem-backed runtime state and diagnostics to `Library/Caches`
- retry `Config.toml` with a non-atomic write when atomic replacement is denied
- update tvOS backup/diagnostic tooling, tests, storage warnings, and 0.4.1 packaging metadata
- preserve iOS/macOS Application Support behavior and the pinned SunPad snapshot

Closes no issue: keep #17 open until the reporter retests the exact signed public hotfix.

## Validation

- 51 Python contract tests pass (1 environment-dependent skip)
- 337 patch hunks validate across 36 patches
- pinned source verification passes
- SunPad snapshot remains byte-identical
- native Apple subsystem smoke passes
- non-tvOS runtime storage contract passes
- exact ARM64 tvOS 17 app 0.4.1 build 4 compiles and passes `audit-tvos-app.sh`
- built executable contains `Caches` and no `Application Support` string