### PR TITLE
Android A2: boot Original and survive surface recreation

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -42,6 +42,14 @@ and writable renderer databases out of both the APK and shared storage. A cold
 launch without staged game data must reach the explicit `No DVD root is
 configured` boundary; it is not gameplay evidence.
 
+With an already validated ignored RMCP01 DATA directory staged separately in
+that private storage, the API 36 emulator now boots and renders the Original
+title/demo loop. Six consecutive HOME/foreground surface generations retained
+one process and resumed presentation. See
+`docs/artifacts/2026-09-03/android/a2-emulator-boot-lifecycle.md` for the exact
+evidence and open failures. A2 remains open: the complete race/results,
+save/relaunch, real-controller, and physical-device rows are not yet proven.
+
 On an Apple Silicon Mac, explicitly install the pinned public toolchain and
 AVDs, then verify it:
 

--- a/docs/artifacts/2026-09-03/android/a2-emulator-boot-lifecycle.md
+++ b/docs/artifacts/2026-09-03/android/a2-emulator-boot-lifecycle.md
@@ -1,0 +1,105 @@
+# Android A2 emulator boot and lifecycle evidence
+
+Date: 2026-09-03
+
+Base checkpoint: `9d057e9` (`codex/android-a2-private-paths`)
+
+Host: Apple Silicon macOS 26.6.2
+
+Target: `KartPad_API_36_ARM64`, Android API 36, `arm64-v8a`, 4,096-byte pages,
+gfxstream with host lavapipe
+
+## Falsifiable subgoal
+
+Stage the already validated ignored `RMCP01` DATA directory outside the APK,
+boot the complete Original runtime to rendered game content, and keep that
+process alive while Android repeatedly destroys and recreates its SDL surface.
+This checkpoint does not claim the complete A2 controller/race/save/physical-
+device matrix.
+
+## Private input boundary
+
+The ignored `private/self-build/disc` source contained exactly 2,044 files and
+the expected RMCP01 disc/revision/Wii headers. Its pinned executables matched:
+
+- `main.dol`: SHA-256
+  `80d18895b39c63bd80f457398bfcbb91b7d16ac116a41a88967e954080155b05`
+- `rel/StaticR.rel`: SHA-256
+  `16d9d146112541fefea701ecb5bc1a496f9d50e4a752fbb5b6778e7c6399f67d`
+
+The same 2,044-file tree was streamed into
+`files/KartPad/GameData` with macOS AppleDouble creation disabled, then
+validated again on the device. `files/KartPad/Config.toml` selects the relative
+`GameData` path. Neither the game data nor the translated graph is present in
+the APK or Git.
+
+## Boot result
+
+The API 36 emulator indexed 2,037 disc files, published 2,068 FST entries,
+executed the main-DOL and StaticR constructors, initialized Vulkan/Aurora,
+merged the 1,199-row public pipeline seed, and rendered the Original title and
+demo race. SDL host playback received non-silent PCM. Keyboard injection also
+navigated a separate run through license creation, Single Player, 50cc Grand
+Prix, Mario, automatic drift, Mushroom Cup, and into a live Luigi Circuit race.
+That keyboard path is diagnostic input, not physical-controller evidence, and
+the race was not completed.
+
+The ignored visual evidence is deliberately not committed with copyrighted
+game pixels:
+
+- first rendered title: `.android-bootstrap/a2-emulator-game.png`, SHA-256
+  `a2d722612e6b2b5cede480c62c90e8a5413baa8d994f02909b0b144d78724b45`
+- live Luigi Circuit race: `.android-bootstrap/a2-emulator-live-race.png`,
+  SHA-256
+  `4b696244dc6ac776a9c93016a3e758a0620f59b29be355d7c0cd7c7bc2ef7a7a`
+
+## Failure-driven lifecycle correction
+
+The first live-race HOME/foreground attempt recreated the SDL surface but then
+aborted in `ImGui::Begin` because `g.WithinFrameScope` was false. Aurora's
+asynchronous worker can lose its ImGui frame during surface replacement while
+the runtime's optimistic `g_auroraFrameActive` flag is still true.
+
+The Android runtime patch now waits for the worker and verifies ImGui's actual
+frame scope before either presentation route draws the host overlay or calls
+`aurora_end_frame`. A stale frame is dropped and the optimistic flag is cleared
+so the next GX command retries frame creation. Both immediate `GXCopyDisp` and
+VI-retrace presentation use the same readiness contract.
+
+The final build survived six consecutive HOME/foreground cycles in the title
+and demo renderer loop. Each cycle produced `surfaceDestroyed`, `nativePause`,
+`surfaceCreated`, and `nativeResume`; PID `6894` remained unchanged. The final
+log contained zero `imgui.cpp`, `WithinFrameScope`, or `SIGABRT` matches and
+continued reporting game presentation and non-silent audio. The ignored final
+screenshot is `.android-bootstrap/a2-resume-final-generation-6.png`, SHA-256
+`7b4c8c8f2dcd9ccdb52d68ab8689dce25e2f35b8daf34ae31c6418df53e35775`.
+
+## Reproducibility and package audit
+
+- Fresh preparation applied the complete Android patch stack: pass.
+- The four lifecycle-modified runtime files from that fresh preparation were
+  byte-identical to the tested source: pass.
+- Full private Original APK build: pass.
+- Strict APK/native/public-asset/private-data audit: pass.
+- Final local APK: 103,429,984 bytes, SHA-256
+  `5e07a417f5695f0b0eb1a7237deb649fcac0e3bb16f23f0ae092e722f22314c3`.
+- Stripped `libmain.so`: 83,533,016 bytes, SHA-256
+  `71486d448c0765e916b95c3ca703d1276152357a912ad0d2fd49c673cc98b44a`.
+- Lifecycle patch: SHA-256
+  `53404197bef0f46441fee67a993a82cdb963dafa03a8eb1bf8657523f41cfdbb`.
+
+No APK or AAB was hosted or published.
+
+## Honest classification
+
+**Pass for first Original emulator rendering and repeated title/demo surface
+recreation.** A2 remains open. The emulator uses a software Vulkan path and
+ran at roughly 10–15 effective FPS, so it is not performance evidence. Audible
+quality was not judged. A full race, results, save/relaunch, exact live-race
+resume retest, real controller, and physical Android hardware remain unproven.
+
+A separate relaunch attempt also exposed a persisted managed-NAND defect:
+`MiiManager::Init` jumped through guest address zero after an earlier session
+had written state. The failing NAND was preserved by in-place rename during
+testing rather than deleted. This blocks any save/relaunch claim and is the
+next emulator-side A2 failure to isolate.

