### PR TITLE
Android A2: link complete Original runtime

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -19,6 +19,21 @@ checks. None of these paths use game data or generated translated code.
 Gameplay, physical-device support, performance, and release readiness remain
 unproven. A1 is complete; A2 is the next gate.
 
+The first A2 build slice can privately prepare and package the complete
+29,065-function Original runtime when the ignored translated graph already
+exists. This command never copies that graph or game data into Git and does
+not publish the resulting APK:
+
+```sh
+./scripts/build-android-game-app.sh private/g8-full-translation
+./scripts/audit-android-package.sh \
+  android/app/build/outputs/apk/debug/app-debug.apk
+```
+
+Fixture mode remains the default when the private Gradle properties are not
+provided. A full-runtime package is only build/link evidence until separately
+staged validated game data boots and completes the A2 gameplay matrix.
+
 On an Apple Silicon Mac, explicitly install the pinned public toolchain and
 AVDs, then verify it:
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
 }
 
 val dawnAndroidRoot = providers.environmentVariable("DAWN_ANDROID_ROOT")
+val gameRuntimeSource = providers.gradleProperty("kartpadGameRuntimeSource").orNull
+val translatedShardManifest = providers.gradleProperty("kartpadTranslatedShardManifest").orNull
 
 android {
     namespace = "dev.kartpad.android"
@@ -29,6 +31,15 @@ android {
                     "-DANDROID_STL=c++_shared",
                     "-DDAWN_ANDROID_ROOT=${dawnAndroidRoot.get()}",
                 )
+                if (gameRuntimeSource != null || translatedShardManifest != null) {
+                    require(gameRuntimeSource != null && translatedShardManifest != null) {
+                        "kartpadGameRuntimeSource and kartpadTranslatedShardManifest must be set together"
+                    }
+                    arguments += listOf(
+                        "-DKARTPAD_GAME_RUNTIME_SOURCE=$gameRuntimeSource",
+                        "-DKARTPAD_TRANSLATED_SHARD_MANIFEST=$translatedShardManifest",
+                    )
+                }
                 cppFlags += listOf("-std=c++20", "-fvisibility=hidden")
             }
         }

--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -21,18 +21,46 @@ endif()
 get_filename_component(KARTPAD_REPO_ROOT
   "${CMAKE_CURRENT_LIST_DIR}/../../../../.." ABSOLUTE)
 
-add_library(main SHARED
-  fixture_main.cpp
-  guest_memory_fixture.cpp
-  scheduler_fixture.cpp
-  fiber_switch_android.S
-  "${KARTPAD_REPO_ROOT}/runtime/src/scheduler/guest_scheduler.cpp")
-target_compile_features(main PRIVATE cxx_std_20)
-target_compile_options(main PRIVATE -Wall -Wextra -Werror -fvisibility=hidden)
-target_include_directories(main PRIVATE
-  "${KARTPAD_REPO_ROOT}/runtime/include")
-target_link_libraries(main PRIVATE SDL3::SDL3 dawn::webgpu_dawn android log dl)
+set(KARTPAD_GAME_RUNTIME_SOURCE "" CACHE PATH
+  "Prepared private WiiCompiled source; empty builds the source-only fixture")
+set(KARTPAD_TRANSLATED_SHARD_MANIFEST "" CACHE FILEPATH
+  "Ignored private translated shard manifest used by game-runtime builds")
 
-set_target_properties(main PROPERTIES
-  CXX_VISIBILITY_PRESET hidden
-  VISIBILITY_INLINES_HIDDEN YES)
+if(KARTPAD_GAME_RUNTIME_SOURCE)
+  if(NOT EXISTS "${KARTPAD_GAME_RUNTIME_SOURCE}/CMakeLists.txt")
+    message(FATAL_ERROR "Prepared game runtime is missing: ${KARTPAD_GAME_RUNTIME_SOURCE}")
+  endif()
+  if(NOT EXISTS "${KARTPAD_TRANSLATED_SHARD_MANIFEST}")
+    message(FATAL_ERROR
+      "Private translated shard manifest is missing: ${KARTPAD_TRANSLATED_SHARD_MANIFEST}")
+  endif()
+  add_compile_options(
+    "-ffile-prefix-map=${KARTPAD_REPO_ROOT}=."
+    "-fmacro-prefix-map=${KARTPAD_REPO_ROOT}=.")
+  list(PREPEND CMAKE_PREFIX_PATH "${DAWN_ANDROID_ROOT}")
+  set(Dawn_DIR "${DAWN_ANDROID_ROOT}/lib/cmake/Dawn" CACHE PATH "" FORCE)
+  set(MKW_AURORA_DIR "${KARTPAD_GAME_RUNTIME_SOURCE}/aurora-main" CACHE PATH "" FORCE)
+  set(MKW_TRANSLATED_SHARD_MANIFEST
+    "${KARTPAD_TRANSLATED_SHARD_MANIFEST}" CACHE FILEPATH "" FORCE)
+  set(MKW_KARTPAD_RUNTIME_INCLUDE
+    "${KARTPAD_REPO_ROOT}/runtime/include" CACHE PATH "" FORCE)
+  set(MKW_KARTPAD_REPO_ROOT "${KARTPAD_REPO_ROOT}" CACHE PATH "" FORCE)
+  set(MKW_TRANSLATED_COMPILE_JOBS 2 CACHE STRING "" FORCE)
+  add_subdirectory("${KARTPAD_GAME_RUNTIME_SOURCE}" game-runtime)
+else()
+  add_library(main SHARED
+    fixture_main.cpp
+    guest_memory_fixture.cpp
+    scheduler_fixture.cpp
+    fiber_switch_android.S
+    "${KARTPAD_REPO_ROOT}/runtime/src/scheduler/guest_scheduler.cpp")
+  target_compile_features(main PRIVATE cxx_std_20)
+  target_compile_options(main PRIVATE -Wall -Wextra -Werror -fvisibility=hidden)
+  target_include_directories(main PRIVATE
+    "${KARTPAD_REPO_ROOT}/runtime/include")
+  target_link_libraries(main PRIVATE SDL3::SDL3 dawn::webgpu_dawn android log dl)
+
+  set_target_properties(main PROPERTIES
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN YES)
+endif()

--- a/android/app/src/main/cpp/fixture_main.cpp
+++ b/android/app/src/main/cpp/fixture_main.cpp
@@ -2,6 +2,7 @@
 #include <SDL3/SDL_main.h>
 #include <SDL3/SDL_vulkan.h>
 #include <android/log.h>
+#include <jni.h>
 #include <dawn/native/DawnNative.h>
 #include <dawn/webgpu.h>
 #include <unistd.h>
@@ -297,6 +298,12 @@ bool RunSurfacePresent(dawn::native::Instance& instance,
 }
 
 }  // namespace
