### PR TITLE
Add tvOS settings and correct aspect presentation

### DIFF
--- a/apple/tvos/KartPadTVRuntimeHost.mm
+++ b/apple/tvos/KartPadTVRuntimeHost.mm
@@ -7,7 +7,6 @@
 #import "SunPadSettings.h"
 
 #import <CommonCrypto/CommonDigest.h>
-#import <GameController/GameController.h>
 #import <UIKit/UIKit.h>
 
 #include <algorithm>
@@ -164,13 +163,6 @@ BOOL KartPadTVWriteRuntimePaths(NSError **error) {
   return NO;
 }
 
-BOOL KartPadTVHasExtendedController() {
-  for (GCController *controller in GCController.controllers) {
-    if (controller.extendedGamepad != nil) return YES;
-  }
-  return NO;
-}
-
 UIButton *KartPadTVButton(NSString *title, UIColor *color,
                           void (^handler)(void)) {
   UIButtonConfiguration *configuration =
@@ -275,7 +267,6 @@ UIButton *KartPadTVButton(NSString *title, UIColor *color,
 - (void)showGameDataState;
 - (void)selectRetroRewind:(BOOL)retroRewind;
 - (void)finishWithRetroRewind:(BOOL)retroRewind;
-- (void)showControllerRequired:(BOOL)retroRewind;
 - (void)downloadRetroRewind;
 - (void)installArchiveAtPath:(NSString *)archivePath;
 - (UIWindowScene *)availableScene;
@@ -310,40 +301,12 @@ UIButton *KartPadTVButton(NSString *title, UIColor *color,
     [self.root showStatus:message buttons:@[retry]];
     return;
   }
-  __weak KartPadTVLaunchHost *weakSelf = self;
-  UIButton *original = KartPadTVButton(@"Mario Kart Wii", UIColor.systemBlueColor, ^{
-    [weakSelf selectRetroRewind:NO];
-  });
-  UIButton *retro = KartPadTVButton(@"Retro Rewind", UIColor.systemPinkColor, ^{
-    [weakSelf selectRetroRewind:YES];
-  });
-  [self.root showStatus:
-      @"Choose a mode. An Extended Gamepad is required for gameplay."
-                    buttons:@[original, retro]];
-}
-
-- (void)showControllerRequired:(BOOL)retroRewind {
-  __weak KartPadTVLaunchHost *weakSelf = self;
-  UIButton *discover = KartPadTVButton(@"Find Controller", UIColor.systemBlueColor, ^{
-    [GCController startWirelessControllerDiscoveryWithCompletionHandler:^{
-      dispatch_async(dispatch_get_main_queue(), ^{
-        [weakSelf selectRetroRewind:retroRewind];
-      });
-    }];
-  });
-  UIButton *back = KartPadTVButton(@"Back", UIColor.systemGrayColor, ^{
-    [weakSelf showGameDataState];
-  });
-  [self.root showStatus:
-      @"Connect an Extended Gamepad in Apple TV Settings. The Siri Remote can operate setup screens, but it is not a supported racing controller."
-                    buttons:@[discover, back]];
+  NSString *profile =
+      [NSUserDefaults.standardUserDefaults stringForKey:kKartPadTVProfileKey];
+  [self selectRetroRewind:[profile isEqualToString:@"retro_rewind"]];
 }
 
 - (void)finishWithRetroRewind:(BOOL)retroRewind {
-  if (!KartPadTVHasExtendedController()) {
-    [self showControllerRequired:retroRewind];
-    return;
-  }
   NSError *error = nil;
   if (!KartPadTVWriteRuntimePaths(&error)) {
     [self showFailure:@"KartPad could not prepare its runtime paths."
@@ -525,7 +488,7 @@ extern "C" bool KartPadMobileReadRuntimeSettings(
     KartPadMobileRuntimeSettings *settings) {
   if (settings == nullptr) return false;
   SunPadSettings *source = SunPadSettings.sharedSettings;
-  settings->aspectRatioMode = 1;
+  settings->aspectRatioMode = static_cast<int>(source.aspectRatioMode);
   settings->resolutionScale = source.renderScaleFloat;
   settings->showFps = source.showFPSCounter ? 1 : 0;
   return true;

--- a/apple/tvos/Settings.bundle/Root.plist
+++ b/apple/tvos/Settings.bundle/Root.plist
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreferenceSpecifiers</key>
+	<array>
+		<dict>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+			<key>Title</key>
+			<string>Games</string>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Title</key>
+			<string>Game version</string>
+			<key>Key</key>
+			<string>KartPadTVRuntimeProfile</string>
+			<key>DefaultValue</key>
+			<string>base</string>
+			<key>Titles</key>
+			<array>
+				<string>Mario Kart Wii</string>
+				<string>Retro Rewind</string>
+			</array>
+			<key>Values</key>
+			<array>
+				<string>base</string>
+				<string>retro_rewind</string>
+			</array>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Title</key>
+			<string>Aspect ratio</string>
+			<key>Key</key>
+			<string>SunPadAspectRatioMode</string>
+			<key>DefaultValue</key>
+			<integer>0</integer>
+			<key>Titles</key>
+			<array>
+				<string>Original 4:3</string>
+				<string>16:9</string>
+				<string>Fill screen</string>
+			</array>
+			<key>Values</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+				<integer>2</integer>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/patches/wiicompiled-ios-settings-bridge.patch
+++ b/patches/wiicompiled-ios-settings-bridge.patch
@@ -106,6 +106,37 @@ index db9be6c..1fb9754 100644
      // Wait for the frame worker's DONE phase: it has replayed the previous frame's ImGui draw lists
      // and started the next ImGui frame, so all overlay callers can now safely issue ImGui commands.
      aurora_wait_for_frame_worker();
+diff --git a/src/hle/sc.cpp b/src/hle/sc.cpp
+--- a/src/hle/sc.cpp
++++ b/src/hle/sc.cpp
+@@ -1,6 +1,12 @@
+ #include "hle_stubs.h"
+ 
++#if defined(__APPLE__)
++#include <TargetConditionals.h>
++#if TARGET_OS_IOS || TARGET_OS_TV
++#include "kartpad_mobile_runtime_host.h"
++#endif
++#endif
+ #include "console_identity.h"
+ #include <cstdlib>
+ #include <cstddef>
+ #include <cstdint>
+@@ -32,6 +38,13 @@
+ // 0x801B1BE4 -> SCGetAspectRatio()
+ // Returns: 0 = 4:3, 1 = 16:9
+ extern "C" uint32_t SCGetAspectRatio_HLE()
+ {
+-    return RuntimeConfigFile::WidescreenEnabled(true) ? 1u : 0u;
++    bool widescreen = RuntimeConfigFile::WidescreenEnabled(true);
++#if defined(__APPLE__) && (TARGET_OS_IOS || TARGET_OS_TV)
++    KartPadMobileRuntimeSettings settings{};
++    if (KartPadMobileReadRuntimeSettings(&settings)) {
++        widescreen = settings.aspectRatioMode != 0;
++    }
++#endif
++    return widescreen ? 1u : 0u;
+ }
 diff --git a/src/dynamic_aspect.cpp b/src/dynamic_aspect.cpp
 index 5c1601c..0a56fc2 100644
 --- a/src/dynamic_aspect.cpp
@@ -147,8 +178,7 @@ index 5c1601c..0a56fc2 100644
 +    ConfigureMkwMobileAspectMode(widescreen ? 2 : 0, surfaceWidth, surfaceHeight);
 +}
 +
-+void ConfigureMkwMobileAspectMode(int aspectMode, uint32_t surfaceWidth,
-+                                  uint32_t surfaceHeight) {
++void ConfigureMkwMobileAspectMode(int aspectMode, uint32_t, uint32_t) {
 +    g_aspectMode = std::clamp(aspectMode, 0, 2);
 +    const bool widescreen = g_aspectMode != 0;
      g_widescreenConfigured = widescreen;
@@ -165,7 +195,8 @@ index 5c1601c..0a56fc2 100644
 -    AuroraSetViewportPolicy(AURORA_VIEWPORT_FIT);
 -    VILockAspectRatio(4, 3);
 -    ApplyEggScreenRecords(surfaceWidth, surfaceHeight);
-+    UpdateMkwDynamicAspectSurface(surfaceWidth, surfaceHeight);
++    // Defer viewport policy, VI presentation aspect, and guest EGG updates until
++    // the post-initialization Update call has a live window.
  }
 diff --git a/src/main.cpp b/src/main.cpp
 index 7338f78..0f51bc1 100644

--- a/patches/wiicompiled-tvos-runtime.patch
+++ b/patches/wiicompiled-tvos-runtime.patch
@@ -36,7 +36,7 @@
          _DISABLE_STRING_ANNOTATION _DISABLE_VECTOR_ANNOTATION TARGET_PC)
      target_compile_features(${target} PRIVATE cxx_std_20)
      mkw_apply_common_compile_options(${target})
-@@ -390,7 +390,113 @@
+@@ -390,7 +390,112 @@
          XCODE_ATTRIBUTE_SUPPORTS_MACCATALYST NO
          XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2")
  endif()

--- a/patches/wiicompiled-tvos-runtime.patch
+++ b/patches/wiicompiled-tvos-runtime.patch
@@ -36,7 +36,7 @@
          _DISABLE_STRING_ANNOTATION _DISABLE_VECTOR_ANNOTATION TARGET_PC)
      target_compile_features(${target} PRIVATE cxx_std_20)
      mkw_apply_common_compile_options(${target})
-@@ -390,7 +390,104 @@
+@@ -390,7 +390,113 @@
          XCODE_ATTRIBUTE_SUPPORTS_MACCATALYST NO
          XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2")
  endif()
@@ -59,8 +59,13 @@
 +        "${MKW_KARTPAD_IOS_DIR}/PrivacyInfo.xcprivacy")
 +    set(MKW_KARTPAD_TVOS_ASSETS
 +        "${MKW_KARTPAD_TVOS_DIR}/Assets.xcassets")
++    set(MKW_KARTPAD_TVOS_SETTINGS
++        "${MKW_KARTPAD_TVOS_DIR}/Settings.bundle")
 +    if(NOT EXISTS "${MKW_KARTPAD_TVOS_ASSETS}/Contents.json")
 +        message(FATAL_ERROR "Missing KartPad tvOS asset catalog")
++    endif()
++    if(NOT EXISTS "${MKW_KARTPAD_TVOS_SETTINGS}/Root.plist")
++        message(FATAL_ERROR "Missing KartPad tvOS Settings bundle")
 +    endif()
 +    if(NOT EXISTS "${MKW_KARTPAD_MINIZIP_SOURCE_DIR}/CMakeLists.txt")
 +        message(FATAL_ERROR "Missing pinned minizip-ng source for tvOS")
@@ -98,7 +103,8 @@
 +
 +    function(mkw_configure_kartpad_tvos target output_name)
 +        target_sources(${target} PRIVATE ${MKW_KARTPAD_TVOS_SOURCES}
-+            "${MKW_KARTPAD_TVOS_PRIVACY_MANIFEST}" "${MKW_KARTPAD_TVOS_ASSETS}")
++            "${MKW_KARTPAD_TVOS_PRIVACY_MANIFEST}" "${MKW_KARTPAD_TVOS_ASSETS}"
++            "${MKW_KARTPAD_TVOS_SETTINGS}")
 +        target_include_directories(${target} PRIVATE
 +            "${MKW_KARTPAD_TVOS_DIR}"
 +            "${MKW_KARTPAD_IOS_DIR}"
@@ -112,6 +118,8 @@
 +        set_source_files_properties("${MKW_KARTPAD_TVOS_PRIVACY_MANIFEST}"
 +            PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 +        set_source_files_properties("${MKW_KARTPAD_TVOS_ASSETS}"
++            PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
++        set_source_files_properties("${MKW_KARTPAD_TVOS_SETTINGS}"
 +            PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 +        target_link_options(${target} PRIVATE "-ObjC")
 +        target_link_libraries(${target} PRIVATE MINIZIP::minizip

--- a/scripts/audit-tvos-app.sh
+++ b/scripts/audit-tvos-app.sh
@@ -13,14 +13,16 @@ case "${expected_platform}" in TVOS|TVOSSIMULATOR) ;; *) exit 64 ;; esac
 plist="${app}/Info.plist"
 binary="${app}/KartPad"
 assets_car="${app}/Assets.car"
+settings_bundle="${app}/Settings.bundle/Root.plist"
 test -d "${app}"
 test -x "${binary}"
 test -f "${plist}"
 test -f "${app}/PrivacyInfo.xcprivacy"
 test -f "${assets_car}"
+test -f "${settings_bundle}"
 test -f "${app}/initial_pipeline_cache.db"
 test -f "${app}/dsp_coef.bin"
-plutil -lint "${plist}" "${app}/PrivacyInfo.xcprivacy" >/dev/null
+plutil -lint "${plist}" "${app}/PrivacyInfo.xcprivacy" "${settings_bundle}" >/dev/null
 test "$(plutil -extract CFBundleIdentifier raw "${plist}")" = \
   "${expected_bundle_identifier}"
 test "$(plutil -extract CFBundleExecutable raw "${plist}")" = "KartPad"
@@ -30,6 +32,12 @@ test "$(plutil -extract GCSupportedGameControllers.0.ProfileName raw "${plist}")
 test "$(plutil -extract CFBundleIcons.CFBundlePrimaryIcon raw "${plist}")" = "App Icon - Small"
 test "$(plutil -extract TVTopShelfImage.TVTopShelfPrimaryImage raw "${plist}")" = "Top Shelf Image"
 test "$(plutil -extract UIApplicationSceneManifest.UISceneConfigurations.UIWindowSceneSessionRoleApplication.0.UISceneDelegateClassName raw "${plist}")" = "SDLUIKitSceneDelegate"
+test "$(plutil -extract PreferenceSpecifiers.1.Key raw "${settings_bundle}")" = \
+  "KartPadTVRuntimeProfile"
+test "$(plutil -extract PreferenceSpecifiers.1.DefaultValue raw "${settings_bundle}")" = "base"
+test "$(plutil -extract PreferenceSpecifiers.2.Key raw "${settings_bundle}")" = \
+  "SunPadAspectRatioMode"
+test "$(plutil -extract PreferenceSpecifiers.2.DefaultValue raw "${settings_bundle}")" = "0"
 
 asset_info="$(xcrun assetutil --info "${assets_car}")"
 for asset in '"Name" : "App Icon - Small"' \
@@ -81,7 +89,7 @@ for required in \
 done
 for contract in \
   'KartPad for Apple TV' \
-  'The Siri Remote can operate setup screens, but it is not a supported racing controller.' \
+  'KartPadTVRuntimeProfile' \
   'Download Official Pack' \
   'The pack may be purged by tvOS and can be downloaded again.'; do
   rg -a -F -q "${contract}" "${binary}" || {

--- a/tests/test_tvos_contract.py
+++ b/tests/test_tvos_contract.py
@@ -47,16 +47,78 @@ class TvOSContractTests(unittest.TestCase):
         )
         self.assertIn("SunPadDiagnostics.mm", diagnostics)
 
-    def test_extended_gamepad_is_explicit_and_siri_remote_is_not_gameplay(self):
+    def test_extended_gamepad_is_explicit_and_settings_own_choices(self):
         with (ROOT / "apple/tvos/RuntimeInfo.plist").open("rb") as handle:
             info = plistlib.load(handle)
         self.assertTrue(info["GCSupportsControllerUserInteraction"])
         self.assertEqual(
             info["GCSupportedGameControllers"], [{"ProfileName": "ExtendedGamepad"}]
         )
+        with (ROOT / "apple/tvos/Settings.bundle/Root.plist").open("rb") as handle:
+            settings = plistlib.load(handle)
+        specifiers = {
+            specifier.get("Key"): specifier
+            for specifier in settings["PreferenceSpecifiers"]
+            if "Key" in specifier
+        }
+        profile = specifiers["KartPadTVRuntimeProfile"]
+        self.assertEqual(profile["Type"], "PSMultiValueSpecifier")
+        self.assertEqual(profile["DefaultValue"], "base")
+        self.assertEqual(profile["Values"], ["base", "retro_rewind"])
+        aspect = specifiers["SunPadAspectRatioMode"]
+        self.assertEqual(aspect["Type"], "PSMultiValueSpecifier")
+        self.assertEqual(aspect["DefaultValue"], 0)
+        self.assertEqual(aspect["Values"], [0, 1, 2])
+        runtime_patch = (
+            ROOT / "patches/wiicompiled-tvos-runtime.patch"
+        ).read_text()
+        self.assertIn("MKW_KARTPAD_TVOS_SETTINGS", runtime_patch)
         host = (ROOT / "apple/tvos/KartPadTVRuntimeHost.mm").read_text()
-        self.assertIn("Siri Remote", host)
-        self.assertIn("not a supported racing controller", host)
+        self.assertIn("stringForKey:kKartPadTVProfileKey", host)
+        self.assertIn("source.aspectRatioMode", host)
+        self.assertNotIn("Siri Remote", host)
+        self.assertNotIn("showControllerRequired", host)
+        self.assertNotIn("Choose a mode", host)
+        self.assertNotIn("settings->aspectRatioMode = 1", host)
+
+    def test_tvos_aspect_modes_preserve_original_and_native_widescreen(self):
+        settings_bridge = (
+            ROOT / "patches/wiicompiled-ios-settings-bridge.patch"
+        ).read_text()
+        self.assertIn("AURORA_VIEWPORT_FIT", settings_bridge)
+        self.assertIn("AURORA_VIEWPORT_STRETCH", settings_bridge)
+        self.assertIn("VILockAspectRatio(4, 3)", settings_bridge)
+        self.assertIn("VILockAspectRatio(16, 9)", settings_bridge)
+        self.assertIn("diff --git a/src/hle/sc.cpp", settings_bridge)
+        self.assertIn("widescreen = settings.aspectRatioMode != 0;", settings_bridge)
+        host = (ROOT / "apple/tvos/KartPadTVRuntimeHost.mm").read_text()
+        self.assertIn("settings->aspectRatioMode = static_cast<int>(source.aspectRatioMode)", host)
+        configure = settings_bridge.split(
+            "void ConfigureMkwMobileAspectMode(int aspectMode, uint32_t, uint32_t)",
+            1,
+        )[1].split("diff --git", 1)[0]
+        added_configure = "\n".join(
+            line[1:] for line in configure.splitlines() if line.startswith("+")
+        )
+        self.assertNotIn("ApplyEggScreenRecords", added_configure)
+        self.assertNotIn("UpdateMkwDynamicAspectSurface", added_configure)
+        self.assertNotIn("AuroraSetViewportPolicy", added_configure)
+        dynamic_diff = settings_bridge.split(
+            "diff --git a/src/dynamic_aspect.cpp",
+            1,
+        )[1]
+        update = dynamic_diff.split(
+            "void UpdateMkwDynamicAspectSurface(uint32_t surfaceWidth, uint32_t surfaceHeight)",
+            1,
+        )[1].split("diff --git", 1)[0]
+        added_update = "\n".join(
+            line[1:] for line in update.splitlines() if line.startswith("+")
+        )
+        self.assertIn(
+            "} else if (g_aspectMode == 1) {\n"
+            "        AuroraSetViewportPolicy(AURORA_VIEWPORT_FIT);",
+            added_update,
+        )
 
     def test_tvos_brand_assets_are_layered_and_original(self):
         assets = ROOT / "apple/tvos/Assets.xcassets/App Icon.brandassets"


### PR DESCRIPTION
## Summary

- add a native tvOS Settings bundle for game profile and aspect-ratio selection
- remove the startup controller-discovery gate and read the selected game profile from Settings
- feed the same 4:3/16:9/fill choice into the guest `SCGetAspectRatio` path and Aurora presentation
- keep native 16:9 on the FIT path so 2D UI and the game canvas are not treated as a stretched 4:3 frame
- package and audit `Settings.bundle/Root.plist` with the tvOS app

## Validation

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=builder python3 -m unittest -v tests.test_tvos_contract` (9 tests)
- `./scripts/verify-patch-hunks.py patches/*.patch` (339 hunks)
- `plutil -lint apple/tvos/Settings.bundle/Root.plist`
- `git diff --check`

The physical Apple TV play test was performed on the cumulative local stack; this PR contains only the settings/aspect portion. No game data, ISO, runtime artifacts, signing material, or published app bundle is included.