--- a/patches/wiicompiled-android-surface-resume.patch
+++ b/patches/wiicompiled-android-surface-resume.patch
@@ -1,0 +1,101 @@
+--- a/include/settings_overlay.h
++++ b/include/settings_overlay.h
+@@ -10,7 +10,8 @@
+ void RefreshHostSettings() noexcept;
+ // Draw the F10 settings bar before each Aurora present.
+ void HandleEvents(const AuroraEvent* events) noexcept;
+-void Draw() noexcept;
++bool FrameReadyForOverlay() noexcept;
++bool Draw() noexcept;
+ bool StartupScreenVisible() noexcept;
+ void NotifyStrapInputAccepted() noexcept;
+ void AdvancePresentedFrame() noexcept;
+--- a/src/settings_overlay.cpp
++++ b/src/settings_overlay.cpp
+@@ -16,6 +16,7 @@
+ #include "runtime_log.h"
+ 
+ #include <imgui.h>
++#include <imgui_internal.h>
+ #include <SDL3/SDL_events.h>
+ #include <SDL3/SDL_gamepad.h>
+ #include <SDL3/SDL_keyboard.h>
+@@ -1055,11 +1056,19 @@
+     }
+ }
+ 
+-void Draw() noexcept {
+-    RefreshHostSettings();
++bool FrameReadyForOverlay() noexcept {
+     // Wait for the frame worker's DONE phase: it has replayed the previous frame's ImGui draw lists
+     // and started the next ImGui frame, so all overlay callers can now safely issue ImGui commands.
+     aurora_wait_for_frame_worker();
++    const ImGuiContext* context = ImGui::GetCurrentContext();
++    return context != nullptr && context->WithinFrameScope;
++}
++
++bool Draw() noexcept {
++    RefreshHostSettings();
++    if (!FrameReadyForOverlay()) {
++        return false;
++    }
+     ApplyConfiguredMappings();
+     PersistDisplayModeIfChanged();
+     UpdateCursorAutoHide();
+@@ -1073,6 +1082,7 @@
+     // top bar is hidden mid-setup.
+     PADBlockInput(g_topBarVisible || controller_mapping_wizard::IsActive());
+     DrawStartupScreen();
++    return true;
+ }
+ 
+ bool StartupScreenVisible() noexcept {
+--- a/src/hle/gx/gx_copy.cpp
++++ b/src/hle/gx/gx_copy.cpp
+@@ -121,11 +121,16 @@
+     // phase, which strictly subsumes the drain this call would perform.
+     ++g_gxFrameCount;
+     VI_HLE_SetXfbReady(da);
++    // Surface loss can leave Aurora's asynchronous worker without an ImGui
++    // frame even when the runtime's optimistic frame flag is still set. Drop
++    // this presentation and clear the flag so the next GX call retries begin.
++    if (!settings_overlay::Draw()) {
++        g_auroraFrameActive.store(false, std::memory_order_release);
++        return;
++    }
+     // Present immediately so post-copy draws don't leak into this frame. Join at the DONE phase
+     // (not the cheaper SEALED phase GXDrawDone waits for) because ImGui's draw lists, owned by
+     // Aurora's render worker, replay during encode; aurora_end_frame would join here anyway.
+-    aurora_wait_for_frame_worker();
+-    settings_overlay::Draw();
+     // Seal, pace to the VI retrace boundary (Aurora renders the sealed frame
+     // during the wait), and pre-warm the next frame.
+     VI_HLE_PresentFrame(/*presentedXfb=*/true, /*paceToRetrace=*/true);
+--- a/src/hle/vi.cpp
++++ b/src/hle/vi.cpp
+@@ -424,13 +424,21 @@
+         const bool shouldSubmit = frameActive && (shouldPresentXfb || shouldPresentBlack);
+ 
+         if (shouldSubmit) {
++            bool frameReady = false;
+             if (!isBlack || settings_overlay::StartupScreenVisible()) {
+                 // Normal presentation: draw overlay on top of GX content
+-                settings_overlay::Draw();
++                frameReady = settings_overlay::Draw();
++            } else {
++                frameReady = settings_overlay::FrameReadyForOverlay();
+             }
+-            // Outside startup, VI black remains a pure black presentation.
+-            // Unpaced: this present already runs in retrace context.
+-            VI_HLE_PresentFrame(shouldPresentXfb, false);
++            if (frameReady) {
++                // Outside startup, VI black remains a pure black presentation.
++                // Unpaced: this present already runs in retrace context.
++                VI_HLE_PresentFrame(shouldPresentXfb, false);
++            } else {
++                g_auroraFrameActive.store(false, std::memory_order_release);
++                g_auroraFrameHadWork.store(false, std::memory_order_release);
++            }
+         } else if (g_auroraFrameHadWork.load(std::memory_order_acquire) && !shouldPresentXfb && !isBlack) {
+             // GX work is in progress but frame not complete - just poll window events
+             // Don't call aurora_end_frame() as that would present incomplete work

--- a/scripts/prepare-android-game-runtime.sh
+++ b/scripts/prepare-android-game-runtime.sh
@@ -38,6 +38,8 @@ patch --batch -p1 -d "$runtime_source" < \
   "$repo_root/patches/wiicompiled-android-runtime.patch"
 patch --batch -p1 -d "$runtime_source" < \
   "$repo_root/patches/wiicompiled-android-private-paths.patch"
+patch --batch -p1 -d "$runtime_source" < \
+  "$repo_root/patches/wiicompiled-android-surface-resume.patch"
 
 generated_link="$(dirname "$runtime_source")/generated"
 if [[ -e "$generated_link" && ! -L "$generated_link" ]]; then


### PR DESCRIPTION
## Summary
- boot the privately staged RMCP01 Original runtime to rendered title/demo and a diagnostic live race on the API 36 ARM64 emulator
- verify the real ImGui frame scope before overlay drawing or either Aurora presentation route
- drop stale surface-transition frames and retry frame creation instead of aborting during HOME/foreground
- record exact package, runtime, lifecycle, and open-gate evidence without committing private inputs or copyrighted screenshots

## Verification
- fresh Android game-runtime preparation; 392 patch hunks validated
- byte-identical lifecycle files between fresh preparation and tested source
- full private Original APK build
- strict Android APK audit
- Android lintDebug
- six consecutive HOME/foreground generations with one PID and continued presentation
- zero imgui.cpp / WithinFrameScope / SIGABRT matches after the final stress run
- repository safety audit

## Honest scope
A2 remains open. This does not claim a complete race/results flow, save/relaunch, a real controller, audio quality, performance, or physical-device proof. A persisted managed-NAND relaunch defect is recorded as the next emulator-side failure. No APK/AAB was published.