### PR TITLE
Android: expose app-private debug race fixture

### DIFF
--- a/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.system.Os
 import android.util.Log
 import android.view.ViewGroup
+import java.io.File
 import org.libsdl.app.SDLActivity
 import org.libsdl.app.SDLSurface
 
@@ -16,6 +17,7 @@ class KartPadActivity : SDLActivity() {
             KartPadRuntimeResources.install(this)
             Os.setenv("KARTPAD_ANDROID_FILES_DIR", filesDir.absolutePath, true)
             Os.setenv("KARTPAD_ANDROID_CACHE_DIR", cacheDir.absolutePath, true)
+            configureDebugRkgInput()
         }
         super.onCreate(savedInstanceState)
         val overlay = KartPadOverlayView(this)
@@ -30,7 +32,38 @@ class KartPadActivity : SDLActivity() {
         Log.i(TAG, "A0 SDLActivity shell created")
     }
 
+    private fun configureDebugRkgInput() {
+        if (!BuildConfig.DEBUG) return
+
+        val fixture = File(filesDir, DEBUG_RKG_RELATIVE_PATH)
+        val header = ByteArray(RKG_MAGIC.size)
+        val valid = fixture.isFile &&
+            fixture.length() in MIN_RKG_BYTES..MAX_RKG_BYTES &&
+            runCatching {
+                fixture.inputStream().use { input ->
+                    input.read(header) == header.size && header.contentEquals(RKG_MAGIC)
+                }
+            }.getOrDefault(false)
+
+        if (valid) {
+            Os.setenv("KARTPAD_RKG_INPUT_V2", fixture.absolutePath, true)
+            Os.setenv("KARTPAD_RKG_AUTOSTART_V2", "1", true)
+            Os.setenv("KARTPAD_RKG_FORCE_METADATA_V2", "1", true)
+            Os.setenv("KARTPAD_PRECISE_MENU_PULSE_V2", "1", true)
+            Log.i(TAG, "Debug app-private RKG input enabled")
+        } else {
+            Os.unsetenv("KARTPAD_RKG_INPUT_V2")
+            Os.unsetenv("KARTPAD_RKG_AUTOSTART_V2")
+            Os.unsetenv("KARTPAD_RKG_FORCE_METADATA_V2")
+            Os.unsetenv("KARTPAD_PRECISE_MENU_PULSE_V2")
+        }
+    }
+
     companion object {
         private const val TAG = "KartPadFixture"
+        private const val DEBUG_RKG_RELATIVE_PATH = "KartPad/Diagnostics/TestInput.rkg"
+        private const val MIN_RKG_BYTES = 0x90L
+        private const val MAX_RKG_BYTES = 1024L * 1024L
+        private val RKG_MAGIC = byteArrayOf('R'.code.toByte(), 'K'.code.toByte(), 'G'.code.toByte(), 'D'.code.toByte())
     }
 }

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -93,15 +93,15 @@ not block offline Retro Rewind support.
 ## Next executable work
 
 1. Continue Android A2 using `docs/ANDROID-GOAL-LOOP.md`. The complete private
-   29,065-function Original graph builds, and its app-private resource/config/
-   cache/NAND bridge now cold-starts through translated constructors and the
-   Vulkan renderer before failing closed on the intentionally absent DVD root.
-   Stage the already validated ignored `RMCP01` DATA directory outside the
-   APK, write its app-private config path, and establish the first emulator
-   game boot/frame before controller-driven title/menu/race/save/relaunch.
-   Evidence is in `docs/artifacts/2026-09-03/android/a2-original-runtime-link.md`
-   and `docs/artifacts/2026-09-03/android/a2-app-private-runtime.md`. Do not call
-   this gameplay or physical-device acceptance; A2 remains open.
+   Original runtime now boots ignored app-private RMCP01 data, restores its
+   saved license across cold processes, enters live Luigi Circuit gameplay,
+   survives repeated title/demo and live-race surface recreation, and sustains
+   a clean retail staff replay. The debug-only app-private RKG bridge works,
+   but the existing player fixture diverges and must not be used as completion
+   evidence. Establish a complete player race, results, post-race save/relaunch,
+   then repeat with a real controller and physical Android hardware. Evidence
+   is in `docs/artifacts/2026-09-03/android/a2-emulator-boot-lifecycle.md` and
+   `docs/artifacts/2026-09-03/android/a2-debug-input-replay.md`. A2 remains open.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -1787,3 +1787,34 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   no APK/AAB was published. Continue with ignored private DATA staging and the
   first emulator game frame. Evidence:
   `docs/artifacts/2026-09-03/android/a2-app-private-runtime.md`.
