### PR TITLE
Android A2: bridge SDL controllers into KPAD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,15 @@ target_compile_options(kartpad_semantics_contract PRIVATE
 )
 add_test(NAME kartpad_semantics_contract COMMAND kartpad_semantics_contract)
 
+add_executable(kartpad_android_gamepad_contract
+  runtime/tests/android_gamepad_contract_tests.cpp)
+target_include_directories(kartpad_android_gamepad_contract PRIVATE runtime/include)
+target_compile_features(kartpad_android_gamepad_contract PRIVATE cxx_std_20)
+target_compile_options(kartpad_android_gamepad_contract PRIVATE
+  -Wall -Wextra -Wpedantic -Werror)
+add_test(NAME kartpad.android.gamepad-contract
+  COMMAND kartpad_android_gamepad_contract)
+
 option(MKW_PRODUCT_BASE "Build the original-disc base product" ON)
 option(MKW_PRODUCT_RETRO_REWIND "Build the Retro Rewind product" OFF)
 option(MKW_BUILD_MACOS "Build the native macOS host" OFF)

--- a/android/app/src/main/cpp/fixture_main.cpp
+++ b/android/app/src/main/cpp/fixture_main.cpp
@@ -8,6 +8,7 @@
 #include <unistd.h>
 
 #include "guest_memory_fixture.h"
+#include "kartpad/android/gamepad_contract.h"
 #include "scheduler_fixture.h"
 
 #include <algorithm>
