### PR TITLE
Android A2: route runtime through app-private storage

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -34,6 +34,14 @@ Fixture mode remains the default when the private Gradle properties are not
 provided. A full-runtime package is only build/link evidence until separately
 staged validated game data boots and completes the A2 gameplay matrix.
 
+In game-runtime mode the APK contains exactly 14 audited public support assets.
+`KartPadRuntimeResources` atomically installs them into versioned app-private
+storage before SDL loads. The Activity supplies its Context-derived private
+files/cache paths to the native runtime, which keeps configuration, logs, NAND,
+and writable renderer databases out of both the APK and shared storage. A cold
+launch without staged game data must reach the explicit `No DVD root is
+configured` boundary; it is not gameplay evidence.
+
 On an Apple Silicon Mac, explicitly install the pinned public toolchain and
 AVDs, then verify it:
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -21,6 +21,7 @@ android {
         targetSdk = 36
         versionCode = 1
         versionName = "0.0.1-a0"
+        buildConfigField("boolean", "GAME_RUNTIME", (gameRuntimeSource != null).toString())
 
         ndk {
             abiFilters += "arm64-v8a"
@@ -55,6 +56,11 @@ android {
     buildFeatures {
         prefab = true
         buildConfig = true
+    }
+    if (gameRuntimeSource != null) {
+        sourceSets.named("main") {
+            assets.srcDir(file("$gameRuntimeSource/assets"))
+        }
     }
 
     compileOptions {

--- a/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
@@ -2,6 +2,7 @@ package dev.kartpad.android
 
 import android.os.Bundle
 import android.content.Context
+import android.system.Os
 import android.util.Log
 import android.view.ViewGroup
 import org.libsdl.app.SDLActivity
@@ -11,6 +12,11 @@ class KartPadActivity : SDLActivity() {
     override fun createSDLSurface(context: Context): SDLSurface = KartPadSurface(context)
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        if (BuildConfig.GAME_RUNTIME) {
+            KartPadRuntimeResources.install(this)
+            Os.setenv("KARTPAD_ANDROID_FILES_DIR", filesDir.absolutePath, true)
+            Os.setenv("KARTPAD_ANDROID_CACHE_DIR", cacheDir.absolutePath, true)
+        }
         super.onCreate(savedInstanceState)
         val overlay = KartPadOverlayView(this)
         mLayout.addView(

--- a/android/app/src/main/java/dev/kartpad/android/KartPadRuntimeResources.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadRuntimeResources.kt
@@ -1,0 +1,61 @@
+package dev.kartpad.android
+
+import android.content.Context
+import android.util.Log
+import java.io.File
+
+/** Installs immutable public runtime support files into versioned app-private storage. */
+internal object KartPadRuntimeResources {
+    private const val TAG = "KartPadResources"
+    private const val VERSION = "a2-v1"
+
+    private val files = listOf(
+        "dsp/dsp_coef.bin",
+        "pipeline/initial_pipeline_cache.db",
+        "wii/README.md",
+        "wii/shared2/wc24/misc.bin",
+        "wii/shared2/wc24/nwc24dl.bin",
+        "wii/shared2/wc24/nwc24fl.bin",
+        "wii/shared2/wc24/nwc24fls.bin",
+        "wii/shared2/wc24/nwc24msg.cbk",
+        "wii/shared2/wc24/nwc24msg.cfg",
+        "wii/shared2/wc24/mbox/Readme.txt",
+        "wii/shared2/wc24/mbox/wc24recv.ctl",
+        "wii/shared2/wc24/mbox/wc24recv.mbx",
+        "wii/shared2/wc24/mbox/wc24send.ctl",
+        "wii/shared2/wc24/mbox/wc24send.mbx",
+    )
+
+    fun install(context: Context) {
+        val parent = File(context.filesDir, "KartPad/RuntimeResources")
+        val destination = File(parent, VERSION)
+        if (files.all { File(destination, it).isFile }) {
+            return
+        }
+
+        val staging = File(parent, ".$VERSION-staging")
+        check(!staging.exists() || staging.deleteRecursively()) {
+            "Unable to clear stale runtime-resource staging directory"
+        }
+        check(staging.mkdirs()) { "Unable to create runtime-resource staging directory" }
+
+        files.forEach { relativePath ->
+            val output = File(staging, relativePath)
+            val outputParent = checkNotNull(output.parentFile)
+            check(outputParent.isDirectory || outputParent.mkdirs()) {
+                "Unable to create runtime-resource directory for $relativePath"
+            }
+            context.assets.open(relativePath).use { input ->
+                output.outputStream().use { stream -> input.copyTo(stream) }
+            }
+        }
+
+        check(!destination.exists() || destination.deleteRecursively()) {
+            "Unable to replace incomplete runtime resources"
+        }
+        check(staging.renameTo(destination)) {
+            "Unable to activate runtime resources"
+        }
+        Log.i(TAG, "Installed runtime resources version=$VERSION files=${files.size}")
+    }
+}

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -15,10 +15,11 @@
   ARM64 AVDs. The shared scheduler and ELF AArch64 fiber additionally pass two
   million deterministic operations and one million register-checked switches
   per lane.
-- **Decision:** A1 is green and the first A2 build/link slice packages the
-  complete 29,065-function Original runtime. Continue A2 with app-private
-  paths/data staging and controller-driven gameplay; keep emulator and
-  physical-device claims separate.
+- **Decision:** A1 is green. A2 packages the complete 29,065-function Original
+  runtime and now cold-starts through translated constructors and Vulkan using
+  versioned public resources plus Context-derived app-private config/cache/
+  NAND paths. Continue A2 with private DATA staging and controller-driven
+  gameplay; keep emulator and physical-device claims separate.
 
 KartPad can be ported to Android without changing its defining architecture.
 The Android build should contain the same ahead-of-time translated Original
@@ -783,11 +784,13 @@ Before any tester receives an artifact, verify at minimum:
 A1 is complete: deterministic Vulkan readback/present, flipped-landscape and
 repeated surface lifecycle, dynamic 4 GiB shared aliases/protection, and ELF
 AArch64 scheduler/register stress pass on both pinned AVDs. A2's private
-29,065-function Original runtime now compiles, links, and packages through
-Gradle with a clean strict audit. Continue A2 by bridging app-private
-config/cache/data paths, staging the validated ignored DATA directory outside
-the APK, and proving controller-driven gameplay without weakening the package
-privacy boundary.
+29,065-function Original runtime compiles, links, and packages through Gradle.
+Its exact public resources install before SDL loads, and a cleared API 36
+launch reaches translated constructors and Vulkan using only app-private
+config/cache/NAND paths before the expected missing-DVD failure. Continue A2 by
+staging the validated ignored DATA directory outside the APK, setting its
+app-private path, and proving controller-driven gameplay without weakening the
+package privacy boundary.
 
 The A0 commands and sanitized result are recorded in
 [`android/README.md`](../android/README.md) and

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -93,13 +93,14 @@ not block offline Retro Rewind support.
 ## Next executable work
 
 1. Continue Android A2 using `docs/ANDROID-GOAL-LOOP.md`. The complete private
-   29,065-function Original graph now compiles, links, packages, and passes the
-   strict Android APK audit through a reproducible ignored-source path. Add the
-   Android app-private data/config/cache bridge, stage the already validated
-   `RMCP01` DATA directory without packaging it, and establish the first
-   emulator boot/frame before controller-driven title/menu/race/save/relaunch.
-   Build/package evidence is
-   `docs/artifacts/2026-09-03/android/a2-original-runtime-link.md`. Do not call
+   29,065-function Original graph builds, and its app-private resource/config/
+   cache/NAND bridge now cold-starts through translated constructors and the
+   Vulkan renderer before failing closed on the intentionally absent DVD root.
+   Stage the already validated ignored `RMCP01` DATA directory outside the
+   APK, write its app-private config path, and establish the first emulator
+   game boot/frame before controller-driven title/menu/race/save/relaunch.
+   Evidence is in `docs/artifacts/2026-09-03/android/a2-original-runtime-link.md`
+   and `docs/artifacts/2026-09-03/android/a2-app-private-runtime.md`. Do not call
    this gameplay or physical-device acceptance; A2 remains open.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -1757,3 +1757,33 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   Android acceptance is claimed. A2 remains open for app-private paths and the
   gameplay matrix. Evidence:
   `docs/artifacts/2026-09-03/android/a2-original-runtime-link.md`.
+
+## 2026-09-03 — Android A2 app-private runtime initialization
+
+- Added an exact 14-file public runtime-resource asset allowlist and a
+  versioned staging/rename installer that runs before SDL loads. Fixture mode
+  remains asset-free, and the package audit rejects any unexpected game-mode
+  asset.
+- Routed native configuration, logs, NAND, and mutable renderer caches through
+  the Activity's Context-derived app-private files/cache directories. The
+  first attempt called SDL's Android path helper from `libmain.so` static
+  initialization and aborted with a null SDL JNI class; exporting the exact
+  directories before `SDLActivity.onCreate` removes that load cycle.
+- The next run exposed a production-memory defect hidden by the source-only
+  fixture: Android shared memory is already sized by `ASharedMemory_create`, so
+  a redundant POSIX `ftruncate` failed with `EINVAL`. Skipping that resize only
+  on Android preserves the accepted alias/protection model.
+- A cleared API 36 / 4 KiB launch now installs all resources, initializes the
+  4 GiB guest map, loads the complete translated image, executes 43 main-DOL
+  and 192 StaticR constructors, creates Vulkan/Aurora, seeds 1,199 public
+  pipeline rows, creates only app-private writable databases/NAND/log paths,
+  and fails closed with `No DVD root is configured`. The accepted 103,429,792-
+  byte APK has SHA-256
+  `49526a79b60bdc0f1b3ca51202f4b95c12b2fef3329a552a125a63f1863011c2`;
+  the default fixture rebuild/audit also passes at
+  `dcc02c1b618e1de4e32b135ff058159eadbd9632a19e74b9a64384de18c3128b`.
+- Classification: **Pass for A2 app-private runtime initialization without
+  game data.** No game boot/gameplay or physical-device result is claimed and
+  no APK/AAB was published. Continue with ignored private DATA staging and the
+  first emulator game frame. Evidence:
+  `docs/artifacts/2026-09-03/android/a2-app-private-runtime.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -60,6 +60,22 @@ and physical-device rows remain open. A2 remains the lowest incomplete goal.
 Evidence:
 [`docs/artifacts/2026-09-03/android/a2-original-runtime-link.md`](artifacts/2026-09-03/android/a2-original-runtime-link.md).
 
+The next A2 storage/runtime slice also passes. Game-runtime builds package an
+exact 14-file public asset allowlist and atomically install it before SDL loads
+at `files/KartPad/RuntimeResources/a2-v1`. Context-derived app-private paths
+now own configuration, logs, NAND, and mutable Dawn/Aurora caches without any
+storage permission or private content in the APK. A cleared API 36 / 4 KiB
+cold launch initializes the dynamic 4 GiB guest mapping, loads the translated
+image, executes 43 main-DOL and 192 StaticR constructors, creates the Vulkan
+renderer, seeds 1,199 public pipeline rows, and then fails closed at the exact
+expected boundary because no DVD root is configured. The audited game APK is
+103,429,792 bytes with SHA-256
+`49526a79b60bdc0f1b3ca51202f4b95c12b2fef3329a552a125a63f1863011c2`.
+This is app-private initialization evidence, not game boot or gameplay. A2
+remains open for privately staged `RMCP01` data and the emulator/physical
+gameplay matrix. Evidence:
+[`docs/artifacts/2026-09-03/android/a2-app-private-runtime.md`](artifacts/2026-09-03/android/a2-app-private-runtime.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-03/android/a2-app-private-runtime.md
+++ b/docs/artifacts/2026-09-03/android/a2-app-private-runtime.md
@@ -1,0 +1,86 @@
+# Android A2 app-private runtime evidence
+
+Date: 2026-09-03
+
+Base checkpoint: `d791221` (`codex/android-a2-runtime-link`)
+
+Host: Apple Silicon macOS 26.6.2
+
+Target: `KartPad_API_36_ARM64`, Android API 36, `arm64-v8a`, 4,096-byte pages,
+gfxstream with host lavapipe
+
+## Falsifiable subgoal
+
+Package only the public runtime support files, install them before SDL loads,
+route configuration, logs, NAND, and mutable renderer caches to Android
+app-private storage, then start the complete Original runtime without staging
+game data. The accepted outcome is initialization through the renderer and
+guest constructors followed by the existing explicit missing-DVD failure.
+
+## Package and storage boundary
+
+Gradle's private game-runtime mode packages exactly 14 allowlisted public
+assets: the DSP coefficient ROM, initial pipeline cache, and Wii bootstrap
+files. `KartPadRuntimeResources` installs them through a versioned staging
+directory at `files/KartPad/RuntimeResources/a2-v1` before
+`SDLActivity.onCreate`. The strict APK audit now rejects any other asset set;
+fixture mode continues to package no assets.
+
+The Activity exports its exact `filesDir` and `cacheDir` to the native process
+before SDL loads. The runtime uses those Context-derived paths without calling
+SDL's Android JNI helpers during library static initialization. Durable config,
+logs, NAND, and resource files resolve below `files/KartPad`; Dawn and Aurora
+mutable databases resolve below `cache/KartPad`. No broad storage permission is
+requested, and no private game data is in the APK.
+
+## Failure-driven corrections
+
+The first cold launch aborted inside `SDL_GetAndroidInternalStoragePath` with
+`CallStaticObjectMethod received NULL jclass`: `libmain.so` static
+initialization ran while SDL was still loading the library. Moving resource
+installation ahead of SDL and passing Context-derived directories through the
+process environment removes that initialization cycle.
+
+The next launch reached guest-memory setup but failed with `ftruncate failed:
+Invalid argument`. Android `ASharedMemory_create` already sizes the object and
+does not accept the redundant resize used by the POSIX/iOS backings. Skipping
+only that Android `ftruncate` preserves the shared-alias implementation.
+
+## Accepted result
+
+- Fresh runtime preparation with the complete patch stack: pass.
+- Full private game-runtime Gradle build: pass.
+- Strict package/native/private-data and exact public-asset audit: pass.
+- Default source-only fixture build and zero-asset audit: pass.
+- Cold API 36 launch from cleared app data: pass for this subgoal.
+- Versioned public resource install: 14/14 files.
+- Dynamic 4 GiB guest reservation and translated image load: pass.
+- Main DOL constructors: 43 executed.
+- StaticR constructors: 192 executed.
+- Vulkan adapter/device/surface initialization: pass.
+- Public pipeline seed: 1,199 rows merged, zero skipped.
+- Mutable cache location: `cache/KartPad`, including Dawn and pipeline SQLite
+  databases.
+- Managed NAND location: `files/KartPad/NAND`.
+- Missing private DVD data: explicit `No DVD root is configured` failure with
+  diagnostics under `files/KartPad/Logs`.
+
+The accepted local APK is 103,429,792 bytes with SHA-256
+`49526a79b60bdc0f1b3ca51202f4b95c12b2fef3329a552a125a63f1863011c2`.
+Its stripped `libmain.so` is 83,532,824 bytes with SHA-256
+`3b78fba2aef646f13be698c5cbefa8b6a934e4a44feb1d6468329fddb74d2ef5`.
+The private-path patch SHA-256 is
+`7e47ebe0cad1a7664ed95b32eb21ad2f6d7925d10704ce69a6a6efd0dce6c351`.
+The post-change default fixture APK also passes the same audit with SHA-256
+`dcc02c1b618e1de4e32b135ff058159eadbd9632a19e74b9a64384de18c3128b`.
+
+## Honest classification
+
+**Pass for the A2 app-private resource/config/cache/NAND bridge and complete
+runtime initialization without game data.** This is stronger than build-only
+evidence but is not title, menu, rendered game frame, controller, race, result,
+save/relaunch, game lifecycle, audio acceptance, performance, or physical-
+device evidence. No APK/AAB was hosted or published. The next subgoal is to
+stage the already validated ignored `RMCP01` DATA directory outside the APK,
+write its app-private config path, and establish the first emulator game boot.
+A2 remains open.

--- a/patches/wiicompiled-android-private-paths.patch
+++ b/patches/wiicompiled-android-private-paths.patch
@@ -1,0 +1,98 @@
+--- a/include/runtime_config.h
++++ b/include/runtime_config.h
+@@ -224,6 +224,14 @@
+         account && account->pw_dir && *account->pw_dir) {
+         return std::filesystem::path(account->pw_dir) / "Library" / "Application Support" / "KartPad";
+     }
++#elif defined(__ANDROID__)
++    // SDL's Android helpers cannot be called from libmain.so static
++    // initialization: SDLActivity is still loading the library and has not
++    // installed its JNI class references yet. The Activity exports its exact
++    // Context-derived directory before delegating to SDLActivity.onCreate().
++    if (const char* files = std::getenv("KARTPAD_ANDROID_FILES_DIR"); files && *files) {
++        return std::filesystem::path(files) / "KartPad";
++    }
+ #endif
+     return std::filesystem::current_path() / kApplicationDirectoryName;
+ }
+@@ -243,9 +251,19 @@
+         account && account->pw_dir && *account->pw_dir) {
+         return std::filesystem::path(account->pw_dir) / "Library" / "Caches" / "KartPad";
+     }
++#elif defined(__ANDROID__)
++    if (const char* cache = std::getenv("KARTPAD_ANDROID_CACHE_DIR"); cache && *cache) {
++        return std::filesystem::path(cache) / "KartPad";
++    }
+ #endif
+     return ApplicationDataDirectory() / "Cache";
++}
++
++#ifdef __ANDROID__
++inline std::filesystem::path BundledResourcesDirectory() {
++    return ApplicationDataDirectory() / "RuntimeResources" / "a2-v1";
+ }
++#endif
+ 
+ inline std::filesystem::path ResolveConfigPath() {
+     return ApplicationDataDirectory() / kConfigFileName;
+--- a/include/nand_path.h
++++ b/include/nand_path.h
+@@ -68,6 +68,12 @@
+ }
+ 
+ inline std::optional<std::filesystem::path> BootstrapPayloadPath() {
++#ifdef __ANDROID__
++    const auto bundled = RuntimeConfigFile::BundledResourcesDirectory() / "wii";
++    if (ExistingDirectory(bundled / "shared2" / "wc24")) {
++        return bundled;
++    }
++#endif
+     if (auto executableDirectory = RuntimeConfigFile::ExecutableDirectory()) {
+         const auto adjacent = *executableDirectory / "wii_bootstrap";
+         if (ExistingDirectory(adjacent / "shared2" / "wc24")) {
+--- a/src/apple/guest_flat_memory_apple.cpp
++++ b/src/apple/guest_flat_memory_apple.cpp
+@@ -128,11 +128,13 @@ int CreateSharedSection(uint64_t size, unsigned ordinal)
+     shm_unlink(name.c_str());
+ #endif
++#if !defined(__ANDROID__)
+     if (ftruncate(fd, static_cast<off_t>(size)) != 0) {
+         const int saved = errno;
+         close(fd);
+         errno = saved;
+         ThrowErrno("ftruncate");
+     }
++#endif
+     return fd;
+ }
+ 
+--- a/src/hle/audio/ax_mix.cpp
++++ b/src/hle/audio/ax_mix.cpp
+@@ -32,6 +32,13 @@
+ namespace {
+ 
+ std::filesystem::path FindDspCoefficientRom() {
++#ifdef __ANDROID__
++    const auto bundled = RuntimeConfigFile::BundledResourcesDirectory() /
++                         "dsp" / "dsp_coef.bin";
++    if (std::filesystem::is_regular_file(bundled)) {
++        return bundled;
++    }
++#endif
+     if (const auto executableDirectory = RuntimeConfigFile::ExecutableDirectory()) {
+         const auto adjacent = *executableDirectory / "dsp_coef.bin";
+         if (std::filesystem::is_regular_file(adjacent)) {
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -1233,6 +1233,11 @@
+         const std::string auroraCachePath = rendererCacheDirectory.string();
+         auroraConfig.userPath = auroraUserPath.c_str();
+         auroraConfig.cachePath = auroraCachePath.c_str();
++#if defined(__ANDROID__)
++        const std::string auroraResourcesPath =
++            (RuntimeConfigFile::BundledResourcesDirectory() / "pipeline").string();
++        auroraConfig.resourcesPath = auroraResourcesPath.c_str();
++#endif
+         auroraConfig.logCallback = &RuntimeAuroraLogCallback;
+         auroraConfig.logLevel = LOG_DEBUG;
+         bool configWidescreen = RuntimeConfigFile::WidescreenEnabled(false);

--- a/scripts/audit-android-package.sh
+++ b/scripts/audit-android-package.sh
@@ -54,6 +54,28 @@ expected_native_members="$(printf '%s\n' \
   echo "ERROR: APK native-library set differs from the A0 allowlist" >&2
   exit 1
 }
+asset_members="$(printf '%s\n' "$members" | grep '^assets/.' | sort || true)"
+if [[ -n "$asset_members" ]]; then
+  expected_asset_members="$(printf '%s\n' \
+    assets/dsp/dsp_coef.bin \
+    assets/pipeline/initial_pipeline_cache.db \
+    assets/wii/README.md \
+    assets/wii/shared2/wc24/mbox/Readme.txt \
+    assets/wii/shared2/wc24/mbox/wc24recv.ctl \
+    assets/wii/shared2/wc24/mbox/wc24recv.mbx \
+    assets/wii/shared2/wc24/mbox/wc24send.ctl \
+    assets/wii/shared2/wc24/mbox/wc24send.mbx \
+    assets/wii/shared2/wc24/misc.bin \
+    assets/wii/shared2/wc24/nwc24dl.bin \
+    assets/wii/shared2/wc24/nwc24fl.bin \
+    assets/wii/shared2/wc24/nwc24fls.bin \
+    assets/wii/shared2/wc24/nwc24msg.cbk \
+    assets/wii/shared2/wc24/nwc24msg.cfg | sort)"
+  [[ "$asset_members" == "$expected_asset_members" ]] || {
+    echo "ERROR: APK asset set differs from the public runtime-resource allowlist" >&2
+    exit 1
+  }
+fi
 
 "$zipalign" -c -P 16 -v 4 "$apk" >/dev/null
 audit_root="$repo_root/.android-bootstrap/audit"

--- a/scripts/prepare-android-game-runtime.sh
+++ b/scripts/prepare-android-game-runtime.sh
@@ -36,6 +36,8 @@ patch --batch -p1 -d "$runtime_source/aurora-main" < \
   "$repo_root/patches/aurora-android-public-sdl-surface-lock.patch"
 patch --batch -p1 -d "$runtime_source" < \
   "$repo_root/patches/wiicompiled-android-runtime.patch"
+patch --batch -p1 -d "$runtime_source" < \
+  "$repo_root/patches/wiicompiled-android-private-paths.patch"
 
 generated_link="$(dirname "$runtime_source")/generated"
 if [[ -e "$generated_link" && ! -L "$generated_link" ]]; then


### PR DESCRIPTION
## Summary
- install the exact public runtime-resource set into versioned app-private storage before SDL loads
- route native config, logs, NAND, and writable renderer caches through Context-derived private paths
- fix Android ASharedMemory startup by avoiding an invalid redundant ftruncate
- extend the APK audit with an exact public asset allowlist

## Evidence
- complete 29,065-function Original runtime cold-starts on API 36 / ARM64 / 4 KiB pages
- guest image and constructors load, Vulkan/Aurora initializes, and the public pipeline seed is consumed
- runtime reaches the expected explicit missing-DVD boundary without packaged or staged game data
- game APK audit, default fixture build/audit, Android lint, patch integrity, repository safety, and SunPad snapshot pass

A2 remains open for privately staged RMCP01 data, gameplay, and physical-device acceptance. No APK/AAB was published.