### PR TITLE
Android A1: complete ELF scheduler stress

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -11,11 +11,13 @@ and verifies alias visibility and read-only/guard/read-only protection changes
 using the runtime page size. The surface fixture now also retains and
 reconfigures its Dawn surface across a physical flipped-landscape sensor
 transition, then replaces and presents through three consecutive Android
-background/foreground surface generations. None of these paths use game data
-or generated translated code.
+background/foreground surface generations. The final A1 slice runs the shared
+cooperative scheduler for two million deterministic operations and a native
+ELF AArch64 fiber for one million context switches with callee-saved register
+checks. None of these paths use game data or generated translated code.
 
-Fibers, gameplay, physical-device support, performance, and release readiness
-remain unproven.
+Gameplay, physical-device support, performance, and release readiness remain
+unproven. A1 is complete; A2 is the next gate.
 
 On an Apple Silicon Mac, explicitly install the pinned public toolchain and
 AVDs, then verify it:

--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.24)
-project(kartpad_android_fixture LANGUAGES C CXX)
+project(kartpad_android_fixture LANGUAGES C CXX ASM)
 
 if(NOT ANDROID OR NOT CMAKE_ANDROID_ARCH_ABI STREQUAL "arm64-v8a")
   message(FATAL_ERROR "KartPad A0 supports Android arm64-v8a only")
@@ -18,9 +18,19 @@ if(NOT TARGET dawn::webgpu_dawn)
   message(FATAL_ERROR "Pinned Dawn config did not define dawn::webgpu_dawn")
 endif()
 
-add_library(main SHARED fixture_main.cpp guest_memory_fixture.cpp)
+get_filename_component(KARTPAD_REPO_ROOT
+  "${CMAKE_CURRENT_LIST_DIR}/../../../../.." ABSOLUTE)
+
+add_library(main SHARED
+  fixture_main.cpp
+  guest_memory_fixture.cpp
+  scheduler_fixture.cpp
+  fiber_switch_android.S
+  "${KARTPAD_REPO_ROOT}/runtime/src/scheduler/guest_scheduler.cpp")
 target_compile_features(main PRIVATE cxx_std_20)
 target_compile_options(main PRIVATE -Wall -Wextra -Werror -fvisibility=hidden)