@@ -25,6 +26,29 @@ constexpr char kLogTag[] = "KartPadFixture";
 void LogError(const char* message) {
   __android_log_print(ANDROID_LOG_ERROR, kLogTag, "%s: %s", message,
                       SDL_GetError());
+}
+
+bool RunAndroidGamepadContract() {
+  using namespace kartpad::android;
+  RawGamepadState input;
+  input.connected = true;
+  input.buttons = kGamepadSouth | kGamepadEast | kGamepadWest |
+                  kGamepadNorth | kGamepadBack | kGamepadStart |
+                  kGamepadLeftShoulder | kGamepadRightShoulder |
+                  kGamepadDpadUp | kGamepadDpadDown |
+                  kGamepadDpadLeft | kGamepadDpadRight;
+  input.left_trigger = kTriggerThreshold;
+  input.right_trigger = kTriggerThreshold;
+  input.left_x = 32767;
+  input.left_y = -32768;
+  const auto mapped = MapGamepadToClassic(input);
+  constexpr uint32_t kExpectedButtons =
+      kClassicA | kClassicB | kClassicX | kClassicY | kClassicMinus |
+      kClassicPlus | kClassicL | kClassicR | kClassicUp | kClassicDown |
+      kClassicLeft | kClassicRight | kClassicZl | kClassicZr;
+  return mapped.connected && mapped.buttons == kExpectedButtons &&
+         mapped.left_stick_x == 1.0f && mapped.left_stick_y == 1.0f &&
+         !MapGamepadToClassic({}).connected;
 }
 
 struct MapState {
@@ -319,6 +343,14 @@ extern "C" __attribute__((visibility("default"))) int SDL_main(int, char**) {
     SDL_Quit();
     return 3;
   }
+  if (!RunAndroidGamepadContract()) {
+    __android_log_print(ANDROID_LOG_ERROR, kLogTag,
+                        "A2 SDL gamepad contract failed");
+    SDL_Quit();
+    return 10;
+  }
+  __android_log_print(ANDROID_LOG_INFO, kLogTag,
+                      "A2 SDL gamepad contract passed");
   SDL_Window* window = SDL_CreateWindow(
       "KartPad", 960, 540, SDL_WINDOW_VULKAN | SDL_WINDOW_HIGH_PIXEL_DENSITY);
   if (window == nullptr) {

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -789,8 +789,11 @@ Its exact public resources install before SDL loads, and a cleared API 36
 launch reaches translated constructors and Vulkan using only app-private
 config/cache/NAND paths before the expected missing-DVD failure. Continue A2 by
 staging the validated ignored DATA directory outside the APK, setting its
-app-private path, and proving controller-driven gameplay without weakening the
-package privacy boundary.
+app-private path, and using the new Aurora-to-Classic SDL controller bridge to
+prove a complete controller-driven player race, results, and save/relaunch
+without weakening the package privacy boundary. The bridge's deterministic
+source-only contract passes on both page-size lanes, but no controller
+acceptance is claimed until an actual controller is attached.
 
 The A0 commands and sanitized result are recorded in
 [`android/README.md`](../android/README.md) and

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -100,12 +100,16 @@ not block offline Retro Rewind support.
    and an Android-only marker can replace only its steering with the debug
    keyboard stick, but neither route completes a race. Exact GCN Mario Circuit
    metadata and the macOS-proven SNES Mario Circuit 3 stream also diverge on
-   Android and must not be used as completion evidence. Establish a complete
+   Android and must not be used as completion evidence. Aurora's discovered
+   SDL pads now feed the Android Classic/KPAD path through a deterministic
+   mapping contract, but no controller was attached, so this is implementation
+   and compile evidence only. Establish a complete
    player race, results, post-race save/relaunch,
    then repeat with a real controller and physical Android hardware. Evidence
    is in `docs/artifacts/2026-09-03/android/a2-emulator-boot-lifecycle.md` and
    `docs/artifacts/2026-09-03/android/a2-debug-input-replay.md`, plus
-   `docs/artifacts/2026-09-03/android/a2-keyboard-steer-diagnostic.md`. A2
+   `docs/artifacts/2026-09-03/android/a2-keyboard-steer-diagnostic.md` and
+   `docs/artifacts/2026-09-03/android/a2-sdl-controller-bridge.md`. A2
    remains open.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -1851,3 +1851,31 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   results/save/relaunch, real controller, and physical Android hardware.
   Evidence:
   `docs/artifacts/2026-09-03/android/a2-keyboard-steer-diagnostic.md`.
+
+## 2026-09-03 — Android A2 SDL controller bridge
+
+- Found that Aurora already opened Android SDL gamepads, but Mario Kart's
+  Classic/KPAD HLE consumed only keyboard, RKG fixture, and the iOS mobile
+  bridge. A connected Android controller therefore could not satisfy A2.
+- Added a narrow public Aurora standard-gamepad snapshot and mapped it into the
+  shared Classic contract. South/east/west/north map to A/B/X/Y, Start/Back to
+  Plus/Minus, shoulders/triggers to L/R/ZL/ZR, D-pad directions directly, and
+  the left stick through an 8,000-unit normalized/inverted deadzone.
+- Explicit port assignments win. Player one may use a sole unassigned pad
+  before A4's settings UI exists; multiple unassigned pads are never guessed.
+  Existing KPAD history emits neutral state after secondary disconnect, and
+  sanitized logs contain no controller identifiers.
+- Added a host CTest and source-only Android marker for the shared mapping.
+  Both API 36 / 4 KiB and API 35 / 16 KiB fixture lanes pass their complete
+  lifecycle suites with the new marker.
+- A fresh prepared private source graph compiled/linked, and a final reproduced
+  tree matches all patched upstream files byte-for-byte. The audited local-only
+  103,433,120-byte APK has SHA-256
+  `7491b416ea3640b8d7a9cb8545fffe41dc625a4d378dd4d0d4abc8293ae22d01`;
+  its stripped 83,536,152-byte `libmain.so` is
+  `15a7c1dfecd40066b5f15dc950bb4d555d4375a09a21553ff9fbf9dd8f6c3c74`.
+- Classification: **Pass for controller-path implementation, deterministic
+  contract, patch reproduction, and private compile/link/package only.** No
+  controller was attached, so live controller and physical-device acceptance
+  remain open. No APK/AAB or private input was published. Evidence:
+  `docs/artifacts/2026-09-03/android/a2-sdl-controller-bridge.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -102,6 +102,17 @@ This is diagnostic capability only and does not narrow A2's remaining player,
 controller, or physical-device gates. Evidence:
 [`docs/artifacts/2026-09-03/android/a2-keyboard-steer-diagnostic.md`](artifacts/2026-09-03/android/a2-keyboard-steer-diagnostic.md).
 
+Android's discovered SDL controllers now reach the Classic/KPAD path through
+a narrow public Aurora snapshot and shared, host-tested mapping contract. A
+lone unassigned controller may drive player one until the native settings UI
+exists; explicit port assignments remain authoritative and multiple
+unassigned pads are never guessed. Both page-size fixture lanes, a clean
+private runtime preparation/link, lint, package/privacy audit, and exact patch
+reproduction pass. No controller was attached, so live controller,
+disconnect/reconnect, rumble, race, and physical-device acceptance remain
+open. Evidence:
+[`docs/artifacts/2026-09-03/android/a2-sdl-controller-bridge.md`](artifacts/2026-09-03/android/a2-sdl-controller-bridge.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-03/android/a2-sdl-controller-bridge.md
+++ b/docs/artifacts/2026-09-03/android/a2-sdl-controller-bridge.md
@@ -1,0 +1,77 @@
+# Android A2 SDL controller bridge
+
+Date: 2026-09-03
+
+Base checkpoint: `02543e9` (`codex/android-a2-keyboard-race`)
+
+Targets: host contract test, `KartPad_API_36_ARM64` (API 36, 4,096-byte
+pages), `KartPad_API_35_PS16K_ARM64` (API 35, 16,384-byte pages), and the
+private Original ARM64 runtime link
+
+## Falsifiable subgoal
+
+Make controllers already discovered by Aurora's SDL layer reach Mario Kart's
+Classic/KPAD input path on Android, without changing Apple input behavior or
+claiming controller acceptance in the absence of attached hardware.
+
+## Implemented contract
+
+Aurora now exposes a narrow, SDL-free public snapshot containing standard
+face buttons, shoulders, Start/Back, D-pad, left stick, and analog triggers.
+KPAD maps that snapshot to the existing Classic Controller representation:
+
+- south/east/west/north to A/B/X/Y;
+- Start/Back to Plus/Minus;
+- shoulders to L/R and analog triggers to ZL/ZR at 16,000;
+- D-pad directions to the matching Classic directions; and
+- the SDL left stick through an inclusive 8,000-unit deadzone, normalized to
+  `[-1, 1]`, with SDL's downward-positive Y axis inverted.
+
+Explicit Aurora player assignments remain authoritative. Until the native
+controller settings UI exists, player one may also consume exactly one
+connected, unassigned controller. The bridge refuses to guess when multiple
+unassigned controllers exist and never steals a controller explicitly
+assigned to another port. Controller input is mixed only when the RKG fixture
+is inactive. Existing trigger/release history supplies a final neutral sample
+after a secondary channel disconnect so held inputs do not remain asserted.
+Sanitized transition logs contain only channel number and connected state.
+
+The mapping is a shared header used by the production patch, a host CTest, and
+the Android source-only fixture. Compile-time assertions lock Aurora's public
+button bits to the KartPad contract.
+
+## Verification
+
+- `kartpad.android.gamepad-contract` passes the disconnected-neutral, complete
+  button map, trigger threshold, axis endpoints, inversion, and inclusive
+  deadzone cases.
+- The source-only API 36 / 4 KiB and API 35 / 16 KiB cold-boot fixtures both
+  emit `A2 SDL gamepad contract passed` while retaining their guest-memory,
+  scheduler/fiber, Vulkan present, rotation, and three background/foreground
+  recreation checks. The audited fixture APK SHA-256 is
+  `b6309fbd054fdac7bd12f724961b03f07af98413ab30217cbcdaaa338935abbd`.
+- A from-scratch prepared private source tree compiled and linked the complete
+  ARM64 Original runtime. After the final transition-log hardening, the
+  preparation script reproduced all three patched upstream files
+  byte-for-byte and the full runtime rebuilt successfully.
+- The final local-only game APK is 103,433,120 bytes with SHA-256
+  `7491b416ea3640b8d7a9cb8545fffe41dc625a4d378dd4d0d4abc8293ae22d01`.
+  Its stripped 83,536,152-byte `libmain.so` has SHA-256
+  `15a7c1dfecd40066b5f15dc950bb4d555d4375a09a21553ff9fbf9dd8f6c3c74`.
+  The strict APK audit passes.
+- Debug lint, release Kotlin compilation, storage-layout contract, repository
+  safety audit, `git diff --check`, and 11-hunk patch verification pass.
+- Both emulators were shut down; `adb devices` was empty after testing.
+
+No game data, translated shards, saves, controller identifiers, captures,
+APK, or AAB were committed, hosted, or published.
+
+## Classification
+
+**Pass for the deterministic mapping contract, reproducible Aurora/KPAD
+integration, both source-only emulator lanes, and the private runtime
+compile/link/package boundary.** No physical or emulated SDL controller was
+available, so connection, live menu navigation, gameplay, disconnect/reconnect,
+rumble, and hands-on behavior remain unaccepted. A2 remains open for a complete
+player race, results, save/relaunch, real controller, and physical Android
+hardware.

--- a/patches/aurora-android-gamepad-snapshot.patch
+++ b/patches/aurora-android-gamepad-snapshot.patch
@@ -1,0 +1,111 @@
+diff --git a/lib/input.cpp b/lib/input.cpp
+--- a/lib/input.cpp
++++ b/lib/input.cpp
+@@ -1,6 +1,8 @@
+ #include "input.hpp"
+ #include "internal.hpp"
+ 
++#include <aurora/input.hpp>
++
+ #include "magic_enum.hpp"
+ 
+ #include <SDL3/SDL_haptic.h>
+@@ -345,6 +347,56 @@ GameController* get_controller_for_player(uint32_t player) noexcept {
+   }
+ 
+   return nullptr;
++}
++
++bool read_standard_gamepad_state(uint32_t player, bool allowSingleUnassigned,
++                                 StandardGamepadState* state) noexcept {
++  if (state == nullptr) {
++    return false;
++  }
++  *state = {};
++
++  GameController* controller = get_controller_for_player(player);
++  if (controller == nullptr && player == 0 && allowSingleUnassigned &&
++      g_GameControllers.size() == 1) {
++    auto& [instance, candidate] = *g_GameControllers.begin();
++    if (player_index(instance) < 0) {
++      controller = &candidate;
++    }
++  }
++  if (controller == nullptr || controller->m_controller == nullptr ||
++      !SDL_GamepadConnected(controller->m_controller)) {
++    return false;
++  }
++
++  state->connected = true;
++  const auto add = [&](SDL_GamepadButton source,
++                       StandardGamepadButton destination) {
++    if (SDL_GetGamepadButton(controller->m_controller, source)) {
++      state->buttons |= destination;
++    }
++  };
++  add(SDL_GAMEPAD_BUTTON_SOUTH, kStandardGamepadSouth);
++  add(SDL_GAMEPAD_BUTTON_EAST, kStandardGamepadEast);
++  add(SDL_GAMEPAD_BUTTON_WEST, kStandardGamepadWest);
++  add(SDL_GAMEPAD_BUTTON_NORTH, kStandardGamepadNorth);
++  add(SDL_GAMEPAD_BUTTON_BACK, kStandardGamepadBack);
++  add(SDL_GAMEPAD_BUTTON_START, kStandardGamepadStart);
++  add(SDL_GAMEPAD_BUTTON_LEFT_SHOULDER, kStandardGamepadLeftShoulder);
++  add(SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER, kStandardGamepadRightShoulder);
++  add(SDL_GAMEPAD_BUTTON_DPAD_UP, kStandardGamepadDpadUp);
++  add(SDL_GAMEPAD_BUTTON_DPAD_DOWN, kStandardGamepadDpadDown);
++  add(SDL_GAMEPAD_BUTTON_DPAD_LEFT, kStandardGamepadDpadLeft);
++  add(SDL_GAMEPAD_BUTTON_DPAD_RIGHT, kStandardGamepadDpadRight);
++  state->leftX = SDL_GetGamepadAxis(controller->m_controller,
++                                   SDL_GAMEPAD_AXIS_LEFTX);
++  state->leftY = SDL_GetGamepadAxis(controller->m_controller,
++                                   SDL_GAMEPAD_AXIS_LEFTY);
++  state->leftTrigger = SDL_GetGamepadAxis(controller->m_controller,
++                                         SDL_GAMEPAD_AXIS_LEFT_TRIGGER);
++  state->rightTrigger = SDL_GetGamepadAxis(controller->m_controller,
++                                          SDL_GAMEPAD_AXIS_RIGHT_TRIGGER);
++  return true;
+ }
+ 
+ Sint32 get_instance_for_player(uint32_t player) noexcept {
+diff --git a/include/aurora/input.hpp b/include/aurora/input.hpp
+new file mode 100644
+--- /dev/null
++++ b/include/aurora/input.hpp
+@@ -0,0 +1,37 @@
++#pragma once
++
++#include <cstdint>
++
++namespace aurora::input {
++
++enum StandardGamepadButton : uint32_t {
++  kStandardGamepadSouth = 1u << 0,
++  kStandardGamepadEast = 1u << 1,
++  kStandardGamepadWest = 1u << 2,
++  kStandardGamepadNorth = 1u << 3,
++  kStandardGamepadBack = 1u << 4,
++  kStandardGamepadStart = 1u << 5,
++  kStandardGamepadLeftShoulder = 1u << 6,
++  kStandardGamepadRightShoulder = 1u << 7,
++  kStandardGamepadDpadUp = 1u << 8,
++  kStandardGamepadDpadDown = 1u << 9,
++  kStandardGamepadDpadLeft = 1u << 10,
++  kStandardGamepadDpadRight = 1u << 11,
++};
++
++struct StandardGamepadState {
++  bool connected = false;
++  uint32_t buttons = 0;
++  int16_t leftX = 0;
++  int16_t leftY = 0;
++  int16_t leftTrigger = 0;
++  int16_t rightTrigger = 0;
++};
++
++// Reads an explicitly assigned controller. Player zero may opt into a lone,
++// unassigned controller so the first connected pad works before a settings UI
++// exists; multiple unassigned controllers are never selected implicitly.
++bool read_standard_gamepad_state(uint32_t player, bool allowSingleUnassigned,
++                                 StandardGamepadState* state) noexcept;
++
++}  // namespace aurora::input

--- a/patches/wiicompiled-android-sdl-controller.patch
+++ b/patches/wiicompiled-android-sdl-controller.patch
@@ -1,0 +1,155 @@
+diff --git a/src/hle/input/kpad.cpp b/src/hle/input/kpad.cpp
+--- a/src/hle/input/kpad.cpp
++++ b/src/hle/input/kpad.cpp
+@@ -6,6 +6,11 @@
+ #include <SDL3/SDL_scancode.h>
+ #include <SDL3/SDL_timer.h>
+ 
++#if defined(__ANDROID__)
++#include <aurora/input.hpp>
++#include "kartpad/android/gamepad_contract.h"
++#endif
++
+ #if defined(__APPLE__)
+ #include <TargetConditionals.h>
+ #endif
+@@ -70,6 +75,9 @@
+ std::array<std::atomic<uint32_t>, 4> g_pendingPresses{};
+ std::array<std::atomic<uint32_t>, 4> g_pendingClassicPresses{};
+ std::array<std::atomic<bool>, 4> g_keyboardConnected{};
++#if defined(__ANDROID__)
++std::array<std::atomic<bool>, 4> g_androidControllerConnected{};
++#endif
+ std::atomic<bool> g_fixtureArmRequested{false};
+ std::atomic<bool> g_preciseMenuPulseRequested{false};
+ std::array<std::atomic<uint64_t>, SDL_SCANCODE_COUNT> g_syntheticExpiryNs{};
+@@ -659,6 +667,50 @@
+     return {x, y};
+ }
+ 
++#if defined(__ANDROID__)
++kartpad::android::ClassicInputState ReadAndroidClassicInput(uint32_t chan)
++{
++    using namespace kartpad::android;
++    static_assert(aurora::input::kStandardGamepadSouth == kGamepadSouth);
++    static_assert(aurora::input::kStandardGamepadEast == kGamepadEast);
++    static_assert(aurora::input::kStandardGamepadWest == kGamepadWest);
++    static_assert(aurora::input::kStandardGamepadNorth == kGamepadNorth);
++    static_assert(aurora::input::kStandardGamepadBack == kGamepadBack);
++    static_assert(aurora::input::kStandardGamepadStart == kGamepadStart);
++    static_assert(aurora::input::kStandardGamepadLeftShoulder ==
++                  kGamepadLeftShoulder);
++    static_assert(aurora::input::kStandardGamepadRightShoulder ==
++                  kGamepadRightShoulder);
++    static_assert(aurora::input::kStandardGamepadDpadUp == kGamepadDpadUp);
++    static_assert(aurora::input::kStandardGamepadDpadDown == kGamepadDpadDown);
++    static_assert(aurora::input::kStandardGamepadDpadLeft == kGamepadDpadLeft);
++    static_assert(aurora::input::kStandardGamepadDpadRight ==
++                  kGamepadDpadRight);
++    aurora::input::StandardGamepadState snapshot;
++    RawGamepadState raw;
++    const bool connected = aurora::input::read_standard_gamepad_state(
++        chan, chan == 0, &snapshot);
++    const bool wasConnected =
++        g_androidControllerConnected[chan].exchange(connected,
++                                                     std::memory_order_acq_rel);
++    if (connected != wasConnected) {
++        std::fprintf(stderr, "[input] Android SDL controller channel %u %s\n",
++                     chan, connected ? "connected" : "disconnected");
++    }
++    if (!connected) {
++        return MapGamepadToClassic(raw);
++    }
++
++    raw.connected = snapshot.connected;
++    raw.buttons = snapshot.buttons;
++    raw.left_x = snapshot.leftX;
++    raw.left_y = snapshot.leftY;
++    raw.left_trigger = snapshot.leftTrigger;
++    raw.right_trigger = snapshot.rightTrigger;
++    return MapGamepadToClassic(raw);
++}
++#endif
++
+ uint32_t ClassicButtonsForGhost(const GhostSample& sample)
+ {
+     uint32_t buttons = 0;
+@@ -777,8 +829,12 @@
+ 
+ extern "C" bool KPAD_IsKeyboardChannelConnected(uint32_t chan)
+ {
+-    return chan < g_keyboardConnected.size() &&
+-           (chan == 0 || g_keyboardConnected[chan].load(std::memory_order_acquire));
++    if (chan >= g_keyboardConnected.size()) return false;
++#if defined(__ANDROID__)
++    if (ReadAndroidClassicInput(chan).connected) return true;
++#endif
++    return chan == 0 ||
++           g_keyboardConnected[chan].load(std::memory_order_acquire);
+ }
+ 
+ extern "C" int32_t KPAD__Read_HLE(uint32_t chan, uint32_t statusPtr, uint32_t count)
+@@ -801,8 +857,16 @@
+ #else
+     const bool mobileConnected = false;
+ #endif
++#if defined(__ANDROID__)
++    const auto androidInput = ReadAndroidClassicInput(chan);
++    const bool androidConnected = androidInput.connected;
++#else
++    const bool androidConnected = false;
++#endif
+     const bool connected = chan == 0 || mobileConnected ||
+-        g_keyboardConnected[chan].load(std::memory_order_acquire);
++        androidConnected ||
++        g_keyboardConnected[chan].load(std::memory_order_acquire) ||
++        g_previousButtons[chan] != 0 || g_previousClassicButtons[chan] != 0;
+     if (!connected) return 0;
+     const uint32_t pending = g_pendingPresses[chan].exchange(0, std::memory_order_acq_rel);
+     const uint32_t pendingClassic = g_pendingClassicPresses[chan].exchange(0, std::memory_order_acq_rel);
+@@ -831,6 +895,13 @@
+         stick = {mobileInput.leftStickX, mobileInput.leftStickY};
+     }
+ #endif
++#if defined(__ANDROID__)
++    if (!fixtureActive && androidConnected) {
++        classicHold |= androidInput.buttons;
++        hold |= CoreButtonsForClassic(androidInput.buttons);
++        stick = {androidInput.left_stick_x, androidInput.left_stick_y};
++    }
++#endif
+     const uint32_t previous = g_previousButtons[chan];
+     const uint32_t previousClassic = g_previousClassicButtons[chan];
+     const uint32_t trigger = (fixtureActive ? 0 : pending) | (hold & ~previous);
+@@ -885,8 +956,15 @@
+ #else
+     const bool mobileConnected = false;
+ #endif
+-    if (chan != 0 && !mobileConnected &&
+-        !g_keyboardConnected[chan].load(std::memory_order_acquire)) {
++#if defined(__ANDROID__)
++    const auto androidInput = ReadAndroidClassicInput(chan);
++    const bool androidConnected = androidInput.connected;
++#else
++    const bool androidConnected = false;
++#endif
++    if (chan != 0 && !mobileConnected && !androidConnected &&
++        !g_keyboardConnected[chan].load(std::memory_order_acquire) &&
++        g_previousButtons[chan] == 0 && g_previousClassicButtons[chan] == 0) {
+         return 0;
+     }
+     const uint32_t pending = g_pendingPresses[chan].exchange(0, std::memory_order_acq_rel);
+@@ -912,6 +990,13 @@
+             stick = {mobileInput.leftStickX, mobileInput.leftStickY};
+         }
+ #endif
++#if defined(__ANDROID__)
++        if (!fixtureActive && androidConnected) {
++            classicButtons |= androidInput.buttons;
++            coreButtons |= CoreButtonsForClassic(androidInput.buttons);
++            stick = {androidInput.left_stick_x, androidInput.left_stick_y};
++        }
++#endif
+         Memory::Write16(statusPtr + 0x00,
+                         static_cast<uint16_t>(coreButtons));
+         Memory::Write16(statusPtr + 0x2A,

--- a/runtime/include/kartpad/android/gamepad_contract.h
+++ b/runtime/include/kartpad/android/gamepad_contract.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+namespace kartpad::android {
+
+enum GamepadButton : uint32_t {
+  kGamepadSouth = 1u << 0,
+  kGamepadEast = 1u << 1,
+  kGamepadWest = 1u << 2,
+  kGamepadNorth = 1u << 3,
+  kGamepadBack = 1u << 4,
+  kGamepadStart = 1u << 5,
+  kGamepadLeftShoulder = 1u << 6,
+  kGamepadRightShoulder = 1u << 7,
+  kGamepadDpadUp = 1u << 8,
+  kGamepadDpadDown = 1u << 9,
+  kGamepadDpadLeft = 1u << 10,
+  kGamepadDpadRight = 1u << 11,
+};
+
+enum ClassicButton : uint32_t {
+  kClassicUp = 0x00000001,
+  kClassicLeft = 0x00000002,
+  kClassicZr = 0x00000004,
+  kClassicX = 0x00000008,
+  kClassicA = 0x00000010,
+  kClassicY = 0x00000020,
+  kClassicB = 0x00000040,
+  kClassicZl = 0x00000080,
+  kClassicR = 0x00000200,
+  kClassicPlus = 0x00000400,
+  kClassicMinus = 0x00001000,
+  kClassicL = 0x00002000,
+  kClassicDown = 0x00004000,
+  kClassicRight = 0x00008000,
+};
+
+struct RawGamepadState {
+  bool connected = false;
+  uint32_t buttons = 0;
+  int16_t left_x = 0;
+  int16_t left_y = 0;
+  int16_t left_trigger = 0;
+  int16_t right_trigger = 0;
+};
+
+struct ClassicInputState {
+  bool connected = false;
+  uint32_t buttons = 0;
+  float left_stick_x = 0.0f;
+  float left_stick_y = 0.0f;
+};
+
+inline constexpr int32_t kStickDeadzone = 8000;
+inline constexpr int32_t kTriggerThreshold = 16000;
+
+inline float NormalizeStickAxis(int16_t raw) {
+  const int32_t value = raw;
+  if (value >= -kStickDeadzone && value <= kStickDeadzone) {
+    return 0.0f;
+  }
+  if (value > 0) {
+    return static_cast<float>(value - kStickDeadzone) /
+           static_cast<float>(32767 - kStickDeadzone);
+  }
+  return static_cast<float>(value + kStickDeadzone) /
+         static_cast<float>(32768 - kStickDeadzone);
+}
+
+inline ClassicInputState MapGamepadToClassic(const RawGamepadState& input) {
+  ClassicInputState output;
+  output.connected = input.connected;
+  if (!input.connected) {
+    return output;
+  }
+
+  const auto map = [&](GamepadButton source, ClassicButton destination) {
+    if ((input.buttons & static_cast<uint32_t>(source)) != 0) {
+      output.buttons |= static_cast<uint32_t>(destination);
+    }
+  };
+  map(kGamepadSouth, kClassicA);
+  map(kGamepadEast, kClassicB);
+  map(kGamepadWest, kClassicX);
+  map(kGamepadNorth, kClassicY);
+  map(kGamepadBack, kClassicMinus);
+  map(kGamepadStart, kClassicPlus);
+  map(kGamepadLeftShoulder, kClassicL);
+  map(kGamepadRightShoulder, kClassicR);
+  map(kGamepadDpadUp, kClassicUp);
+  map(kGamepadDpadDown, kClassicDown);
+  map(kGamepadDpadLeft, kClassicLeft);
+  map(kGamepadDpadRight, kClassicRight);
+  if (input.left_trigger >= kTriggerThreshold) {
+    output.buttons |= kClassicZl;
+  }
+  if (input.right_trigger >= kTriggerThreshold) {
+    output.buttons |= kClassicZr;
+  }
+
+  output.left_stick_x =
+      std::clamp(NormalizeStickAxis(input.left_x), -1.0f, 1.0f);
+  output.left_stick_y =
+      std::clamp(-NormalizeStickAxis(input.left_y), -1.0f, 1.0f);
+  return output;
+}
+
+}  // namespace kartpad::android

--- a/runtime/tests/android_gamepad_contract_tests.cpp
+++ b/runtime/tests/android_gamepad_contract_tests.cpp
@@ -1,0 +1,81 @@
+#include "kartpad/android/gamepad_contract.h"
+
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+
+namespace {
+
+bool Near(float actual, float expected) {
+  return std::fabs(actual - expected) < 0.0001f;
+}
+
+bool Require(bool condition, const char* message) {
+  if (!condition) {
+    std::cerr << "FAIL: " << message << '\n';
+  }
+  return condition;
+}
+
+}  // namespace
+
+int main() {
+  using namespace kartpad::android;
+  bool passed = true;
+
+  const auto disconnected = MapGamepadToClassic({});
+  passed &= Require(!disconnected.connected && disconnected.buttons == 0 &&
+                        Near(disconnected.left_stick_x, 0.0f) &&
+                        Near(disconnected.left_stick_y, 0.0f),
+                    "disconnected controllers must be neutral");
+
+  RawGamepadState buttons;
+  buttons.connected = true;
+  buttons.buttons = kGamepadSouth | kGamepadEast | kGamepadWest |
+                    kGamepadNorth | kGamepadBack | kGamepadStart |
+                    kGamepadLeftShoulder | kGamepadRightShoulder |
+                    kGamepadDpadUp | kGamepadDpadDown |
+                    kGamepadDpadLeft | kGamepadDpadRight;
+  buttons.left_trigger = kTriggerThreshold;
+  buttons.right_trigger = kTriggerThreshold;
+  const auto mapped_buttons = MapGamepadToClassic(buttons);
+  constexpr uint32_t kAllExpected =
+      kClassicA | kClassicB | kClassicX | kClassicY | kClassicMinus |
+      kClassicPlus | kClassicL | kClassicR | kClassicUp | kClassicDown |
+      kClassicLeft | kClassicRight | kClassicZl | kClassicZr;
+  passed &= Require(mapped_buttons.connected &&
+                        mapped_buttons.buttons == kAllExpected,
+                    "standard SDL buttons must map to Classic buttons");
+
+  buttons.left_trigger = kTriggerThreshold - 1;
+  buttons.right_trigger = kTriggerThreshold - 1;
+  buttons.buttons = 0;
+  passed &= Require(MapGamepadToClassic(buttons).buttons == 0,
+                    "triggers must remain released below the threshold");
+
+  RawGamepadState axes;
+  axes.connected = true;
+  axes.left_x = 32767;
+  axes.left_y = -32768;
+  auto mapped_axes = MapGamepadToClassic(axes);
+  passed &= Require(Near(mapped_axes.left_stick_x, 1.0f) &&
+                        Near(mapped_axes.left_stick_y, 1.0f),
+                    "positive X and SDL-up must map to positive Classic axes");
+  axes.left_x = -32768;
+  axes.left_y = 32767;
+  mapped_axes = MapGamepadToClassic(axes);
+  passed &= Require(Near(mapped_axes.left_stick_x, -1.0f) &&
+                        Near(mapped_axes.left_stick_y, -1.0f),
+                    "negative X and SDL-down must map to negative Classic axes");
+  axes.left_x = kStickDeadzone;
+  axes.left_y = -kStickDeadzone;
+  mapped_axes = MapGamepadToClassic(axes);
+  passed &= Require(Near(mapped_axes.left_stick_x, 0.0f) &&
+                        Near(mapped_axes.left_stick_y, 0.0f),
+                    "the inclusive deadzone must map to neutral");
+
+  if (passed) {
+    std::cout << "Android SDL gamepad contract passed\n";
+  }
+  return passed ? 0 : 1;
+}

--- a/scripts/prepare-android-game-runtime.sh
+++ b/scripts/prepare-android-game-runtime.sh
@@ -34,6 +34,8 @@ KARTPAD_PREPARE_ONLY=1 "$repo_root/scripts/prepare-ios-game-runtime.sh" \
   "$translation_root" "$runtime_source" "$runtime_build" "$product"
 patch --batch -p1 -d "$runtime_source/aurora-main" < \
   "$repo_root/patches/aurora-android-public-sdl-surface-lock.patch"
+patch --batch -p1 -d "$runtime_source/aurora-main" < \
+  "$repo_root/patches/aurora-android-gamepad-snapshot.patch"
 patch --batch -p1 -d "$runtime_source" < \
   "$repo_root/patches/wiicompiled-android-runtime.patch"
 patch --batch -p1 -d "$runtime_source" < \
@@ -42,6 +44,8 @@ patch --batch -p1 -d "$runtime_source" < \
   "$repo_root/patches/wiicompiled-android-surface-resume.patch"
 patch --batch -p1 -d "$runtime_source" < \
   "$repo_root/patches/wiicompiled-android-keyboard-steer.patch"
+patch --batch -p1 -d "$runtime_source" < \
+  "$repo_root/patches/wiicompiled-android-sdl-controller.patch"
 
 generated_link="$(dirname "$runtime_source")/generated"
 if [[ -e "$generated_link" && ! -L "$generated_link" ]]; then

--- a/scripts/run-android-fixture.sh
+++ b/scripts/run-android-fixture.sh
@@ -84,6 +84,7 @@ wait_for_marker \
   "A1 guest memory passed reserve_bytes=4294967296"
 wait_for_marker \
   "A1 ELF scheduler passed operations=2000000 hash=0x7287563387fb1677 fiber_switches=1000000"
+wait_for_marker "A2 SDL gamepad contract passed"
 wait_for_marker \
   "A1 Vulkan present passed abi=arm64-v8a page_size=$expected_page_size"
 
@@ -112,4 +113,4 @@ if "$adb" logcat -d -v brief KartPadFixture:E '*:S' | grep -q .; then
   exit 1
 fi
 
-echo "Android A1 fixture passed: avd=$avd api=$("$adb" shell getprop ro.build.version.sdk | tr -d '\r') abi=$abi page_size=$page_size guest_memory=4GiB-aliased-protected scheduler=2M-operations fiber=1M-register-checked-switches backend=Vulkan readback_rgba=20-80-e0-ff surface=presented lifecycle=orientation-plus-3-background-foreground-recreations"
+echo "Android A1/A2 fixture passed: avd=$avd api=$("$adb" shell getprop ro.build.version.sdk | tr -d '\r') abi=$abi page_size=$page_size guest_memory=4GiB-aliased-protected scheduler=2M-operations fiber=1M-register-checked-switches gamepad_contract=passed backend=Vulkan readback_rgba=20-80-e0-ff surface=presented lifecycle=orientation-plus-3-background-foreground-recreations"


### PR DESCRIPTION
## Summary
- expose a narrow public Aurora standard-gamepad snapshot without leaking SDL/container internals
- map Android SDL gamepads into Mario Kart Classic/KPAD input with deterministic buttons, triggers, deadzone, and disconnect-safe neutral state
- add shared host/source-only contract tests, both page-size fixture evidence, and exact private runtime build/audit evidence

## Validation
- `ctest --test-dir build/g15-host-tests -R kartpad.android.gamepad-contract --output-on-failure`
- `./scripts/run-android-fixture.sh KartPad_API_36_ARM64`
- `./scripts/run-android-fixture.sh KartPad_API_35_PS16K_ARM64`
- clean prepared private ARM64 runtime build and final incremental rebuild
- `./scripts/audit-android-package.sh android/app/build/outputs/apk/debug/app-debug.apk`
- `:app:lintDebug :app:compileReleaseKotlin`
- `./scripts/check-repo-safety.sh`
- 11-hunk patch verification and byte-identical prepared-source comparison

## Scope
No physical or emulated SDL controller was available, so this PR claims implementation/compile/contract evidence only. Live controller behavior, disconnect/reconnect, rumble, a complete player race/results/save, and physical Android hardware remain open. No APK/AAB or private game input is published.