+
+extern "C" JNIEXPORT void JNICALL
+Java_dev_kartpad_android_KartPadSurface_nativeBeginSurfaceMutation(JNIEnv*, jobject) {}
+
+extern "C" JNIEXPORT void JNICALL
+Java_dev_kartpad_android_KartPadSurface_nativeEndSurfaceMutation(JNIEnv*, jobject, jboolean) {}
 
 extern "C" __attribute__((visibility("default"))) int SDL_main(int, char**) {
   SDL_SetAppMetadata("KartPad", "0.0.1-a0", "dev.kartpad.android");

--- a/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
@@ -1,11 +1,15 @@
 package dev.kartpad.android
 
 import android.os.Bundle
+import android.content.Context
 import android.util.Log
 import android.view.ViewGroup
 import org.libsdl.app.SDLActivity
+import org.libsdl.app.SDLSurface
 
 class KartPadActivity : SDLActivity() {
+    override fun createSDLSurface(context: Context): SDLSurface = KartPadSurface(context)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val overlay = KartPadOverlayView(this)

--- a/android/app/src/main/java/dev/kartpad/android/KartPadSurface.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadSurface.kt
@@ -1,0 +1,38 @@
+package dev.kartpad.android
+
+import android.content.Context
+import android.view.SurfaceHolder
+import org.libsdl.app.SDLSurface
+
+/** Holds Aurora's native surface lock across SDL's Java/native mutations. */
+internal class KartPadSurface(context: Context) : SDLSurface(context) {
+    private external fun nativeBeginSurfaceMutation()
+    private external fun nativeEndSurfaceMutation(ready: Boolean)
+
+    override fun surfaceCreated(holder: SurfaceHolder) {
+        nativeBeginSurfaceMutation()
+        try {
+            super.surfaceCreated(holder)
+        } finally {
+            nativeEndSurfaceMutation(true)
+        }
+    }
+
+    override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
+        nativeBeginSurfaceMutation()
+        try {
+            super.surfaceChanged(holder, format, width, height)
+        } finally {
+            nativeEndSurfaceMutation(true)
+        }
+    }
+
+    override fun surfaceDestroyed(holder: SurfaceHolder) {
+        nativeBeginSurfaceMutation()
+        try {
+            super.surfaceDestroyed(holder)
+        } finally {
+            nativeEndSurfaceMutation(false)
+        }
+    }
+}

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -15,9 +15,10 @@
   ARM64 AVDs. The shared scheduler and ELF AArch64 fiber additionally pass two
   million deterministic operations and one million register-checked switches
   per lane.
-- **Decision:** A1 is green. Continue A2 with the private generated
-  Original-mode runtime and controller-driven gameplay proof; keep emulator
-  and physical-device claims separate.
+- **Decision:** A1 is green and the first A2 build/link slice packages the
+  complete 29,065-function Original runtime. Continue A2 with app-private
+  paths/data staging and controller-driven gameplay; keep emulator and
+  physical-device claims separate.
 
 KartPad can be ported to Android without changing its defining architecture.
 The Android build should contain the same ahead-of-time translated Original
@@ -781,10 +782,12 @@ Before any tester receives an artifact, verify at minimum:
 
 A1 is complete: deterministic Vulkan readback/present, flipped-landscape and
 repeated surface lifecycle, dynamic 4 GiB shared aliases/protection, and ELF
-AArch64 scheduler/register stress pass on both pinned AVDs. Continue A2 by
-preparing and linking the ignored private generated Original-mode runtime,
-then prove controller-driven gameplay without weakening the package privacy
-boundary.
+AArch64 scheduler/register stress pass on both pinned AVDs. A2's private
+29,065-function Original runtime now compiles, links, and packages through
+Gradle with a clean strict audit. Continue A2 by bridging app-private
+config/cache/data paths, staging the validated ignored DATA directory outside
+the APK, and proving controller-driven gameplay without weakening the package
+privacy boundary.
 
 The A0 commands and sanitized result are recorded in
 [`android/README.md`](../android/README.md) and

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -92,16 +92,15 @@ not block offline Retro Rewind support.
 
 ## Next executable work
 
-1. Continue Android A1 using `docs/ANDROID-GOAL-LOOP.md`: deterministic Vulkan
-   clear/readback/present and HOME/foreground surface recreation now pass on
-   both page-size lanes. Dynamic 4 GiB reservation, shared aliases, and
-   protection changes now also pass at both 4 KiB and 16 KiB. A physical
-   flipped-landscape transition plus three consecutive surface teardown/
-   foreground/recreate/present cycles pass on both lanes. The Android ELF
-   scheduler/register fixture now passes two million scheduler operations and
-   one million native switches on both lanes, closing A1. Continue A2 with the
-   private generated Original-mode graph and controller-driven gameplay proof.
-   Evidence is under `docs/artifacts/2026-09-03/android/`.
+1. Continue Android A2 using `docs/ANDROID-GOAL-LOOP.md`. The complete private
+   29,065-function Original graph now compiles, links, packages, and passes the
+   strict Android APK audit through a reproducible ignored-source path. Add the
+   Android app-private data/config/cache bridge, stage the already validated
+   `RMCP01` DATA directory without packaging it, and establish the first
+   emulator boot/frame before controller-driven title/menu/race/save/relaunch.
+   Build/package evidence is
+   `docs/artifacts/2026-09-03/android/a2-original-runtime-link.md`. Do not call
+   this gameplay or physical-device acceptance; A2 remains open.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -1732,3 +1732,28 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   lifecycle gate. It is not production-runtime, gameplay, physical-driver,
   or performance evidence. A2 is next. No package was hosted or published.
   Evidence: `docs/artifacts/2026-09-03/android/a1-elf-scheduler.md`.
+
+## 2026-09-03 — Android A2 complete Original runtime link
+
+- Prepared a disposable WiiCompiled source tree from the existing ordered
+  mobile patch stack, then added narrow Android CMake, shared-memory, ELF fiber,
+  SDL entry, Crypto++, and object-format adaptations. The production Android
+  fiber preserves x19-x29, x30/SP, d8-d15, FPCR, and FPSR.
+- Compiled all 29,065 functions in the ignored Original translation graph and
+  linked `libmain.so`. Older private registration shards are profile-labeled in
+  the build directory, leaving the translator-owned inputs unchanged.
+- Replaced Aurora's unexported SDL-internal activity mutex dependency with a
+  KartPad-owned Java/native surface mutation lock. The normal source-only
+  fixture still builds because it exports matching no-op hooks.
+- The Gradle game-runtime mode produced a 103,425,387-byte local debug APK with
+  SHA-256 `5d96c31ef91ead5d7ada0977c1853d39b4fcc7f57ea8f4fe3439c1de89ac9e13`.
+  Its stripped 83,529,560-byte `libmain.so` has SHA-256
+  `a1b15ee74f77fd891f7d885c6602bf23bd73c9b6e4cfcfc56ce1ee2279089165`.
+  The strict package audit passes, including 16 KiB alignment and local/private
+  path rejection. No APK/AAB was published.
+- Classification: **Pass for A2 private Original compile/link/Gradle package
+  integration only.** No game data is packaged or staged, and no boot,
+  gameplay, controller, audio, save/relaunch, game lifecycle, or physical
+  Android acceptance is claimed. A2 remains open for app-private paths and the
+  gameplay matrix. Evidence:
+  `docs/artifacts/2026-09-03/android/a2-original-runtime-link.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -42,6 +42,24 @@ This closes A1's source-only native primitive and Vulkan-surface gate. It does
 not prove production-runtime integration, gameplay, physical-device Vulkan,
 or performance. The lowest incomplete goal is A2.
 
+The first A2 build/link slice passes. A fresh ignored runtime copy consumes the
+current common Apple patch stack plus narrow Android patches, compiles all
+29,065 Original translated functions, and links them with the production
+4 GiB guest-memory implementation, ELF AArch64 fibers, Aurora, pinned Dawn,
+and the official SDL AAR as `libmain.so`. Gradle packages the complete runtime
+through the normal app module while fixture mode remains the public default.
+The resulting local ARM64 debug APK is 103,425,387 bytes with SHA-256
+`5d96c31ef91ead5d7ada0977c1853d39b4fcc7f57ea8f4fe3439c1de89ac9e13`;
+its stripped `libmain.so` is 83,529,560 bytes with SHA-256
+`a1b15ee74f77fd891f7d885c6602bf23bd73c9b6e4cfcfc56ce1ee2279089165`.
+The package passes ABI, dependency, RELRO, non-executable-stack, 16 KiB load,
+JNI/SDL export, permission, native allowlist, and private-path/data audits.
+This is build and package evidence only: no game data was included or staged,
+and boot, gameplay, controller, audio, save/relaunch, lifecycle under the game,
+and physical-device rows remain open. A2 remains the lowest incomplete goal.
+Evidence:
+[`docs/artifacts/2026-09-03/android/a2-original-runtime-link.md`](artifacts/2026-09-03/android/a2-original-runtime-link.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-03/android/a2-original-runtime-link.md
+++ b/docs/artifacts/2026-09-03/android/a2-original-runtime-link.md
@@ -1,0 +1,60 @@
+# Android A2 Original runtime link evidence
+
+Date: 2026-09-03
+
+Base checkpoint: `74b35b2` (`codex/android-a1-elf-scheduler`)
+
+Host: Apple Silicon macOS 26.6.2
+
+Target: Android API 28+, `arm64-v8a`, NDK 29.0.14206865
+
+## Falsifiable subgoal
+
+Compile and package the complete ignored Original translated graph through the
+real Android Gradle app module. Require the packaged library to export SDL and
+KartPad surface entry points and pass the existing strict package audit. Do not
+classify this as boot or gameplay evidence.
+
+## Private input boundary
+
+The ignored shard manifest reports 29,065/29,065 Original functions and no
+Retro Rewind functions. Its SHA-256 is
+`f5c2371c4d2af9e416e26aacdf9288e2d1f10c499b5fcbdd94b6208e4db5ca18`.
+Preparation reads the graph only from the ignored private directory. Legacy
+registration metadata and the data-blob assembly section are normalized into
+the ignored build directory; the translator-owned graph is never modified.
+No extracted game DATA directory is read or packaged in this slice.
+
+## Result
+
+- Fresh Android runtime preparation: pass.
+- Production shared runtime compile: pass.
+- All 29,065 Original translated functions: pass.
+- ELF AArch64 production fiber object: pass.
+- Final `libmain.so` link: pass.
+- Gradle `:app:assembleDebug` game-runtime mode: pass in 9m19s after the final
+  path-remapping change.
+- Default fixture-mode Gradle build after surface-owner changes: pass.
+- Strict APK audit: pass.
+
+The packaged APK is 103,425,387 bytes with SHA-256
+`5d96c31ef91ead5d7ada0977c1853d39b4fcc7f57ea8f4fe3439c1de89ac9e13`.
+Its stripped `libmain.so` is 83,529,560 bytes with SHA-256
+`a1b15ee74f77fd891f7d885c6602bf23bd73c9b6e4cfcfc56ce1ee2279089165`
+and Build ID `469d0b33cb76217c7c4e3580859f2ecc13d8cdc7`.
+
+The APK contains exactly `libmain.so`, `libSDL3.so`, and `libc++_shared.so` for
+`arm64-v8a`. It passes ZIP and native 16 KiB alignment, expected dynamic
+dependencies, RELRO, non-executable stack, no-permission policy, SDL/JNI export
+checks, forbidden-extension checks, and whole-package absolute-path/private-key
+scanning. The first audit correctly failed on compiler-emitted absolute paths;
+Android-owner prefix maps removed them before the accepted package was built.
+
+## Honest classification
+
+**Pass for the first A2 compile/link/package subgoal only.** The artifact was
+not hosted or published. No game data was staged, and no game boot, frame,
+audio, controller, race, result, save, relaunch, lifecycle, performance, or
+physical-device behavior was exercised. The next subgoal is an Android
+app-private config/cache/data bridge followed by a privately staged emulator
+boot. A2 remains open.

--- a/patches/aurora-android-public-sdl-surface-lock.patch
+++ b/patches/aurora-android-public-sdl-surface-lock.patch
@@ -1,0 +1,60 @@
+--- a/lib/window.cpp
++++ b/lib/window.cpp
+@@ -28,12 +28,11 @@
+ 
+ #if defined(SDL_PLATFORM_ANDROID)
+ #include <jni.h>
+-extern "C" void Android_LockActivityMutex(void);
+-extern "C" void Android_UnlockActivityMutex(void);
+ #endif
+ 
+ #include <algorithm>
+ #include <atomic>
++#include <mutex>
+ #include <vector>
+ 
+ #include "dolphin/vi/vi_internal.hpp"
+@@ -56,6 +55,7 @@
+ std::atomic<AuroraDisplayMode> g_displayMode{AURORA_DISPLAY_MODE_WINDOWED};
+ #if defined(SDL_PLATFORM_ANDROID)
+ std::atomic_bool g_surfaceReady = false;
++std::recursive_mutex g_surfaceMutex;
+ #else
+ std::atomic_bool g_surfaceReady = true;
+ #endif
+@@ -607,13 +607,13 @@
+ 
+ SurfaceLock::SurfaceLock() noexcept {
+ #if defined(SDL_PLATFORM_ANDROID)
+-  Android_LockActivityMutex();
++  g_surfaceMutex.lock();
+ #endif
+ }
+ 
+ SurfaceLock::~SurfaceLock() {
+ #if defined(SDL_PLATFORM_ANDROID)
+-  Android_UnlockActivityMutex();
++  g_surfaceMutex.unlock();
+ #endif
+ }
+ 
+@@ -811,6 +811,19 @@
+ } // namespace aurora::window
+ 
+ #if defined(SDL_PLATFORM_ANDROID)
++extern "C" JNIEXPORT void JNICALL
++Java_dev_kartpad_android_KartPadSurface_nativeBeginSurfaceMutation(JNIEnv*, jobject) {
++  aurora::window::g_surfaceMutex.lock();
++  aurora::window::set_surface_ready(false);
++}
++
++extern "C" JNIEXPORT void JNICALL
++Java_dev_kartpad_android_KartPadSurface_nativeEndSurfaceMutation(JNIEnv*, jobject,
++                                                                  jboolean ready) {
++  aurora::window::set_surface_ready(ready == JNI_TRUE);
++  aurora::window::g_surfaceMutex.unlock();
++}
++
+ extern "C" JNIEXPORT void JNICALL Java_org_libsdl_app_SDLSurface_auroraNativeSetSurfaceReady(JNIEnv*, jclass,
+                                                                                              jboolean ready) {
+   aurora::window::set_surface_ready(ready == JNI_TRUE);

--- a/patches/wiicompiled-android-runtime.patch
+++ b/patches/wiicompiled-android-runtime.patch
@@ -1,0 +1,654 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,11 +1,11 @@
+ ﻿cmake_minimum_required(VERSION 3.16)
+-project(mkw_recompiled LANGUAGES C CXX)
++project(mkw_recompiled LANGUAGES C CXX ASM)
+ 
+-if(NOT APPLE OR NOT CMAKE_SIZEOF_VOID_P EQUAL 8 OR
++if((NOT APPLE AND NOT ANDROID) OR NOT CMAKE_SIZEOF_VOID_P EQUAL 8 OR
+    NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64|ARM64)$")
+-    message(FATAL_ERROR "KartPad G7 runtime spike requires 64-bit Apple arm64")
++    message(FATAL_ERROR "KartPad runtime requires 64-bit Apple/Android arm64")
+ endif()
+-if(NOT CMAKE_BUILD_TYPE STREQUAL "Release")
++if(NOT ANDROID AND NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+     message(FATAL_ERROR "WiiCompiled only supports Release builds")
+ endif()
+ 
+@@ -18,6 +18,7 @@
+ set(MKW_PROJECT_COMPILE_DEFINITIONS NOMINMAX)
+ 
+ set(CMAKE_CXX_STANDARD 20)
++find_package(Threads REQUIRED)
+ 
+ # Release binaries must not disclose the local checkout path through __FILE__
+ # strings emitted by first-party sources and header-only dependencies.
+@@ -117,7 +118,13 @@
+     if(NOT EXISTS ${MKW_AURORA_DIR}/CMakeLists.txt)
+         message(FATAL_ERROR "Requested aurora-main but ${MKW_AURORA_DIR} is missing")
+     endif()
+-    set(AURORA_DAWN_PROVIDER package CACHE STRING "" FORCE)
++    if(ANDROID)
++        set(AURORA_DAWN_PROVIDER system CACHE STRING "" FORCE)
++        set(AURORA_SDL3_PROVIDER system CACHE STRING "" FORCE)
++        set(AURORA_SDL3_LINKAGE shared CACHE STRING "" FORCE)
++    else()
++        set(AURORA_DAWN_PROVIDER package CACHE STRING "" FORCE)
++    endif()
+     set(AURORA_DAWN_VERSION v20260603.191052 CACHE STRING "" FORCE)
+     set(AURORA_DAWN_PACKAGE_URL "" CACHE STRING
+         "file:// URL for the pinned Dawn Darwin arm64 archive")
+@@ -143,8 +150,13 @@
+     set(CMAKE_DISABLE_FIND_PACKAGE_absl TRUE CACHE BOOL "" FORCE)
+     set(CMAKE_DISABLE_FIND_PACKAGE_PNG TRUE CACHE BOOL "" FORCE)
+     set(CMAKE_DISABLE_FIND_PACKAGE_Freetype TRUE CACHE BOOL "" FORCE)
+-    set(AURORA_SDL3_PROVIDER vendor CACHE STRING "" FORCE)
+-    set(AURORA_SDL3_LINKAGE static CACHE STRING "" FORCE)
++    if(ANDROID)
++        set(AURORA_SDL3_PROVIDER system CACHE STRING "" FORCE)
++        set(AURORA_SDL3_LINKAGE shared CACHE STRING "" FORCE)
++    else()
++        set(AURORA_SDL3_PROVIDER vendor CACHE STRING "" FORCE)
++        set(AURORA_SDL3_LINKAGE static CACHE STRING "" FORCE)
++    endif()
+     set(AURORA_ENABLE_GX ON CACHE BOOL "" FORCE)
+     set(AURORA_ENABLE_DVD OFF CACHE BOOL "" FORCE)
+ 
+@@ -167,8 +179,10 @@
+     # should add it to the Dawn targets the same way.
+ 
+     # Keep SDL3 lean when aurora is enabled.
+-    set(SDL_SHARED OFF CACHE BOOL "" FORCE)
+-    set(SDL_STATIC ON CACHE BOOL "" FORCE)
++    if(NOT ANDROID)
++        set(SDL_SHARED OFF CACHE BOOL "" FORCE)
++        set(SDL_STATIC ON CACHE BOOL "" FORCE)
++    endif()
+     set(SDL_TEST OFF CACHE BOOL "" FORCE)
+     # FetchContent uses the first declaration for a dependency. Declare the
+     # two Aurora source archives that lack upstream URL_HASH values before the
+@@ -273,9 +287,16 @@
+ list(REMOVE_ITEM SOURCES
+     "${CMAKE_CURRENT_LIST_DIR}/src/guest_flat_memory.cpp"
+     "${CMAKE_CURRENT_LIST_DIR}/src/wup028_adapter.cpp")
+-list(APPEND SOURCES
+-    "${CMAKE_CURRENT_LIST_DIR}/src/apple/guest_flat_memory_apple.cpp"
+-    "${CMAKE_CURRENT_LIST_DIR}/src/apple/wup028_adapter_stub.cpp")
++if(ANDROID)
++    list(APPEND SOURCES
++        "${CMAKE_CURRENT_LIST_DIR}/src/android/fiber_switch_android.S"
++        "${CMAKE_CURRENT_LIST_DIR}/src/apple/guest_flat_memory_apple.cpp"
++        "${CMAKE_CURRENT_LIST_DIR}/src/apple/wup028_adapter_stub.cpp")
++else()
++    list(APPEND SOURCES
++        "${CMAKE_CURRENT_LIST_DIR}/src/apple/guest_flat_memory_apple.cpp"
++        "${CMAKE_CURRENT_LIST_DIR}/src/apple/wup028_adapter_stub.cpp")
++endif()
+ 
+ # The translator emits the complete, content-addressed source graph. Consuming
+ # this one manifest keeps configure independent of the 28k generated function
+@@ -295,6 +316,40 @@
+     "${MKW_PROFILE_SENSITIVE_CALLER_COUNT} profile-sensitive callers; "
+     "${MKW_RETRO_REWIND_FUNCTION_COUNT} Retro Rewind functions")
+ 
++# Older private translation graphs predate profile-owned bulk registration.
++# Normalize those cold registration shards into the build directory without
++# modifying the translator-owned graph. Modern shards already carry the
++# profile string and pass through unchanged.
++if(ANDROID)
++    function(mkw_android_label_legacy_registrations variable profile)
++        set(normalized_sources)
++        foreach(source IN LISTS ${variable})
++            if(source MATCHES "/(base|retro_rewind)_registration/")
++                file(READ "${source}" registration_content)
++                string(REPLACE
++                    "kRegistrar(kRecords, std::size(kRecords))"
++                    "kRegistrar(\"${profile}\", kRecords, std::size(kRecords))"
++                    normalized_content "${registration_content}")
++                if(NOT normalized_content STREQUAL registration_content)
++                    get_filename_component(source_name "${source}" NAME)
++                    set(normalized_source
++                        "${CMAKE_CURRENT_BINARY_DIR}/android_${profile}_${source_name}")
++                    file(WRITE "${normalized_source}" "${normalized_content}")
++                    list(APPEND normalized_sources "${normalized_source}")
++                else()
++                    list(APPEND normalized_sources "${source}")
++                endif()
++            else()
++                list(APPEND normalized_sources "${source}")
++            endif()
++        endforeach()
++        set(${variable} "${normalized_sources}" PARENT_SCOPE)
++    endfunction()
++    mkw_android_label_legacy_registrations(MKW_BASE_REGISTRATION_SOURCES base)
++    mkw_android_label_legacy_registrations(
++        MKW_RETRO_REGISTRATION_SOURCES retro_rewind)
++endif()
++
+ set(MKW_RUNTIME_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+ set(MKW_KARTPAD_RUNTIME_INCLUDE "" CACHE PATH
+     "Path to KartPad's header-only PowerPC architectural semantics")
+--- a/cmake/PublicProducts.cmake
++++ b/cmake/PublicProducts.cmake
+@@ -6,6 +6,15 @@
+ 
+ set(DATA_INIT_FILE "${MKW_RUNTIME_SOURCE_DIR}/../generated/data_sections_init.cpp")
+ set(DATA_INIT_BLOB_ASM "${MKW_RUNTIME_SOURCE_DIR}/../generated/data_sections_init_blobs.S")
++if(ANDROID AND EXISTS "${DATA_INIT_BLOB_ASM}")
++    file(READ "${DATA_INIT_BLOB_ASM}" MKW_ANDROID_DATA_INIT_BLOB_CONTENT)
++    string(REPLACE ".section .rdata,\"dr\""
++        ".section .rodata,\"a\",%progbits"
++        MKW_ANDROID_DATA_INIT_BLOB_CONTENT
++        "${MKW_ANDROID_DATA_INIT_BLOB_CONTENT}")
++    set(DATA_INIT_BLOB_ASM "${CMAKE_CURRENT_BINARY_DIR}/data_sections_init_blobs_android.S")
++    file(WRITE "${DATA_INIT_BLOB_ASM}" "${MKW_ANDROID_DATA_INIT_BLOB_CONTENT}")
++endif()
+ if(EXISTS "${DATA_INIT_FILE}")
+     list(APPEND SOURCES "${DATA_INIT_FILE}")
+ endif()
+@@ -72,13 +81,15 @@
+ mkw_configure_object_target(mkw_runtime_common)
+ target_compile_features(mkw_runtime_common PRIVATE cxx_std_20)
+ target_compile_definitions(mkw_runtime_common PRIVATE
+-    $<$<NOT:$<PLATFORM_ID:iOS>>:SDL_MAIN_HANDLED>
++    $<$<NOT:$<PLATFORM_ID:iOS,Android>>:SDL_MAIN_HANDLED>
+     _DISABLE_STRING_ANNOTATION _DISABLE_VECTOR_ANNOTATION
+     $<$<PLATFORM_ID:Darwin,iOS>:_XOPEN_SOURCE>)
+ target_link_libraries(mkw_runtime_common PRIVATE
+     aurora::gx aurora::pad aurora::si aurora::vi aurora::mtx)
+ target_link_libraries(mkw_runtime_common PRIVATE mkw::pugixml mkw::toml11 mkw::cryptopp)
+-target_link_libraries(mkw_runtime_common PRIVATE "-framework Foundation")
++if(APPLE)
++    target_link_libraries(mkw_runtime_common PRIVATE "-framework Foundation")
++endif()
+ if(MKW_CPPWINRT_INCLUDE_DIR)
+     if(NOT EXISTS "${MKW_CPPWINRT_INCLUDE_DIR}/winrt/base.h")
+         message(FATAL_ERROR
+@@ -180,7 +191,7 @@
+         "${MKW_RUNTIME_SOURCE_DIR}/.."
+         "${MKW_RUNTIME_SOURCE_DIR}/../aurora-main/include")
+     target_compile_definitions(${target} PRIVATE
+-        $<$<NOT:$<PLATFORM_ID:iOS>>:SDL_MAIN_HANDLED>
++        $<$<NOT:$<PLATFORM_ID:iOS,Android>>:SDL_MAIN_HANDLED>
+         _DISABLE_STRING_ANNOTATION _DISABLE_VECTOR_ANNOTATION TARGET_PC)
+     target_compile_features(${target} PRIVATE cxx_std_20)
+     mkw_apply_common_compile_options(${target})
+@@ -206,9 +217,13 @@
+             $<TARGET_FILE:sqlite3> $<TARGET_FILE_DIR:${target}>)
+     endif()
+ 
+-    target_link_libraries(${target} PRIVATE
+-        "-framework Foundation" "-framework CoreAudio" "-framework AudioToolbox"
+-        "-framework Security")
++    if(APPLE)
++        target_link_libraries(${target} PRIVATE
++            "-framework Foundation" "-framework CoreAudio" "-framework AudioToolbox"
++            "-framework Security")
++    elseif(ANDROID)
++        target_link_libraries(${target} PRIVATE android log dl)
++    endif()
+ 
+     if(WIN32)
+       set_target_properties(${target} PROPERTIES WIN32_EXECUTABLE TRUE)
+@@ -234,8 +249,10 @@
+     if(NOT EXISTS "${MKW_WII_BOOTSTRAP_SOURCE_DIR}/shared2/wc24")
+         message(FATAL_ERROR "Missing Wii first-run bootstrap payload: ${MKW_WII_BOOTSTRAP_SOURCE_DIR}")
+     endif()
+-    add_custom_command(TARGET ${target} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory
+-        "${MKW_WII_BOOTSTRAP_SOURCE_DIR}" "$<TARGET_FILE_DIR:${target}>/wii_bootstrap")
++    if(NOT ANDROID)
++        add_custom_command(TARGET ${target} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory
++            "${MKW_WII_BOOTSTRAP_SOURCE_DIR}" "$<TARGET_FILE_DIR:${target}>/wii_bootstrap")
++    endif()
+ 
+     set(MKW_DSP_COEFFICIENT_ROM "${MKW_RUNTIME_SOURCE_DIR}/assets/dsp/dsp_coef.bin")
+     if(NOT EXISTS "${MKW_DSP_COEFFICIENT_ROM}")
+@@ -246,8 +263,10 @@
+        "d7741279c2e8ec5c5fb318f8fbdd6de6bf583520d288e836a5383233a4238179")
+         message(FATAL_ERROR "Wii DSP coefficient ROM hash mismatch: ${MKW_DSP_COEFFICIENT_ROM_SHA256}")
+     endif()
+-    add_custom_command(TARGET ${target} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different
+-        "${MKW_DSP_COEFFICIENT_ROM}" "$<TARGET_FILE_DIR:${target}>/dsp_coef.bin")
++    if(NOT ANDROID)
++        add_custom_command(TARGET ${target} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different
++            "${MKW_DSP_COEFFICIENT_ROM}" "$<TARGET_FILE_DIR:${target}>/dsp_coef.bin")
++    endif()
+ 
+     # Aurora imports this portable recipe database into each user's writable
+     # pipeline cache. Keep the upstream filename so its default resourcesPath
+@@ -257,12 +276,19 @@
+     if(NOT EXISTS "${MKW_INITIAL_PIPELINE_CACHE}")
+         message(FATAL_ERROR "Missing transferable Aurora pipeline cache: ${MKW_INITIAL_PIPELINE_CACHE}")
+     endif()
+-    add_custom_command(TARGET ${target} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different
+-        "${MKW_INITIAL_PIPELINE_CACHE}"
+-        "$<TARGET_FILE_DIR:${target}>/initial_pipeline_cache.db")
++    if(NOT ANDROID)
++        add_custom_command(TARGET ${target} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different
++            "${MKW_INITIAL_PIPELINE_CACHE}"
++            "$<TARGET_FILE_DIR:${target}>/initial_pipeline_cache.db")
++    endif()
+ endfunction()
+ 
+-add_executable(WiiCompiled "${MKW_BASE_PRODUCT_SOURCE}" ${MKW_BASE_REGISTRATION_SOURCES})
++if(ANDROID)
++    add_library(WiiCompiled SHARED "${MKW_BASE_PRODUCT_SOURCE}" ${MKW_BASE_REGISTRATION_SOURCES})
++    set_target_properties(WiiCompiled PROPERTIES OUTPUT_NAME main)
++else()
++    add_executable(WiiCompiled "${MKW_BASE_PRODUCT_SOURCE}" ${MKW_BASE_REGISTRATION_SOURCES})
++endif()
+ mkw_configure_product(WiiCompiled)
+ target_precompile_headers(WiiCompiled PRIVATE
+     "${MKW_RUNTIME_SOURCE_DIR}/include/mkw_pch.h")
+@@ -537,6 +563,8 @@
+     mkw_retro_rewind_functions WiiCompiled RetroRewind KartPadDual)
+ foreach(target IN LISTS MKW_ALL_BUILD_TARGETS)
+     if(TARGET ${target})
+-        target_compile_options(${target} PRIVATE -mcpu=apple-m2)
++        if(APPLE)
++            target_compile_options(${target} PRIVATE -mcpu=apple-m2)
++        endif()
+     endif()
+ endforeach()
+--- a/include/guest_flat_memory.h
++++ b/include/guest_flat_memory.h
+@@ -18,7 +18,7 @@
+ // of a global. 16 TiB: clear of the Windows ASan shadow (32 TiB) and of the
+ // usual image/heap placement.
+ inline constexpr uint64_t kGuestSpaceSize = 0x1'0000'0000ull;
+-#if defined(__APPLE__) && TARGET_OS_IPHONE
++#if (defined(__APPLE__) && TARGET_OS_IPHONE) || defined(__ANDROID__)
+ // Physical iOS chooses the 4 GiB reservation at launch. Its userspace layout
+ // does not guarantee that a build-time address is available.
+ extern uint8_t* gFlatGuestBase;
+--- a/src/apple/guest_flat_memory_apple.cpp
++++ b/src/apple/guest_flat_memory_apple.cpp
+@@ -14,9 +14,12 @@
+ #include <sys/mman.h>
+ #include <unistd.h>
+ #include <vector>
++#if defined(__ANDROID__)
++#include <android/sharedmem.h>
++#endif
+ 
+ namespace GuestFlat {
+-#if TARGET_OS_IPHONE
++#if (defined(__APPLE__) && TARGET_OS_IPHONE) || defined(__ANDROID__)
+ uint8_t* gFlatGuestBase = nullptr;
+ #endif
+ namespace {
+@@ -90,7 +93,18 @@
+ 
+ int CreateSharedSection(uint64_t size, unsigned ordinal)
+ {
+-#if TARGET_OS_IPHONE
++#if defined(__ANDROID__)
++    const std::string name = "kartpad-guest-" + std::to_string(ordinal);
++    const int fd = ASharedMemory_create(name.c_str(), static_cast<size_t>(size));
++    if (fd < 0)
++        ThrowErrno("ASharedMemory_create");
++    if (ASharedMemory_setProt(fd, PROT_READ | PROT_WRITE) != 0) {
++        const int saved = errno;
++        close(fd);
++        errno = saved;
++        ThrowErrno("ASharedMemory_setProt");
++    }
++#elif defined(__APPLE__) && TARGET_OS_IPHONE
+     const char* temporaryRoot = std::getenv("TMPDIR");
+     if (temporaryRoot == nullptr || *temporaryRoot == '\0') {
+         errno = ENOENT;
+@@ -149,11 +163,11 @@
+ 
+     const uint64_t pageSize = static_cast<uint64_t>(getpagesize());
+     const uint64_t reservationSize = kGuestSpaceSize + pageSize;
+-#if TARGET_OS_IPHONE
++#if (defined(__APPLE__) && TARGET_OS_IPHONE) || defined(__ANDROID__)
+     void* reserved = mmap(nullptr, static_cast<size_t>(reservationSize), PROT_NONE,
+                           MAP_PRIVATE | MAP_ANON, -1, 0);
+     if (reserved == MAP_FAILED)
+-        ThrowErrno("mmap iOS flat guest reservation");
++        ThrowErrno("mmap mobile flat guest reservation");
+     g_base = static_cast<uint8_t*>(reserved);
+     gFlatGuestBase = g_base;
+ #else
+--- a/src/fiber_manager.cpp
++++ b/src/fiber_manager.cpp
+@@ -139,6 +139,73 @@
+ {
+     delete static_cast<AppleFiber*>(handle);
+ }
++#elif defined(__ANDROID__)
++struct AndroidFiberContext {
++    uint64_t x19 = 0;
++    uint64_t x20 = 0;
++    uint64_t x21 = 0;
++    uint64_t x22 = 0;
++    uint64_t x23 = 0;
++    uint64_t x24 = 0;
++    uint64_t x25 = 0;
++    uint64_t x26 = 0;
++    uint64_t x27 = 0;
++    uint64_t x28 = 0;
++    uint64_t fp = 0;
++    uint64_t lr = 0;
++    uint64_t sp = 0;
++    uint32_t fpcr = 0;
++    uint32_t fpsr = 0;
++    uint64_t d8 = 0;
++    uint64_t d9 = 0;
++    uint64_t d10 = 0;
++    uint64_t d11 = 0;
++    uint64_t d12 = 0;
++    uint64_t d13 = 0;
++    uint64_t d14 = 0;
++    uint64_t d15 = 0;
++};
++
++static_assert(sizeof(AndroidFiberContext) == 176);
++extern "C" void KartPadSwitchAndroidRuntimeFiber(AndroidFiberContext* source,
++                                                   const AndroidFiberContext* target);
++
++struct AndroidFiber {
++    AndroidFiberContext context{};
++    std::unique_ptr<std::byte[]> stack;
++};
++
++thread_local AndroidFiber* g_currentAndroidFiber = nullptr;
++
++void* CreateAndroidSchedulerFiber()
++{
++    auto fiber = std::make_unique<AndroidFiber>();
++    g_currentAndroidFiber = fiber.get();
++    return fiber.release();
++}
++
++void SwitchHostFiber(void* handle)
++{
++    auto* target = static_cast<AndroidFiber*>(handle);
++    AndroidFiber* source = g_currentAndroidFiber;
++    if (!source || !target || source == target) {
++        return;
++    }
++
++    g_currentAndroidFiber = target;
++    KartPadSwitchAndroidRuntimeFiber(&source->context, &target->context);
++    g_currentAndroidFiber = source;
++}
++
++void* CurrentHostFiber()
++{
++    return g_currentAndroidFiber;
++}
++
++void DeleteHostFiber(void* handle)
++{
++    delete static_cast<AndroidFiber*>(handle);
++}
+ #elif defined(_WIN32)
+ void SwitchHostFiber(void* handle) { SwitchToFiber(handle); }
+ void* CurrentHostFiber() { return GetCurrentFiber(); }
+@@ -157,7 +224,7 @@
+ thread_local CpuContext* GuestFiberManager::s_cpuContext = nullptr;
+ 
+ void GuestFiberManager::PurgePendingFibers() {
+-#if defined(_WIN32) || defined(__APPLE__)
++#if defined(_WIN32) || defined(__APPLE__) || defined(__ANDROID__)
+     std::vector<void*> toDelete;
+     {
+         std::lock_guard<std::mutex> lock(s_mutex);
+@@ -343,6 +410,12 @@
+                           << std::strerror(errno) << std::endl;
+         std::abort();
+     }
++#elif defined(__ANDROID__)
++    s_schedulerFiber = CreateAndroidSchedulerFiber();
++    if (!s_schedulerFiber) {
++        RT_LOG(RT_TAG_OS) << "FATAL: Failed to initialize Android scheduler fiber!" << std::endl;
++        std::abort();
++    }
+ #else
+     RT_LOG(RT_TAG_OS) << "WARNING: Fiber support not available on this platform!" << std::endl;
+     s_schedulerFiber = nullptr;
+@@ -355,7 +428,7 @@
+ void GuestFiberManager::Shutdown() {
+     std::lock_guard<std::mutex> lock(s_mutex);
+ 
+-#if defined(_WIN32) || defined(__APPLE__)
++#if defined(_WIN32) || defined(__APPLE__) || defined(__ANDROID__)
+     for (auto& [addr, fiber] : s_fibers) {
+         if (fiber.fiber && !fiber.isSchedulerFiber) {
+             DeleteHostFiber(fiber.fiber);
+@@ -370,11 +443,17 @@
+         ConvertFiberToThread();
+         s_schedulerFiber = nullptr;
+     }
+-#else
++#elif defined(__APPLE__)
+     if (s_schedulerFiber) {
+         DeleteHostFiber(s_schedulerFiber);
+         s_schedulerFiber = nullptr;
+         g_currentAppleFiber = nullptr;
++    }
++#else
++    if (s_schedulerFiber) {
++        DeleteHostFiber(s_schedulerFiber);
++        s_schedulerFiber = nullptr;
++        g_currentAndroidFiber = nullptr;
+     }
+ #endif
+ #endif
+@@ -398,7 +477,7 @@
+     // Check if fiber already exists for this thread - if so, reset it
+     auto existingIt = s_fibers.find(guestThreadAddr);
+     if (existingIt != s_fibers.end()) {
+-#if defined(_WIN32) || defined(__APPLE__)
++#if defined(_WIN32) || defined(__APPLE__) || defined(__ANDROID__)
+         // Delete the old fiber if it exists and is not the scheduler fiber
+         if (existingIt->second.fiber && !existingIt->second.isSchedulerFiber) {
+             DeleteHostFiber(existingIt->second.fiber);
+@@ -469,6 +548,22 @@
+                 reinterpret_cast<void (*)()>(trampoline), 1, guestThreadAddr);
+ #endif
+     gf.fiber = appleFiber.release();
++#elif defined(__ANDROID__)
++    constexpr size_t kHostStackSize = 256 * 1024;
++    auto androidFiber = std::make_unique<AndroidFiber>();
++    androidFiber->stack = std::make_unique<std::byte[]>(kHostStackSize);
++    auto trampoline = +[](uint32_t threadAddr) {
++        GuestFiberManager::FiberProc(
++            reinterpret_cast<void*>(static_cast<uintptr_t>(threadAddr)));
++        std::abort();
++    };
++    const uintptr_t stackTop =
++        (reinterpret_cast<uintptr_t>(androidFiber->stack.get()) + kHostStackSize) &
++        ~static_cast<uintptr_t>(0x0f);
++    androidFiber->context.x19 = guestThreadAddr;
++    androidFiber->context.sp = stackTop;
++    androidFiber->context.lr = reinterpret_cast<uintptr_t>(trampoline);
++    gf.fiber = androidFiber.release();
+ #else
+     gf.fiber = nullptr;
+ #endif
+@@ -524,7 +619,7 @@
+         s_currentGuestThread = 0;
+     }
+     
+-#if defined(_WIN32) || defined(__APPLE__)
++#if defined(_WIN32) || defined(__APPLE__) || defined(__ANDROID__)
+     if (it->second.fiber && !it->second.isSchedulerFiber) {
+         const void* current = CurrentHostFiber();
+         if (it->second.fiber == current) {
+@@ -597,7 +692,7 @@
+     // Store CPU context pointer for the target fiber to use
+     s_cpuContext = cpu;
+     
+-#if defined(_WIN32) || defined(__APPLE__)
++#if defined(_WIN32) || defined(__APPLE__) || defined(__ANDROID__)
+     // Check if we're already on the target fiber (e.g., switching to main thread
+     // when we're already on the scheduler fiber)
+     void* currentFiber = CurrentHostFiber();
+@@ -742,7 +837,7 @@
+     uint32_t guestThreadAddr = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(param));
+     
+     
+-#if defined(_WIN32) || defined(__APPLE__)
++#if defined(_WIN32) || defined(__APPLE__) || defined(__ANDROID__)
+     // Get our fiber info
+     GuestFiber* fiber = nullptr;
+     uint32_t entryPoint = 0;
+--- a/src/hle/audio/audio.cpp
++++ b/src/hle/audio/audio.cpp
+@@ -498,7 +498,8 @@
+     static thread_local Clock::time_point lastPoll = Clock::now();
+ 
+     const Clock::time_point now = Clock::now();
+-    auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(now - lastPoll).count();
++    int64_t elapsed = static_cast<int64_t>(
++        std::chrono::duration_cast<std::chrono::microseconds>(now - lastPoll).count());
+     lastPoll = now;
+ 
+     if (elapsed < 0) {
+--- a/src/hle/storage/dvd.cpp
++++ b/src/hle/storage/dvd.cpp
+@@ -637,7 +637,8 @@
+     for (const DVDFileEntry& entry : g_fileEntries) {
+         if (entry.discOffsetWords != 0) {
+             nextFreeBytes = std::max(
+-                nextFreeBytes, static_cast<uint64_t>(entry.discOffsetWords) * 4ull + entry.size);
++                nextFreeBytes,
++                static_cast<uint64_t>(entry.discOffsetWords) * uint64_t{4} + entry.size);
+         }
+     }
+     for (DVDFileEntry& entry : g_fileEntries) {
+@@ -1118,4 +1119,3 @@
+ 
+ extern "C" int32_t DVDLowClearCoverInterrupt_80166964(uint32_t cb) { return 1; }
+ PPC_NATIVE_OVERRIDE(80166964, DVDLowClearCoverInterrupt_80166964, int32_t, (uint32_t cb), (cb));
+-
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -63,8 +63,11 @@
+ #include <dolphin/gx/GXAurora.h>
+ #include <dolphin/vi.h>
+ 
+-#if defined(__APPLE__) && TARGET_OS_IOS
++#if (defined(__APPLE__) && TARGET_OS_IOS) || defined(__ANDROID__)
+ #include <SDL3/SDL_main.h>
++#endif
++
++#if defined(__APPLE__) && TARGET_OS_IOS
+ #include "kartpad_mobile_runtime_host.h"
+ #endif
+ 
+--- a/third_party/cryptopp/cpu.cpp
++++ b/third_party/cryptopp/cpu.cpp
+@@ -69,7 +69,7 @@
+ // "$ANDROID_NDK_ROOT/sources/android/cpufeatures".
+ // setenv-android.sh will copy the header and source file
+ // into PWD and the makefile will build it in place.
+-#if defined(__ANDROID__)
++#if defined(__ANDROID__) && defined(CRYPTOPP_USE_LEGACY_ANDROID_CPU_FEATURES)
+ # include "cpu-features.h"
+ #endif
+ 
+@@ -862,7 +862,7 @@
+ 
+ inline bool CPU_QueryNEON()
+ {
+-#if defined(__ANDROID__) && defined(__aarch64__)
++#if defined(__ANDROID__) && defined(__aarch64__) && defined(CRYPTOPP_USE_LEGACY_ANDROID_CPU_FEATURES)
+ 	if (((android_getCpuFamily() & ANDROID_CPU_FAMILY_ARM64) != 0) &&
+ 		((android_getCpuFeatures() & ANDROID_CPU_ARM64_FEATURE_ASIMD) != 0))
+ 		return true;
+@@ -893,7 +893,7 @@
+ 
+ inline bool CPU_QueryCRC32()
+ {
+-#if defined(__ANDROID__) && defined(__aarch64__)
++#if defined(__ANDROID__) && defined(__aarch64__) && defined(CRYPTOPP_USE_LEGACY_ANDROID_CPU_FEATURES)
+ 	if (((android_getCpuFamily() & ANDROID_CPU_FAMILY_ARM64) != 0) &&
+ 		((android_getCpuFeatures() & ANDROID_CPU_ARM64_FEATURE_CRC32) != 0))
+ 		return true;
+@@ -920,7 +920,7 @@
+ 
+ inline bool CPU_QueryPMULL()
+ {
+-#if defined(__ANDROID__) && defined(__aarch64__)
++#if defined(__ANDROID__) && defined(__aarch64__) && defined(CRYPTOPP_USE_LEGACY_ANDROID_CPU_FEATURES)
+ 	if (((android_getCpuFamily() & ANDROID_CPU_FAMILY_ARM64) != 0) &&
+ 		((android_getCpuFeatures() & ANDROID_CPU_ARM64_FEATURE_PMULL) != 0))
+ 		return true;
+@@ -947,7 +947,7 @@
+ 
+ inline bool CPU_QueryAES()
+ {
+-#if defined(__ANDROID__) && defined(__aarch64__)
++#if defined(__ANDROID__) && defined(__aarch64__) && defined(CRYPTOPP_USE_LEGACY_ANDROID_CPU_FEATURES)
+ 	if (((android_getCpuFamily() & ANDROID_CPU_FAMILY_ARM64) != 0) &&
+ 		((android_getCpuFeatures() & ANDROID_CPU_ARM64_FEATURE_AES) != 0))
+ 		return true;
+@@ -974,7 +974,7 @@
+ 
+ inline bool CPU_QuerySHA1()
+ {
+-#if defined(__ANDROID__) && defined(__aarch64__)
++#if defined(__ANDROID__) && defined(__aarch64__) && defined(CRYPTOPP_USE_LEGACY_ANDROID_CPU_FEATURES)
+ 	if (((android_getCpuFamily() & ANDROID_CPU_FAMILY_ARM64) != 0) &&
+ 		((android_getCpuFeatures() & ANDROID_CPU_ARM64_FEATURE_SHA1) != 0))
+ 		return true;
+@@ -1001,7 +1001,7 @@
+ 
+ inline bool CPU_QuerySHA256()
+ {
+-#if defined(__ANDROID__) && defined(__aarch64__)
++#if defined(__ANDROID__) && defined(__aarch64__) && defined(CRYPTOPP_USE_LEGACY_ANDROID_CPU_FEATURES)
+ 	if (((android_getCpuFamily() & ANDROID_CPU_FAMILY_ARM64) != 0) &&
+ 		((android_getCpuFeatures() & ANDROID_CPU_ARM64_FEATURE_SHA2) != 0))
+ 		return true;
+--- /dev/null
++++ b/src/android/fiber_switch_android.S
+@@ -0,0 +1,43 @@
++.text
++.p2align 2
++.global KartPadSwitchAndroidRuntimeFiber
++.type KartPadSwitchAndroidRuntimeFiber, %function
++KartPadSwitchAndroidRuntimeFiber:
++    stp x19, x20, [x0, #0]
++    stp x21, x22, [x0, #16]
++    stp x23, x24, [x0, #32]
++    stp x25, x26, [x0, #48]
++    stp x27, x28, [x0, #64]
++    stp x29, x30, [x0, #80]
++    mov x9, sp
++    str x9, [x0, #96]
++    mrs x9, fpcr
++    str w9, [x0, #104]
++    mrs x9, fpsr
++    str w9, [x0, #108]
++    stp d8, d9, [x0, #112]
++    stp d10, d11, [x0, #128]
++    stp d12, d13, [x0, #144]
++    stp d14, d15, [x0, #160]
++
++    ldp x19, x20, [x1, #0]
++    ldp x21, x22, [x1, #16]
++    ldp x23, x24, [x1, #32]
++    ldp x25, x26, [x1, #48]
++    ldp x27, x28, [x1, #64]
++    ldp x29, x30, [x1, #80]
++    ldr x9, [x1, #96]
++    mov sp, x9
++    ldr w9, [x1, #104]
++    msr fpcr, x9
++    ldr w9, [x1, #108]
++    msr fpsr, x9
++    ldp d8, d9, [x1, #112]
++    ldp d10, d11, [x1, #128]
++    ldp d12, d13, [x1, #144]
++    ldp d14, d15, [x1, #160]
++    mov x0, x19
++    ret
++.size KartPadSwitchAndroidRuntimeFiber, .-KartPadSwitchAndroidRuntimeFiber
++
++.section .note.GNU-stack,"",%progbits

--- a/scripts/audit-android-package.sh
+++ b/scripts/audit-android-package.sh
@@ -23,7 +23,7 @@ badging="$("$aapt2" dump badging "$apk")"
 [[ "$badging" == *"native-code: 'arm64-v8a'"* ]]
 permissions="$("$aapt2" dump permissions "$apk")"
 if [[ "$permissions" == *"uses-permission:"* ]]; then
-  echo "ERROR: A0 source-only fixture unexpectedly requests a permission" >&2
+  echo "ERROR: KartPad Android package unexpectedly requests a permission" >&2
   exit 1
 fi
 
@@ -81,6 +81,14 @@ sdl_symbols="$("$readelf" --wide --dyn-syms "$audit_root/libSDL3.so")"
   echo "ERROR: libmain.so does not export SDL_main" >&2
   exit 1
 }
+for symbol in \
+  Java_dev_kartpad_android_KartPadSurface_nativeBeginSurfaceMutation \
+  Java_dev_kartpad_android_KartPadSurface_nativeEndSurfaceMutation; do
+  [[ "$main_symbols" == *" $symbol"* ]] || {
+    echo "ERROR: libmain.so does not export $symbol" >&2
+    exit 1
+  }
+done
 [[ "$sdl_symbols" == *" JNI_OnLoad@@"* ]] || {
   echo "ERROR: libSDL3.so does not export its JNI registration entry" >&2
   exit 1

--- a/scripts/build-android-game-app.sh
+++ b/scripts/build-android-game-app.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+# shellcheck source=android-toolchain-versions.sh
+source "$repo_root/scripts/android-toolchain-versions.sh"
+
+absolute_from_repo() {
+  case "$1" in
+    /*) printf '%s\n' "$1" ;;
+    *) printf '%s/%s\n' "$repo_root" "$1" ;;
+  esac
+}
+
+translation_root="$(absolute_from_repo "${1:-private/g8-full-translation}")"
+runtime_source="$(absolute_from_repo "${2:-build/android-game-runtime-source}")"
+runtime_build="$(absolute_from_repo "${3:-build/android-game-runtime-build}")"
+
+"$repo_root/scripts/check-android-host.sh"
+prepare_output="$("$repo_root/scripts/prepare-android-dependencies.sh")"
+echo "$prepare_output"
+dawn_root="$(printf '%s\n' "$prepare_output" | sed -n 's/^DAWN_ANDROID_ROOT=//p')"
+if [[ -z "$dawn_root" ]]; then
+  echo "ERROR: dependency preparation did not report DAWN_ANDROID_ROOT" >&2
+  exit 1
+fi
+if [[ ! -d "$runtime_source" ]]; then
+  "$repo_root/scripts/prepare-android-game-runtime.sh" \
+    "$translation_root" "$runtime_source" "$runtime_build" base
+fi
+if [[ ! -f "$(dirname "$runtime_source")/generated/data_sections_init.cpp" ]]; then
+  echo "ERROR: prepared runtime is not paired with its ignored generated graph" >&2
+  exit 1
+fi
+
+export JAVA_HOME="$repo_root/.android-bootstrap/jdk-$KARTPAD_ANDROID_JDK_VERSION/Contents/Home"
+export ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/Library/Android/sdk}}"
+export DAWN_ANDROID_ROOT="$dawn_root"
+
+"$repo_root/android/gradlew" --project-dir "$repo_root/android" --no-daemon \
+  -PkartpadGameRuntimeSource="$runtime_source" \
+  -PkartpadTranslatedShardManifest="$translation_root/build_shards/shards.cmake" \
+  :app:assembleDebug
+
+apk="$repo_root/android/app/build/outputs/apk/debug/app-debug.apk"
+if [[ ! -f "$apk" ]]; then
+  echo "ERROR: Gradle did not produce $apk" >&2
+  exit 1
+fi
+echo "Built local Android game APK (do not publish): $apk"
+shasum -a 256 "$apk"

--- a/scripts/prepare-android-game-runtime.sh
+++ b/scripts/prepare-android-game-runtime.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+absolute_from_repo() {
+  case "$1" in
+    /*) printf '%s\n' "$1" ;;
+    *) printf '%s/%s\n' "$repo_root" "$1" ;;
+  esac
+}
+
+translation_root="$(absolute_from_repo "${1:-private/g8-full-translation}")"
+runtime_source="$(absolute_from_repo "${2:-build/android-game-runtime-source}")"
+runtime_build="$(absolute_from_repo "${3:-build/android-game-runtime-build}")"
+product="${4:-base}"
+
+case "$product" in
+  base|retro-rewind|dual) ;;
+  *) echo "ERROR: product must be base, retro-rewind, or dual" >&2; exit 64 ;;
+esac
+if [[ ! -f "$translation_root/build_shards/shards.cmake" ]]; then
+  echo "ERROR: missing private translated graph: $translation_root" >&2
+  exit 1
+fi
+if [[ -e "$runtime_source" || -e "$runtime_build" ]]; then
+  echo "ERROR: output already exists; choose fresh output paths" >&2
+  exit 1
+fi
+
+# The existing Apple preparation command owns the common, ordered runtime
+# patch stack. KARTPAD_PREPARE_ONLY stops before any platform configure/build;
+# this Android command then layers only the ELF/NDK delta onto that fresh copy.
+KARTPAD_PREPARE_ONLY=1 "$repo_root/scripts/prepare-ios-game-runtime.sh" \
+  "$translation_root" "$runtime_source" "$runtime_build" "$product"
+patch --batch -p1 -d "$runtime_source/aurora-main" < \
+  "$repo_root/patches/aurora-android-public-sdl-surface-lock.patch"
+patch --batch -p1 -d "$runtime_source" < \
+  "$repo_root/patches/wiicompiled-android-runtime.patch"
+
+generated_link="$(dirname "$runtime_source")/generated"
+if [[ -e "$generated_link" && ! -L "$generated_link" ]]; then
+  echo "ERROR: generated path exists and is not a symlink: $generated_link" >&2
+  exit 1
+fi
+ln -sfn "$translation_root" "$generated_link"
+
+echo "Prepared integrated Android runtime source: $runtime_source"


### PR DESCRIPTION
## Summary
- prepare the current private Original translation graph through the existing mobile runtime patch stack plus narrow Android ELF/NDK adaptations
- package the complete 29,065-function runtime through the normal Gradle app module while retaining source-only fixture mode
- coordinate SDL surface mutations with Aurora through public KartPad JNI hooks and audit the final ARM64 APK

## Verification
- complete Original runtime and all 29,065 functions compile/link as libmain.so
- Gradle :app:assembleDebug game-runtime mode passes
- strict APK audit passes (ARM64 allowlist, 16 KiB alignment, RELRO/NX, SDL/JNI exports, no paths/private data)
- default fixture build and Android lint pass
- repository safety and SunPad snapshot checks pass

This is build/link/package evidence only. It does not claim game boot, gameplay, physical-device acceptance, or publication. A2 remains open.