+
+## 2026-09-03 — Android A2 app-private RKG diagnostic and retail replay
+
+- Added a debug-game-only bridge for the existing native RKG player fixture.
+  It accepts exactly one bounded, magic-checked app-private file, sets the
+  existing `_V2` diagnostic variables before SDL loads, emits no private path,
+  and clears every variable when the file is absent or invalid.
+- The ignored 2,016-byte staff input was staged after installation and verified
+  by SHA-256. Its structural-only inspection reports course 8, 89.670 seconds,
+  2,194 input bytes, and equal 5,615-frame streams. No input bytes, game data,
+  save, or screenshot entered the APK or Git.
+- The diagnostic selected Mario, Standard Kart M, automatic drift, and Luigi
+  Circuit, then moved after the countdown. It diverged into the wall by guest
+  time 10.881 and remained there at 34.236 on lap 1/3. No forced finish was
+  enabled. This is a pass for the Android/private diagnostic bridge and a fail
+  for natural player-fixture completion, matching the existing native warning.
+- With the fixture disabled, a fresh PID rendered the retail Luigi Circuit
+  staff Watch Replay for more than twelve wall-clock minutes at roughly
+  9--13 FPS. Progress captures were byte-distinct, a finish-line crossing was
+  observed, and no ImGui assertion, `SIGABRT`, or Java fatal exception appeared.
+  Because Watch Replay has no player results/save contract, it does not satisfy
+  the complete-race gate.
+- The full game APK build, game release/source-only debug Kotlin compiles,
+  `lintDebug`, and strict APK audit pass. The local 103,429,984-byte APK
+  has SHA-256
+  `c6b0eae50624f1e5466b679558a643e41cf8d721b3f3d5d4179303c3a038884e`;
+  its stripped 83,533,016-byte `libmain.so` remains
+  `71486d448c0765e916b95c3ca703d1276152357a912ad0d2fd49c673cc98b44a`.
+  A2 remains open for a complete player race/results/save, real controller,
+  and physical Android hardware. No package was hosted or published. Evidence:
+  `docs/artifacts/2026-09-03/android/a2-debug-input-replay.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -76,6 +76,22 @@ remains open for privately staged `RMCP01` data and the emulator/physical
 gameplay matrix. Evidence:
 [`docs/artifacts/2026-09-03/android/a2-app-private-runtime.md`](artifacts/2026-09-03/android/a2-app-private-runtime.md).
 
+The first full Original emulator boot now also passes. Ignored validated
+RMCP01 data is staged only under the app sandbox; the title, demo, saved
+license, non-silent SDL stream, and live Luigi Circuit gameplay render through
+the complete translated runtime. Six title/demo and three live-race
+HOME/foreground cycles retained their process after a narrow stale-ImGui-frame
+repair. Three cold processes restored the saved `KartPad` license. A debug-only
+app-private RKG bridge reaches the existing native player fixture, but that
+fixture diverges into the wall and does not finish; a separate clean Nintendo
+staff replay rendered for more than twelve wall-clock minutes without a crash
+but is not player/results/save evidence. A2 remains open for a complete player
+race, results, post-race save/relaunch, real controller, and physical Android
+hardware. Evidence:
+[`docs/artifacts/2026-09-03/android/a2-emulator-boot-lifecycle.md`](artifacts/2026-09-03/android/a2-emulator-boot-lifecycle.md)
+and
+[`docs/artifacts/2026-09-03/android/a2-debug-input-replay.md`](artifacts/2026-09-03/android/a2-debug-input-replay.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-03/android/a2-debug-input-replay.md
+++ b/docs/artifacts/2026-09-03/android/a2-debug-input-replay.md
@@ -1,0 +1,97 @@
+# Android A2 debug input and retail replay evidence
+
+Date: 2026-09-03
+
+Base checkpoint: `3bbbc16` (`codex/android-a2-save-relaunch`)
+
+Target: `KartPad_API_36_ARM64`, Android API 36, `arm64-v8a`, 4,096-byte
+pages, gfxstream with host lavapipe
+
+## Falsifiable subgoal
+
+Make the existing native RKG player-input diagnostic reachable from an Android
+debug game build without packaging private input, then determine whether its
+countdown-synchronized stream can naturally finish a matching Time Trial.
+
+## App-private debug boundary
+
+`KartPadActivity` now considers exactly
+`files/KartPad/Diagnostics/TestInput.rkg`, and only when both the game runtime
+and `BuildConfig.DEBUG` are true. The file must be a regular file between
+`0x90` bytes and 1 MiB with the `RKGD` magic. A valid file enables the existing
+`_V2` input, autostart, metadata, and precise-menu-pulse variables before SDL
+loads. A missing or invalid file clears all four variables. The log reports
+only that the diagnostic is enabled; it does not print the private path or
+payload.
+
+The ignored staff input was copied into the app sandbox after APK installation
+and matched its source SHA-256
+`30c4ec21c2c8324c6180ef3e806df10a36ce14b1c641494acfb40fef911d5ed2`
+at 2,016 bytes. The repository's content-free inspector reports course ID 8,
+89.670 seconds, 2,194 input bytes, 59/1,030/4 sequences, and equal
+5,615-frame streams. No RKG bytes, game data, save, or screenshot is committed
+or packaged.
+
+An initial `adb exec-out` stdin copy delivered the file but did not terminate
+at EOF. The transport was interrupted and replaced with a bounded
+`/data/local/tmp` copy, an app-sandbox copy, SHA-256 verification, and deletion
+of the exact temporary-device file.
+
+## Player-fixture result
+
+The exact debug build reported `Debug app-private RKG input enabled`. Its
+metadata path selected Mario, Standard Kart M, automatic drift, Mushroom Cup,
+and Luigi Circuit. Autostart moved the kart after the countdown, proving the
+Android bridge reached the native player fixture.
+
+The stream did not remain synchronized with live player physics. At guest time
+10.881 seconds the kart was against the outer wall; at 34.236 seconds it
+remained there on lap 1/3. This reproduces the already documented native
+fixture limitation rather than completing a race. No forced-finish variable
+was enabled. The ignored final capture is
+`.android-bootstrap/a2-rkg-diverged-final.png`, SHA-256
+`57cba22e4ffb71a969d3c1cb9de7556a40e4bfd3e1c3a68e27f70d005ad9a71b`.
+
+Classification: **Pass for the private debug bridge; fail for natural
+player-fixture race completion.** This is diagnostic keyboard/RKG evidence,
+not controller evidence.
+
+## Clean retail replay observation
+
+The diagnostic file was renamed to an app-private disabled backup and the app
+was cold-launched. PID `8784` emitted no diagnostic-enabled marker. Precise
+keyboard pulses selected Time Trials, Luigi Circuit, and the on-disc Nintendo
+staff **Watch Replay** path. The retail replay then rendered continuously for
+more than twelve wall-clock minutes at roughly 9--13 FPS under the unchanged
+PID, with byte-distinct progress captures and zero `SIGABRT`, ImGui assertion,
+`WithinFrameScope`, or Java fatal-exception matches.
+
+The observation included a finish-line crossing, but Watch Replay exposes no
+player lap HUD, results, or save and remained in replay presentation afterward.
+It is therefore useful long-course renderer evidence but is **inconclusive as
+a player race/results/save proof**. Representative ignored captures are:
+
+- live replay:
+  `.android-bootstrap/a2-replay-progress1.png`, SHA-256
+  `9320ca7f613a65aab5b15ebf6a19291a279ad5f8f53952e59cf6fd954f26fb4b`
+- later replay progress:
+  `.android-bootstrap/a2-replay-progress6.png`, SHA-256
+  `3418bdf1d1b927f5b0f1c1f1f2fa4b0919ac1147880ccd3cd88bfc960119a4ab`
+- finish-line observation:
+  `.android-bootstrap/a2-replay-finish.png`, SHA-256
+  `a25889c407a87a84e3a6088f2c008eef94f330c2aaa0a39e44e02e19f5407a49`
+
+## Build result and remaining gate
+
+The full private Original debug APK, game-runtime release Kotlin compile, and
+source-only debug Kotlin compile passed. `lintDebug` and the strict APK audit
+also passed.
+The APK is 103,429,984 bytes with SHA-256
+`c6b0eae50624f1e5466b679558a643e41cf8d721b3f3d5d4179303c3a038884e`.
+Its stripped 83,533,016-byte `libmain.so` remains SHA-256
+`71486d448c0765e916b95c3ca703d1276152357a912ad0d2fd49c673cc98b44a`.
+No APK or AAB was hosted or published.
+
+A2 remains open for a complete player race, results, post-race save/relaunch,
+a real controller, and physical Android hardware. The replay does not satisfy
+any of those rows.


### PR DESCRIPTION
## Summary
- gate the existing native RKG diagnostic behind a debug game build and one bounded, magic-checked app-private file
- enable deterministic precise menu pulses only with that private opt-in and clear all diagnostic environment variables otherwise
- document the successful Android bridge, the known live-player divergence, and a clean long retail staff replay without claiming controller/results/save completion

## Validation
- full private Original debug APK build
- `:app:compileReleaseKotlin` in game-runtime mode
- `:app:compileDebugKotlin` in source-only mode
- `:app:lintDebug`
- strict Android APK audit
- repository safety audit
- API 36 ARM64 emulator: diagnostic metadata/menu/countdown path and bounded failure observation
- API 36 ARM64 emulator: fixture-disabled retail Watch Replay, 12+ wall-clock minutes, stable PID, no ImGui/SIGABRT/Java fatal marker

## Boundaries
- no RKG, game data, save, screenshot, APK, or AAB is committed or published
- the player fixture diverges and is explicitly not race-completion or controller evidence
- A2 remains open for player results/save, a real controller, and physical Android hardware
- source verification validated 392 patch hunks plus WiiCompiled/SunPad/WheelWizard, then encountered the pre-existing ignored rr-pulsar checkout mismatch