+target_include_directories(main PRIVATE
+  "${KARTPAD_REPO_ROOT}/runtime/include")
 target_link_libraries(main PRIVATE SDL3::SDL3 dawn::webgpu_dawn android log dl)
 
 set_target_properties(main PROPERTIES

--- a/android/app/src/main/cpp/fiber_switch_android.S
+++ b/android/app/src/main/cpp/fiber_switch_android.S
@@ -1,0 +1,137 @@
+.text
+.p2align 2
+
+.global KartPadSwitchAndroidFiber
+.hidden KartPadSwitchAndroidFiber
+.type KartPadSwitchAndroidFiber, %function
+KartPadSwitchAndroidFiber:
+  stp x19, x20, [x0, #0]
+  stp x21, x22, [x0, #16]
+  stp x23, x24, [x0, #32]
+  stp x25, x26, [x0, #48]
+  stp x27, x28, [x0, #64]
+  stp x29, x30, [x0, #80]
+  mov x9, sp
+  str x9, [x0, #96]
+  mrs x9, fpcr
+  mrs x10, fpsr
+  stp x9, x10, [x0, #104]
+  stp d8, d9, [x0, #128]
+  stp d10, d11, [x0, #144]
+  stp d12, d13, [x0, #160]
+  stp d14, d15, [x0, #176]
+
+  ldp x19, x20, [x1, #0]
+  ldp x21, x22, [x1, #16]
+  ldp x23, x24, [x1, #32]
+  ldp x25, x26, [x1, #48]
+  ldp x27, x28, [x1, #64]
+  ldp x29, x30, [x1, #80]
+  ldr x9, [x1, #96]
+  mov sp, x9
+  ldp x9, x10, [x1, #104]
+  msr fpcr, x9
+  msr fpsr, x10
+  ldp d8, d9, [x1, #128]
+  ldp d10, d11, [x1, #144]
+  ldp d12, d13, [x1, #160]
+  ldp d14, d15, [x1, #176]
+  mov x0, x19
+  ret
+.size KartPadSwitchAndroidFiber, .-KartPadSwitchAndroidFiber
+
+.macro check_x register, offset, code
+  ldr x9, [x19, #\offset]
+  cmp \register, x9
+  b.ne .Lfiber_fail_\code
+.endm
+
+.macro check_d register, offset, code
+  ldr x9, [x19, #\offset]
+  fmov x10, \register
+  cmp x10, x9
+  b.ne .Lfiber_fail_\code
+.endm
+
+.global KartPadAndroidRegisterFiberEntry
+.hidden KartPadAndroidRegisterFiberEntry
+.type KartPadAndroidRegisterFiberEntry, %function
+KartPadAndroidRegisterFiberEntry:
+.Lfiber_loop:
+  check_x x20, 48, 20
+  check_x x21, 56, 21
+  check_x x22, 64, 22
+  check_x x23, 72, 23
+  check_x x24, 80, 24
+  check_x x25, 88, 25
+  check_x x26, 96, 26
+  check_x x27, 104, 27
+  check_x x28, 112, 28
+  check_d d8, 120, 8
+  check_d d9, 128, 9
+  check_d d10, 136, 10
+  check_d d11, 144, 11
+  check_d d12, 152, 12
+  check_d d13, 160, 13
+  check_d d14, 168, 14
+  check_d d15, 176, 15
+  mrs x10, fpcr
+  ldr x9, [x19, #184]
+  cmp x10, x9
+  b.ne .Lfiber_fail_30
+  mrs x10, fpsr
+  ldr x9, [x19, #192]
+  cmp x10, x9
+  b.ne .Lfiber_fail_31
+  ldr x9, [x19, #200]
+  cmp x29, x9
+  b.ne .Lfiber_fail_29
+
+  ldr x9, [x19, #16]
+  cbz x9, .Lfiber_finished
+  sub x9, x9, #1
+  str x9, [x19, #16]
+  ldr x10, [x19, #24]
+  add x10, x10, #1
+  str x10, [x19, #24]
+  ldp x0, x1, [x19, #0]
+  bl KartPadSwitchAndroidFiber
+  b .Lfiber_loop
+
+.macro failure_label code
+.Lfiber_fail_\code:
+  mov x9, #\code
+  str x9, [x19, #32]
+  b .Lfiber_finished
+.endm
+
+  failure_label 8
+  failure_label 9
+  failure_label 10
+  failure_label 11
+  failure_label 12
+  failure_label 13
+  failure_label 14
+  failure_label 15
+  failure_label 20
+  failure_label 21
+  failure_label 22
+  failure_label 23
+  failure_label 24
+  failure_label 25
+  failure_label 26
+  failure_label 27
+  failure_label 28
+  failure_label 29
+  failure_label 30
+  failure_label 31
+
+.Lfiber_finished:
+  mov x9, #1
+  str x9, [x19, #40]
+  ldp x0, x1, [x19, #0]
+  bl KartPadSwitchAndroidFiber
+  brk #0
+.size KartPadAndroidRegisterFiberEntry, .-KartPadAndroidRegisterFiberEntry
+
+.section .note.GNU-stack,"",%progbits

--- a/android/app/src/main/cpp/fixture_main.cpp
+++ b/android/app/src/main/cpp/fixture_main.cpp
@@ -7,6 +7,7 @@
 #include <unistd.h>
 
 #include "guest_memory_fixture.h"
+#include "scheduler_fixture.h"
 
 #include <algorithm>
 #include <array>
@@ -307,18 +308,22 @@ extern "C" __attribute__((visibility("default"))) int SDL_main(int, char**) {
     SDL_Quit();
     return 2;
   }
+  if (!RunSchedulerFixture()) {
+    SDL_Quit();
+    return 3;
+  }
   SDL_Window* window = SDL_CreateWindow(
       "KartPad", 960, 540, SDL_WINDOW_VULKAN | SDL_WINDOW_HIGH_PIXEL_DENSITY);
   if (window == nullptr) {
     LogError("SDL_CreateWindow failed");
     SDL_Quit();
-    return 3;
+    return 4;
   }
   if (!SDL_Vulkan_LoadLibrary(nullptr) || SDL_Vulkan_GetVkGetInstanceProcAddr() == nullptr) {
     LogError("SDL Vulkan loader unavailable");
     SDL_DestroyWindow(window);
     SDL_Quit();
-    return 4;
+    return 5;
   }
 
   WGPURequestAdapterOptions options = WGPU_REQUEST_ADAPTER_OPTIONS_INIT;
@@ -331,7 +336,7 @@ extern "C" __attribute__((visibility("default"))) int SDL_main(int, char**) {
     SDL_Vulkan_UnloadLibrary();
     SDL_DestroyWindow(window);
     SDL_Quit();
-    return 5;
+    return 6;
   }
   __android_log_print(ANDROID_LOG_INFO, kLogTag,
                       "A0 JNI/Vulkan fixture passed abi=arm64-v8a page_size=%ld adapters=%zu",
@@ -351,7 +356,7 @@ extern "C" __attribute__((visibility("default"))) int SDL_main(int, char**) {
     SDL_Vulkan_UnloadLibrary();
     SDL_DestroyWindow(window);
     SDL_Quit();
-    return 6;
+    return 7;
   }
   if (!RunDeterministicReadback(instance, device)) {
     __android_log_print(ANDROID_LOG_ERROR, kLogTag,
@@ -360,7 +365,7 @@ extern "C" __attribute__((visibility("default"))) int SDL_main(int, char**) {
     SDL_Vulkan_UnloadLibrary();
     SDL_DestroyWindow(window);
     SDL_Quit();
-    return 7;
+    return 8;
   }
 
   __android_log_print(ANDROID_LOG_INFO, kLogTag,
@@ -380,7 +385,7 @@ extern "C" __attribute__((visibility("default"))) int SDL_main(int, char**) {
     SDL_Vulkan_UnloadLibrary();
     SDL_DestroyWindow(window);
     SDL_Quit();
-    return 8;
+    return 9;
   }
   __android_log_print(ANDROID_LOG_INFO, kLogTag,
                       "A1 Vulkan present passed abi=arm64-v8a page_size=%ld "
@@ -410,7 +415,7 @@ extern "C" __attribute__((visibility("default"))) int SDL_main(int, char**) {
                              &presented_width, &presented_height)) {
         __android_log_print(ANDROID_LOG_ERROR, kLogTag,
                             "A1 Vulkan fixture failed: surface recreation");
-        exit_code = 9;
+        exit_code = 10;
         break;
       }
       ++presentation_generation;

--- a/android/app/src/main/cpp/scheduler_fixture.cpp
+++ b/android/app/src/main/cpp/scheduler_fixture.cpp
@@ -1,0 +1,244 @@
+#include "scheduler_fixture.h"
+
+#include "kartpad/scheduler/guest_scheduler.h"
+
+#include <android/log.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using kartpad::scheduler::GuestCpuContext;
+using kartpad::scheduler::GuestScheduler;
+using kartpad::scheduler::StepAction;
+using kartpad::scheduler::ThreadState;
+
+constexpr char kLogTag[] = "KartPadFixture";
+constexpr uint64_t kExpectedSchedulerHash = 0x7287563387fb1677ULL;
+constexpr uint64_t kFiberSwitches = 1'000'000;
+
+struct alignas(16) AndroidFiberContext {
+  std::array<uint64_t, 10> x19_x28{};
+  uint64_t fp = 0;
+  uint64_t lr = 0;
+  uint64_t sp = 0;
+  uint64_t fpcr = 0;
+  uint64_t fpsr = 0;
+  uint64_t reserved = 0;
+  std::array<uint64_t, 8> d8_d15{};
+};
+
+struct FiberState {
+  AndroidFiberContext* fiber_context = nullptr;
+  AndroidFiberContext* host_context = nullptr;
+  uint64_t remaining = 0;
+  uint64_t switches = 0;
+  uint64_t failure = 0;
+  uint64_t finished = 0;
+  std::array<uint64_t, 9> expected_x20_x28{};
+  std::array<uint64_t, 8> expected_d8_d15{};
+  uint64_t expected_fpcr = 0;
+  uint64_t expected_fpsr = 0;
+  uint64_t expected_fp = 0;
+};
+
+static_assert(sizeof(AndroidFiberContext) == 192);
+static_assert(offsetof(FiberState, expected_x20_x28) == 48);
+static_assert(offsetof(FiberState, expected_d8_d15) == 120);
+static_assert(offsetof(FiberState, expected_fpcr) == 184);
+static_assert(offsetof(FiberState, expected_fpsr) == 192);
+static_assert(offsetof(FiberState, expected_fp) == 200);
+
+extern "C" void KartPadSwitchAndroidFiber(AndroidFiberContext* source,
+                                           const AndroidFiberContext* target);
+extern "C" void KartPadAndroidRegisterFiberEntry();
+
+void Require(bool condition, const char* message) {
+  if (!condition) throw std::runtime_error(message);
+}
+
+uint64_t HashState(const std::vector<GuestScheduler::ThreadSnapshot>& snapshots,
+                   uint64_t operations, uint64_t retraces) {
+  uint64_t hash = 1469598103934665603ULL;
+  const auto mix = [&](uint64_t value) {
+    hash ^= value;
+    hash *= 1099511628211ULL;
+  };
+  mix(operations);
+  mix(retraces);
+  for (const auto& snapshot : snapshots) {
+    mix(snapshot.id);
+    mix(snapshot.context.gpr[0]);
+    mix(snapshot.context.gpr[31]);
+    mix(snapshot.context.fpr_bits[0]);
+    mix(snapshot.context.fpr_bits[31]);
+    for (uint8_t byte : snapshot.context.simd_state) mix(byte);
+    mix(snapshot.context.fpscr);
+  }
+  return hash;
+}
+
+uint64_t RunMillionSchedulerOperations() {
+  GuestScheduler scheduler;
+  uint64_t retraces = 0;
+  scheduler.ConfigureViRetrace(100, [&](uint64_t index) {
+    Require(index == retraces + 1, "VI retrace index mismatch");
+    ++retraces;
+  });
+  for (uint32_t thread_index = 0; thread_index < 4; ++thread_index) {
+    GuestCpuContext initial{};
+    initial.gpr[31] = 0xA0000000U | thread_index;
+    initial.fpr_bits[0] = 0x3FF0000000000000ULL + thread_index;
+    initial.fpr_bits[31] = 0x7FF8000000000000ULL + thread_index;
+    initial.fpscr = 0xF0000000U | thread_index;
+    initial.simd_state.fill(static_cast<uint8_t>(0x20 + thread_index));
+    (void)scheduler.Create(
+        5, "stress-" + std::to_string(thread_index), initial,
+        [thread_index](GuestCpuContext& context) {
+          ++context.gpr[0];
+          context.pc += 4;
+          context.lr = 0x80000000U | thread_index;
+          return StepAction::Yield();
+        },
+        false);
+  }
+  Require(scheduler.Run(1'000'000) == 1'000'000,
+          "million-operation fixture ended early");
+  Require(retraces == 10'000, "VI retrace cadence mismatch");
+  const auto snapshots = scheduler.SnapshotAll();
+  Require(snapshots.size() == 4, "stress thread count mismatch");
+  for (const auto& snapshot : snapshots) {
+    Require(snapshot.context.gpr[0] == 250'000,
+            "round-robin distribution mismatch");
+    const uint32_t index = static_cast<uint32_t>(snapshot.id - 1);
+    Require(snapshot.context.gpr[31] == (0xA0000000U | index),
+            "scheduler GPR preservation mismatch");
+    Require(snapshot.context.fpr_bits[0] ==
+                0x3FF0000000000000ULL + index &&
+                snapshot.context.fpr_bits[31] ==
+                    0x7FF8000000000000ULL + index,
+            "scheduler FPR preservation mismatch");
+    Require(snapshot.context.fpscr == (0xF0000000U | index),
+            "scheduler FPSCR preservation mismatch");
+    for (uint8_t byte : snapshot.context.simd_state) {
+      Require(byte == static_cast<uint8_t>(0x20 + index),
+              "scheduler SIMD preservation mismatch");
+    }
+  }
+  return HashState(snapshots, scheduler.OperationCount(), retraces);
+}
+
+void TestSchedulerLifecycle() {
+  GuestScheduler scheduler;
+  int start_yield_steps = 0;
+  const auto yielding = scheduler.Create(
+      2, "start-yield", {}, [&](GuestCpuContext&) {
+        return ++start_yield_steps == 1 ? StepAction::Yield()
+                                        : StepAction::Exit(7);
+      });
+  Require(scheduler.Resume(yielding), "start/resume failed");
+  Require(scheduler.Run(2) == 2 &&
+              scheduler.Snapshot(yielding)->exit_code == 7,
+          "yield/exit failed");
+
+  int sleep_steps = 0;
+  const auto sleeper = scheduler.Create(
+      3, "sleep-wake", {}, [&](GuestCpuContext&) {
+        return ++sleep_steps == 1 ? StepAction::SleepUntil(100)
+                                  : StepAction::Exit();
+      }, false);
+  Require(scheduler.RunOne() == GuestScheduler::RunResult::Executed &&
+              scheduler.RunOne() == GuestScheduler::RunResult::AdvancedToAlarm &&
+              scheduler.RunOne() == GuestScheduler::RunResult::Executed &&
+              scheduler.Snapshot(sleeper)->state == ThreadState::Terminated,
+          "sleep/wake failed");
+
+  uint64_t target = 0;
+  int join_steps = 0;
+  const auto joiner = scheduler.Create(
+      1, "joiner", {}, [&](GuestCpuContext&) {
+        return ++join_steps == 1 ? StepAction::WaitJoin(target)
+                                 : StepAction::Exit();
+      }, false);
+  target = scheduler.Create(
+      2, "target", {}, [](GuestCpuContext&) { return StepAction::Exit(42); },
+      false);
+  Require(scheduler.Run(3) == 3 &&
+              scheduler.Snapshot(joiner)->state == ThreadState::Terminated &&
+              scheduler.Snapshot(target)->exit_code == 42,
+          "join failed");
+
+  const auto cancelled = scheduler.Create(
+      4, "cancel", {}, [](GuestCpuContext&) { return StepAction::Yield(); });
+  Require(scheduler.Cancel(cancelled) &&
+              scheduler.Snapshot(cancelled)->state == ThreadState::Cancelled,
+          "cancel failed");
+}
+
+void RunFiberRegisterStress() {
+  AndroidFiberContext host{};
+  AndroidFiberContext fiber{};
+  FiberState state{};
+  state.fiber_context = &fiber;
+  state.host_context = &host;
+  state.remaining = kFiberSwitches;
+  for (size_t index = 0; index < state.expected_x20_x28.size(); ++index) {
+    state.expected_x20_x28[index] =
+        0x2021222324252600ULL + static_cast<uint64_t>(index);
+    fiber.x19_x28[index + 1] = state.expected_x20_x28[index];
+  }
+  for (size_t index = 0; index < state.expected_d8_d15.size(); ++index) {
+    state.expected_d8_d15[index] =
+        0xD8D9DADBDCDDDE00ULL + static_cast<uint64_t>(index);
+    fiber.d8_d15[index] = state.expected_d8_d15[index];
+  }
+  state.expected_fpcr = 0x00400000;
+  state.expected_fpsr = 0x08000000;
+  state.expected_fp = 0x2929292929292929;
+  fiber.x19_x28[0] = reinterpret_cast<uintptr_t>(&state);
+  fiber.fpcr = state.expected_fpcr;
+  fiber.fpsr = state.expected_fpsr;
+  fiber.fp = state.expected_fp;
+  fiber.lr = reinterpret_cast<uintptr_t>(&KartPadAndroidRegisterFiberEntry);
+  alignas(16) std::array<std::byte, 64 * 1024> stack{};
+  fiber.sp = reinterpret_cast<uintptr_t>(stack.data() + stack.size()) &
+             ~uintptr_t{0x0f};
+
+  while (state.finished == 0 && state.failure == 0) {
+    KartPadSwitchAndroidFiber(&host, &fiber);
+  }
+  Require(state.failure == 0, "ELF register preservation mismatch");
+  Require(state.finished == 1 && state.remaining == 0 &&
+              state.switches == kFiberSwitches,
+          "ELF fiber switch count mismatch");
+}
+
+}  // namespace
+
+bool RunSchedulerFixture() {
+  try {
+    TestSchedulerLifecycle();
+    const uint64_t first_hash = RunMillionSchedulerOperations();
+    const uint64_t second_hash = RunMillionSchedulerOperations();
+    Require(first_hash == kExpectedSchedulerHash && second_hash == first_hash,
+            "scheduler deterministic hash mismatch");
+    RunFiberRegisterStress();
+    __android_log_print(
+        ANDROID_LOG_INFO, kLogTag,
+        "A1 ELF scheduler passed operations=2000000 hash=0x%016llx "
+        "fiber_switches=%llu registers=x19-x30-sp-d8-d15-fpcr-fpsr",
+        static_cast<unsigned long long>(first_hash),
+        static_cast<unsigned long long>(kFiberSwitches));
+    return true;
+  } catch (const std::exception& error) {
+    __android_log_print(ANDROID_LOG_ERROR, kLogTag,
+                        "A1 ELF scheduler failed: %s", error.what());
+    return false;
+  }
+}

--- a/android/app/src/main/cpp/scheduler_fixture.h
+++ b/android/app/src/main/cpp/scheduler_fixture.h
@@ -1,0 +1,3 @@
+#pragma once
+
+bool RunSchedulerFixture();

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -12,10 +12,12 @@
   sensor transition and three consecutive replacement-surface cycles, and
   proves dynamic 4 GiB guest-memory reservation, shared aliases, and
   protection changes on the pinned API 36 / 4 KiB and Android 15 / 16 KiB
-  ARM64 AVDs.
-- **Decision:** A1 renderer, lifecycle, and memory bring-up are green. Continue
-  the ELF AArch64 scheduler/register fixture before user-interface or private
-  full-game work.
+  ARM64 AVDs. The shared scheduler and ELF AArch64 fiber additionally pass two
+  million deterministic operations and one million register-checked switches
+  per lane.
+- **Decision:** A1 is green. Continue A2 with the private generated
+  Original-mode runtime and controller-driven gameplay proof; keep emulator
+  and physical-device claims separate.
 
 KartPad can be ported to Android without changing its defining architecture.
 The Android build should contain the same ahead-of-time translated Original
@@ -777,20 +779,22 @@ Before any tester receives an artifact, verify at minimum:
 
 ## Immediate next action
 
-Continue A1 by adding explicit rotation/surface-generation observation and
-bounded repeated lifecycle stress. Then add page-size-aware guest-memory and
-Android ELF AArch64 scheduler/register fixtures and run them on both pinned
-AVDs.
+A1 is complete: deterministic Vulkan readback/present, flipped-landscape and
+repeated surface lifecycle, dynamic 4 GiB shared aliases/protection, and ELF
+AArch64 scheduler/register stress pass on both pinned AVDs. Continue A2 by
+preparing and linking the ignored private generated Original-mode runtime,
+then prove controller-driven gameplay without weakening the package privacy
+boundary.
 
 The A0 commands and sanitized result are recorded in
 [`android/README.md`](../android/README.md) and
 [`a0-source-only-fixture.md`](artifacts/2026-09-03/android/a0-source-only-fixture.md).
-The first A1 renderer evidence is in
-[`a1-vulkan-readback-present.md`](artifacts/2026-09-03/android/a1-vulkan-readback-present.md).
-Do not begin the touch-UI port or private full-game link until A1 passes. The
-first valuable user-facing proof after that is a controller-driven
-Original-mode race on physical Android hardware; Retro Rewind installation and
-touch parity follow from that stable runtime base.
+A1 evidence is under
+[`docs/artifacts/2026-09-03/android/`](artifacts/2026-09-03/android/).
+Do not begin the touch-UI port until A2's controller-driven Original-mode proof
+passes. Physical Android hardware remains authoritative for vendor Vulkan and
+controller behavior; Retro Rewind installation and touch parity follow from
+that stable runtime base.
 
 ## Platform references
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -97,9 +97,11 @@ not block offline Retro Rewind support.
    both page-size lanes. Dynamic 4 GiB reservation, shared aliases, and
    protection changes now also pass at both 4 KiB and 16 KiB. A physical
    flipped-landscape transition plus three consecutive surface teardown/
-   foreground/recreate/present cycles pass on both lanes. Add the Android ELF
-   scheduler/register fixture before private game integration. Evidence is under
-   `docs/artifacts/2026-09-03/android/`.
+   foreground/recreate/present cycles pass on both lanes. The Android ELF
+   scheduler/register fixture now passes two million scheduler operations and
+   one million native switches on both lanes, closing A1. Continue A2 with the
+   private generated Original-mode graph and controller-driven gameplay proof.
+   Evidence is under `docs/artifacts/2026-09-03/android/`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -1708,3 +1708,27 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   the ELF AArch64 scheduler/register stress fixture. No package was hosted or
   published. Evidence:
   `docs/artifacts/2026-09-03/android/a1-lifecycle-stress.md`.
+
+## 2026-09-03 — Android A1 ELF AArch64 scheduler and register stress
+
+- Linked KartPad's accepted portable `GuestScheduler` directly into the
+  Android native library and exercised start/resume, yield/exit, logical
+  sleep/alarm wake, join, and cancellation. Two independent million-operation
+  runs each reproduce the accepted state hash `0x7287563387fb1677` with exact
+  four-thread distribution, VI cadence, GPR/FPR/SIMD/FPSCR state, and nested
+  scheduler transitions.
+- Added a small Android ELF AArch64 context-switch wrapper sharing the Apple
+  register contract while using ELF symbol rules. One million real stack
+  switches preserve x19–x29, use x30/SP to resume exact control flow, preserve
+  d8–d15, and explicitly preserve FPCR/FPSR. The register fiber has its own
+  aligned 64 KiB stack and cannot fall through after completion.
+- The exact combined cold-boot fixture passes on API 36 / 4 KiB and API 35 /
+  16 KiB while retaining the guest-memory, deterministic GPU readback,
+  flipped-landscape, and five-generation surface checks. The audited local
+  debug APK is 33,673,035 bytes with SHA-256
+  `0846efc7058a5cae61ace508c9bdddd3b214c826275925164c148ba1e8b511b0`.
+- Classification: **A1 pass on both pinned ARM64 emulator lanes.** This closes
+  the source-only memory, scheduler/fiber, Vulkan, rotation, and bounded
+  lifecycle gate. It is not production-runtime, gameplay, physical-driver,
+  or performance evidence. A2 is next. No package was hosted or published.
+  Evidence: `docs/artifacts/2026-09-03/android/a1-elf-scheduler.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -15,7 +15,7 @@ This does not prove a presented frame, lifecycle, guest memory, fibers,
 gameplay, physical Android hardware, performance, or release readiness; no APK
 or AAB was published. Evidence:
 [`docs/artifacts/2026-09-03/android/a0-source-only-fixture.md`](artifacts/2026-09-03/android/a0-source-only-fixture.md).
-The lowest incomplete goal is A1.
+The lowest incomplete goal is A2.
 
 The first A1 renderer slice passes on both pinned page-size lanes. One Dawn
 Vulkan device performs an exact 16-pixel GPU clear/readback, presents through
@@ -23,16 +23,24 @@ SDL's Android native window, and presents again after an automated
 HOME/foreground surface recreation. It now also observes an exact physical
 landscape-to-flipped-landscape sensor transition, reconfigures the retained
 Dawn surface, and replaces/presents through three consecutive
-background/foreground surface generations on both lanes. A1 remains open for
-the ELF AArch64 scheduler/register fixture. A separate A1 checkpoint reserves
-a dynamic sparse 4 GiB range and proves two shared
+background/foreground surface generations on both lanes. The ELF AArch64
+fixture passes start/resume, yield, sleep/wake, join, cancel, two million
+deterministic scheduler operations, and one million native context switches
+with the complete callee-saved register set on both lanes. A separate A1
+checkpoint reserves a dynamic sparse 4 GiB range and proves two shared
 views, cross-alias visibility, and runtime-page-size-aware protection changes
 on both 4 KiB and 16 KiB lanes without writable-executable memory. Evidence:
 [`docs/artifacts/2026-09-03/android/a1-vulkan-readback-present.md`](artifacts/2026-09-03/android/a1-vulkan-readback-present.md)
 and
 [`docs/artifacts/2026-09-03/android/a1-lifecycle-stress.md`](artifacts/2026-09-03/android/a1-lifecycle-stress.md)
 and
-[`docs/artifacts/2026-09-03/android/a1-guest-memory.md`](artifacts/2026-09-03/android/a1-guest-memory.md).
+[`docs/artifacts/2026-09-03/android/a1-guest-memory.md`](artifacts/2026-09-03/android/a1-guest-memory.md)
+and
+[`docs/artifacts/2026-09-03/android/a1-elf-scheduler.md`](artifacts/2026-09-03/android/a1-elf-scheduler.md).
+
+This closes A1's source-only native primitive and Vulkan-surface gate. It does
+not prove production-runtime integration, gameplay, physical-device Vulkan,
+or performance. The lowest incomplete goal is A2.
 
 ## Native tvOS work
 

--- a/docs/artifacts/2026-09-03/android/a1-elf-scheduler.md
+++ b/docs/artifacts/2026-09-03/android/a1-elf-scheduler.md
@@ -1,0 +1,64 @@
+# Android A1 ELF AArch64 scheduler and register stress
+
+## Classification
+
+**Pass, completing A1 on both pinned ARM64 emulator lanes.** Each cold-boot
+run executes two million portable scheduler operations with the accepted
+deterministic hash and one million real ELF AArch64 fiber switches with exact
+callee-saved register checks.
+
+This is source-only emulator evidence. It does not yet link the complete
+private WiiCompiled runtime, run translated game code, establish physical
+vendor-driver behavior, or make performance claims.
+
+## Scheduler semantics
+
+The Android library compiles the shared
+`runtime/src/scheduler/guest_scheduler.cpp` implementation rather than a
+parallel Kotlin or Android-only scheduler. Its fixture requires:
+
+- suspended create followed by resume/start;
+- yield followed by exit and exact exit code;
+- logical sleep, idle alarm advancement, and wake;
+- wait-for-thread, target completion, and join wake;
+- cancellation and terminal cancelled state;
+- two independent 1,000,000-operation, four-thread round-robin runs;
+- exact 250,000-operation distribution per thread and 10,000 VI retraces;
+- unchanged GPR, FPR including NaN bits, SIMD, and FPSCR fixture state; and
+- deterministic state hash `0x7287563387fb1677` on both runs.
+
+## ELF fiber contract
+
+`fiber_switch_android.S` uses ELF symbols and AAPCS64. Its 192-byte context
+saves/restores x19–x28, x29, x30, SP, d8–d15, FPCR, and FPSR. A dedicated
+assembly fiber starts on an aligned 64 KiB stack, checks seeded x19–x29 and
+d8–d15 values plus FPCR/FPSR around every yield, and relies on exact x30/SP
+restoration to resume its loop. It completes 1,000,000 switches and returns to
+the host context only through the switch primitive.
+
+## Commands and result
+
+```sh
+./scripts/run-android-fixture.sh KartPad_API_36_ARM64
+./scripts/run-android-fixture.sh KartPad_API_35_PS16K_ARM64
+```
+
+| Lane | Page size | Scheduler operations | State hash | ELF switches | Result |
+| --- | ---: | ---: | --- | ---: | --- |
+| `KartPad_API_36_ARM64` | 4,096 | 2,000,000 | `0x7287563387fb1677` twice | 1,000,000 | pass |
+| `KartPad_API_35_PS16K_ARM64` | 16,384 | 2,000,000 | `0x7287563387fb1677` twice | 1,000,000 | pass |
+
+The exact local debug APK is 33,673,035 bytes with SHA-256
+`0846efc7058a5cae61ace508c9bdddd3b214c826275925164c148ba1e8b511b0`.
+It retains the package's ARM64-only, 16 KiB alignment, RELRO,
+non-executable-stack, exported-symbol, permission, and privacy properties. The
+runner also rejects any error-level fixture line after all positive markers.
+No APK/AAB was hosted or published.
+
+## A1 closure and next gate
+
+Together with the renderer, lifecycle, and guest-memory evidence in this
+directory, this satisfies A1's source-only acceptance criteria on both
+emulator page sizes. A2 is the lowest incomplete goal: prepare/link the
+ignored private generated Original-mode graph and prove controller-driven
+gameplay, while reserving physical Vulkan/controller authority for hardware.

--- a/scripts/run-android-fixture.sh
+++ b/scripts/run-android-fixture.sh
@@ -83,6 +83,8 @@ wait_for_marker() {
 wait_for_marker \
   "A1 guest memory passed reserve_bytes=4294967296"
 wait_for_marker \
+  "A1 ELF scheduler passed operations=2000000 hash=0x7287563387fb1677 fiber_switches=1000000"
+wait_for_marker \
   "A1 Vulkan present passed abi=arm64-v8a page_size=$expected_page_size"
 
 # Exercise the other allowed landscape orientation and require SDL to observe
@@ -110,4 +112,4 @@ if "$adb" logcat -d -v brief KartPadFixture:E '*:S' | grep -q .; then
   exit 1
 fi
 
-echo "Android A1 fixture passed: avd=$avd api=$("$adb" shell getprop ro.build.version.sdk | tr -d '\r') abi=$abi page_size=$page_size guest_memory=4GiB-aliased-protected backend=Vulkan readback_rgba=20-80-e0-ff surface=presented lifecycle=orientation-plus-3-background-foreground-recreations"
+echo "Android A1 fixture passed: avd=$avd api=$("$adb" shell getprop ro.build.version.sdk | tr -d '\r') abi=$abi page_size=$page_size guest_memory=4GiB-aliased-protected scheduler=2M-operations fiber=1M-register-checked-switches backend=Vulkan readback_rgba=20-80-e0-ff surface=presented lifecycle=orientation-plus-3-background-foreground-recreations"


### PR DESCRIPTION
## Summary
- link the accepted shared cooperative scheduler into the Android native library
- prove start/resume, yield, sleep/wake, join, and cancel semantics
- reproduce the accepted scheduler hash twice across two million operations
- add an ELF AArch64 fiber switch and one-million-switch callee-saved register stress
- close A1 and advance the documented lowest incomplete goal to A2

## Validation
- `./scripts/run-android-fixture.sh KartPad_API_36_ARM64`
- `./scripts/run-android-fixture.sh KartPad_API_35_PS16K_ARM64`
- `./scripts/audit-android-package.sh`
- Android `:app:lintDebug :app:testDebugUnitTest`
- `./scripts/check-repo-safety.sh`
- `./scripts/verify-sunpad-overlay-snapshot.sh`
- unstripped ELF symbol inspection confirms both fiber entry points are local/hidden

No APK/AAB was hosted or published.