### PR TITLE
Android A2: gate diagnostic keyboard steering

### DIFF
--- a/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
@@ -46,22 +46,34 @@ class KartPadActivity : SDLActivity() {
             }.getOrDefault(false)
 
         if (valid) {
+            val keyboardSteer = File(filesDir, DEBUG_RKG_KEYBOARD_STEER_RELATIVE_PATH).isFile
             Os.setenv("KARTPAD_RKG_INPUT_V2", fixture.absolutePath, true)
             Os.setenv("KARTPAD_RKG_AUTOSTART_V2", "1", true)
             Os.setenv("KARTPAD_RKG_FORCE_METADATA_V2", "1", true)
             Os.setenv("KARTPAD_PRECISE_MENU_PULSE_V2", "1", true)
-            Log.i(TAG, "Debug app-private RKG input enabled")
+            if (keyboardSteer) {
+                Os.setenv("KARTPAD_RKG_KEYBOARD_STEER_V2", "1", true)
+                Os.setenv("KARTPAD_FULL_SYNTHETIC_STICK_V2", "1", true)
+            } else {
+                Os.unsetenv("KARTPAD_RKG_KEYBOARD_STEER_V2")
+                Os.unsetenv("KARTPAD_FULL_SYNTHETIC_STICK_V2")
+            }
+            Log.i(TAG, "Debug app-private RKG input enabled; keyboard steer=$keyboardSteer")
         } else {
             Os.unsetenv("KARTPAD_RKG_INPUT_V2")
             Os.unsetenv("KARTPAD_RKG_AUTOSTART_V2")
             Os.unsetenv("KARTPAD_RKG_FORCE_METADATA_V2")
             Os.unsetenv("KARTPAD_PRECISE_MENU_PULSE_V2")
+            Os.unsetenv("KARTPAD_RKG_KEYBOARD_STEER_V2")
+            Os.unsetenv("KARTPAD_FULL_SYNTHETIC_STICK_V2")
         }
     }
 
     companion object {
         private const val TAG = "KartPadFixture"
         private const val DEBUG_RKG_RELATIVE_PATH = "KartPad/Diagnostics/TestInput.rkg"
+        private const val DEBUG_RKG_KEYBOARD_STEER_RELATIVE_PATH =
+            "KartPad/Diagnostics/TestInput.keyboard-steer"
         private const val MIN_RKG_BYTES = 0x90L
         private const val MAX_RKG_BYTES = 1024L * 1024L
         private val RKG_MAGIC = byteArrayOf('R'.code.toByte(), 'K'.code.toByte(), 'G'.code.toByte(), 'D'.code.toByte())

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -97,11 +97,16 @@ not block offline Retro Rewind support.
    saved license across cold processes, enters live Luigi Circuit gameplay,
    survives repeated title/demo and live-race surface recreation, and sustains
    a clean retail staff replay. The debug-only app-private RKG bridge works,
-   but the existing player fixture diverges and must not be used as completion
-   evidence. Establish a complete player race, results, post-race save/relaunch,
+   and an Android-only marker can replace only its steering with the debug
+   keyboard stick, but neither route completes a race. Exact GCN Mario Circuit
+   metadata and the macOS-proven SNES Mario Circuit 3 stream also diverge on
+   Android and must not be used as completion evidence. Establish a complete
+   player race, results, post-race save/relaunch,
    then repeat with a real controller and physical Android hardware. Evidence
    is in `docs/artifacts/2026-09-03/android/a2-emulator-boot-lifecycle.md` and
-   `docs/artifacts/2026-09-03/android/a2-debug-input-replay.md`. A2 remains open.
+   `docs/artifacts/2026-09-03/android/a2-debug-input-replay.md`, plus
+   `docs/artifacts/2026-09-03/android/a2-keyboard-steer-diagnostic.md`. A2
+   remains open.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -1818,3 +1818,36 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   A2 remains open for a complete player race/results/save, real controller,
   and physical Android hardware. No package was hosted or published. Evidence:
   `docs/artifacts/2026-09-03/android/a2-debug-input-replay.md`.
+
+## 2026-09-03 — Android A2 keyboard-steer diagnostic
+
+- Added an Android-only, debug-marker-gated hybrid for the existing RKG player
+  fixture. Fixture acceleration remains deterministic while the Classic
+  keyboard stick supplies steering; tricks are disabled and raw/float axes
+  remain coherent. The ordinary RKG, keyboard/controller, release, and Apple
+  paths are unchanged.
+- The live Luigi Circuit player accepted `A`/`D` steering, including recovery
+  from grass to track, but coarse diagnostic pulses did not hold a three-lap
+  line. No forced finish was used and the run is rejected as completion.
+- With keyboard steering disabled, exact GCN Mario Circuit staff metadata
+  diverged at guest time 17.244. The exact SNES Mario Circuit 3 `01:38.880`
+  staff stream and Mario / Standard Kart M / Manual configuration previously
+  proven through the native macOS player path also diverged at 10.749. This
+  falsifies natural Android RKG completion with the strongest available
+  control.
+- A guarded private all-cups save enabled the locked-course control. The
+  original 2,867,200-byte save was restored byte-for-byte at SHA-256
+  `07c4ff00b6eb686cff3b7c7bc365c0e453a99f1a1f8ad6ef9238679a73a71155`;
+  the private RKG was disabled and marker removed. No private input, save, game
+  data, or capture is packaged or committed.
+- The full private debug APK builds at 103,430,368 bytes and SHA-256
+  `6b4e750366661056e42470f995f833fd132c26643eb5f86761a371b85e710b3c`.
+  Debug/release Kotlin compilation, lint, strict package audit, patch dry-run,
+  diff check, and repository safety pass. Source verification accepts 395
+  hunks plus WiiCompiled/SunPad/WheelWizard before the pre-existing ignored
+  rr-pulsar checkout mismatch.
+  Classification: **Pass for the bounded debug steering diagnostic; fail for
+  complete player automation.** A2 remains open for a complete player race,
+  results/save/relaunch, real controller, and physical Android hardware.
+  Evidence:
+  `docs/artifacts/2026-09-03/android/a2-keyboard-steer-diagnostic.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -92,6 +92,16 @@ hardware. Evidence:
 and
 [`docs/artifacts/2026-09-03/android/a2-debug-input-replay.md`](artifacts/2026-09-03/android/a2-debug-input-replay.md).
 
+An additional Android-only debug marker can now retain fixture acceleration
+while routing steering through the existing keyboard stick. It accepts
+steering but did not complete a race. Normal fixture steering also diverged on
+exact GCN Mario Circuit metadata and on the exact SNES Mario Circuit 3 stream
+previously proven through the native macOS player path. No forced finish was
+used; the private all-cups test save was restored byte-for-byte afterward.
+This is diagnostic capability only and does not narrow A2's remaining player,
+controller, or physical-device gates. Evidence:
+[`docs/artifacts/2026-09-03/android/a2-keyboard-steer-diagnostic.md`](artifacts/2026-09-03/android/a2-keyboard-steer-diagnostic.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-03/android/a2-keyboard-steer-diagnostic.md
+++ b/docs/artifacts/2026-09-03/android/a2-keyboard-steer-diagnostic.md
@@ -1,0 +1,80 @@
+# Android A2 keyboard-steer diagnostic
+
+Date: 2026-09-03
+
+Base checkpoint: `dbb138e` (`codex/android-a2-rkg-race`)
+
+Target: `KartPad_API_36_ARM64`, Android API 36, `arm64-v8a`, 4,096-byte
+pages, gfxstream with host lavapipe
+
+## Falsifiable subgoal
+
+Keep the debug-only RKG fixture's deterministic throttle while allowing
+Android keyboard steering, then determine whether either that hybrid or a
+previously proven native staff stream can complete a real player Time Trial.
+
+## Opt-in boundary
+
+The Android-only runtime patch recognizes
+`KARTPAD_RKG_KEYBOARD_STEER_V2=1`. While the existing validated RKG fixture is
+armed, this mode retains constant A/accelerate, takes only the Classic left
+stick from the keyboard bridge, disables fixture tricks, and publishes the
+matching raw axes. It does not change menu input, release builds, Apple
+runtime patches, ordinary keyboard/controller input, or the default RKG
+stream.
+
+`KartPadActivity` sets the mode only in a debug game build when both the
+validated app-private `TestInput.rkg` and the separate regular-file marker
+`TestInput.keyboard-steer` exist. The marker contains no private input. With
+the marker absent, both keyboard-steer environment variables are explicitly
+cleared. Cold-launch logs proved both branches: `keyboard steer=true` with the
+marker and `keyboard steer=false` without it.
+
+## Runtime results
+
+The hybrid run reached the real Luigi Circuit player HUD and accepted Android
+`A`/`D` steering while the fixture held acceleration. Coarse accessibility
+key pulses could recover the kart from grass to the track, but could not keep
+it on the racing line for three laps. The run was stopped without a forced
+finish and is rejected as completion, results, save, controller, or physical
+device evidence.
+
+Two normal RKG-steering controls were then run with the marker absent:
+
+- GCN Mario Circuit used the exact staff card and Mario / Standard Bike M /
+  Manual. It diverged into the outside wall by guest time `17.244`, lap 1/3.
+- SNES Mario Circuit 3 used the exact `01:38.880` staff card and Mario /
+  Standard Kart M / Manual configuration that previously completed through
+  the native macOS live-player path. It hit the outside block by guest time
+  `10.749`, lap 1/3.
+
+The latter falsifies the strongest available natural-completion hypothesis on
+Android. No forced-finish variable was enabled in any run.
+
+The all-cups precondition was generated from the app's ignored save using the
+existing guarded tool. It changed only the documented GP completion word and
+core CRC. After testing, the original 2,867,200-byte save was restored and
+verified byte-for-byte at SHA-256
+`07c4ff00b6eb686cff3b7c7bc365c0e453a99f1a1f8ad6ef9238679a73a71155`.
+The RKG was disabled and the keyboard marker removed before shutdown. No save,
+RKG, game data, or runtime capture is committed or packaged.
+
+## Build and classification
+
+The full private Original debug APK builds with the Android-only patch. The
+local APK is 103,430,368 bytes with SHA-256
+`6b4e750366661056e42470f995f833fd132c26643eb5f86761a371b85e710b3c`.
+Its stripped 83,533,400-byte `libmain.so` has SHA-256
+`9d6cf6a59d553c57dbb9db3ddf7e7925eba6da300d2c92212c2a92363f76ced4`.
+Game debug and release Kotlin compilation, `lintDebug`, the strict APK audit,
+the repository safety audit, patch dry-run, and `git diff --check` pass. A
+fresh prepared source applied the patch and matched the exercised `kpad.cpp`
+byte-for-byte. The broader source verifier accepted 395 hunks and the pinned
+WiiCompiled, SunPad, and WheelWizard checkouts before stopping on the existing
+ignored rr-pulsar checkout mismatch (`b566a5d` local versus `29e76d4` pinned).
+No APK or AAB was hosted or published.
+
+Classification: **Pass for a separately gated Android debug steering
+diagnostic; fail for complete player-race automation.** A2 remains open for a
+complete player race/results/save/relaunch, real controller, and physical
+Android hardware.

--- a/patches/wiicompiled-android-keyboard-steer.patch
+++ b/patches/wiicompiled-android-keyboard-steer.patch
@@ -1,0 +1,79 @@
+diff --git a/src/hle/input/kpad.cpp b/src/hle/input/kpad.cpp
+--- a/src/hle/input/kpad.cpp
++++ b/src/hle/input/kpad.cpp
+@@ -397,6 +397,15 @@ bool ForceFixtureMetadataEnabled()
+         return value != nullptr && std::strcmp(value, "1") == 0;
+     }();
+     return enabled && Fixture().EnsureLoaded();
++}
++
++bool FixtureKeyboardSteerEnabled()
++{
++    static const bool enabled = [] {
++        const char* value = std::getenv("KARTPAD_RKG_KEYBOARD_STEER_V2");
++        return value != nullptr && std::strcmp(value, "1") == 0;
++    }();
++    return enabled;
+ }
+ 
+ uint32_t ButtonForScancode(uint32_t chan, SDL_Scancode code)
+@@ -983,24 +992,37 @@ extern "C" bool KPad_RkgFixture_CalcInner(CpuContext* ctx)
+         Fixture().Disarm();
+         return false;
+     }
+-    const uint8_t xRaw = static_cast<uint8_t>(sample.direction >> 4);
+-    const uint8_t yRaw = static_cast<uint8_t>(sample.direction & 0x0f);
++    uint8_t xRaw = static_cast<uint8_t>(sample.direction >> 4);
++    uint8_t yRaw = static_cast<uint8_t>(sample.direction & 0x0f);
+     const auto axis = [](uint8_t value) {
+         return (static_cast<float>(value) - 7.0f) / 7.0f;
+     };
++
++    const bool keyboardSteer = FixtureKeyboardSteerEnabled();
++    auto stick = keyboardSteer ? ReadClassicLeftStick(0) :
++                                 std::array<float, 2>{axis(xRaw), axis(yRaw)};
++    if (keyboardSteer) {
++        const auto rawAxis = [](float value) {
++            return static_cast<uint8_t>(
++                std::clamp(value, -1.0f, 1.0f) * 7.0f + 7.5f);
++        };
++        xRaw = rawAxis(stick[0]);
++        yRaw = rawAxis(stick[1]);
++    }
+ 
+     try {
+         Memory::Write8(raceState + 0x14,
+                        static_cast<uint8_t>(Memory::Read8(raceState + 0x14) & 0x7f));
+         Memory::Write8(uiState + 0x30,
+                        static_cast<uint8_t>(Memory::Read8(uiState + 0x30) & 0x7f));
+-        float stickX = axis(xRaw);
++        float stickX = stick[0];
++        float stickY = stick[1];
+         const uint32_t raceConfig = Memory::Read32(0x809bd70c);
+         const bool isMirror = Memory::Read8(raceConfig + 0x4155) != 0;
+-        if (isMirror) {
++        if (isMirror && !keyboardSteer) {
+             stickX = -stickX;
+         }
+-        uint8_t trick = sample.trick;
++        uint8_t trick = keyboardSteer ? 0 : sample.trick;
+         if (isMirror) {
+             if (trick == 3) {
+                 trick = 4;
+@@ -1008,13 +1030,13 @@ extern "C" bool KPad_RkgFixture_CalcInner(CpuContext* ctx)
+                 trick = 3;
+             }
+         }
+-        Memory::Write16(raceState + 0x04, sample.face);
++        Memory::Write16(raceState + 0x04, keyboardSteer ? 0x01 : sample.face);
+         Memory::WriteFloat32(raceState + 0x08, stickX);
+-        Memory::WriteFloat32(raceState + 0x0C, axis(yRaw));
++        Memory::WriteFloat32(raceState + 0x0C, stickY);
+         Memory::Write8(raceState + 0x10, xRaw);
+         Memory::Write8(raceState + 0x11, yRaw);
+         Memory::Write8(raceState + 0x12, trick);
+-        Memory::Write8(raceState + 0x13, sample.trick);
++        Memory::Write8(raceState + 0x13, keyboardSteer ? 0 : sample.trick);
+         Memory::Write8(raceState + 0x14,
+                        static_cast<uint8_t>(Memory::Read8(raceState + 0x14) | 0x80));
+ 

--- a/scripts/prepare-android-game-runtime.sh
+++ b/scripts/prepare-android-game-runtime.sh
@@ -40,6 +40,8 @@ patch --batch -p1 -d "$runtime_source" < \
   "$repo_root/patches/wiicompiled-android-private-paths.patch"
 patch --batch -p1 -d "$runtime_source" < \
   "$repo_root/patches/wiicompiled-android-surface-resume.patch"
+patch --batch -p1 -d "$runtime_source" < \
+  "$repo_root/patches/wiicompiled-android-keyboard-steer.patch"
 
 generated_link="$(dirname "$runtime_source")/generated"
 if [[ -e "$generated_link" && ! -L "$generated_link" ]]; then


### PR DESCRIPTION
## Summary
- add an Android-only, debug-marker-gated hybrid that keeps RKG acceleration while routing steering through the existing keyboard stick
- preserve ordinary RKG, keyboard/controller, release, and Apple paths
- document bounded hybrid and exact-staff divergence results, with the original private save restored byte-for-byte

## Validation
- full private Original debug APK build
- debug and release Kotlin compilation
- lintDebug
- strict Android package audit
- repository safety audit
- fresh patch apply/dry-run and diff check
- source verification: 395 hunks plus WiiCompiled/SunPad/WheelWizard pass; stops on the pre-existing ignored rr-pulsar checkout mismatch

No APK/AAB or private game/save/input data is published. A2 remains open for a complete player race/results/save/relaunch, real controller, and physical Android hardware.