### PR TITLE
Route tvOS controller rumble through CoreHaptics

### DIFF
--- a/apple/mobile/KartPadPhysicalControllers.h
+++ b/apple/mobile/KartPadPhysicalControllers.h
@@ -37,6 +37,7 @@ SunPadInputState KartPadAdaptPhysicalControllerSample(
 - (void)reconcileControllers;
 - (BOOL)consumePlayer:(NSUInteger)player state:(SunPadInputState *)state;
 - (NSUInteger)connectedControllerCount;
+- (BOOL)setRumbleForPlayer:(NSUInteger)player enabled:(BOOL)enabled;
 
 @end
 

--- a/apple/mobile/KartPadPhysicalControllers.mm
+++ b/apple/mobile/KartPadPhysicalControllers.mm
@@ -4,6 +4,10 @@
 #import "SunPadDiagnostics.h"
 #import "SunPadInputMixer.h"
 
+#import <TargetConditionals.h>
+#if TARGET_OS_TV
+#import <CoreHaptics/CoreHaptics.h>
+#endif
 #import <GameController/GameController.h>
 
 #include <algorithm>
@@ -93,9 +97,16 @@ SunPadInputState KartPadAdaptPhysicalControllerSample(
 @implementation KartPadPhysicalControllers {
   SunPadControllerSlots _slots;
   NSMutableDictionary<NSNumber *, GCController *> *_configuredControllers;
+#if TARGET_OS_TV
+  NSMutableDictionary<NSNumber *, CHHapticEngine *> *_hapticEngines;
+  NSMutableDictionary<NSNumber *, id<CHHapticPatternPlayer>> *_rumblePlayers;
+#endif
   std::mutex _stateMutex;
   std::array<SunPadInputState, SunPadControllerSlots::kMaxPlayers> _states;
   std::array<uint16_t, SunPadControllerSlots::kMaxPlayers> _latchedButtons;
+#if TARGET_OS_TV
+  std::array<BOOL, SunPadControllerSlots::kMaxPlayers> _rumbleActive;
+#endif
   BOOL _started;
 }
 
@@ -112,8 +123,15 @@ SunPadInputState KartPadAdaptPhysicalControllerSample(
   self = [super init];
   if (self != nil) {
     _configuredControllers = [NSMutableDictionary dictionary];
+#if TARGET_OS_TV
+    _hapticEngines = [NSMutableDictionary dictionary];
+    _rumblePlayers = [NSMutableDictionary dictionary];
+#endif
     _states = {};
     _latchedButtons = {};
+#if TARGET_OS_TV
+    _rumbleActive = {};
+#endif
   }
   return self;
 }
@@ -141,8 +159,20 @@ SunPadInputState KartPadAdaptPhysicalControllerSample(
     controller.extendedGamepad.valueChangedHandler = nil;
     controller.playerIndex = GCControllerPlayerIndexUnset;
   }
+#if TARGET_OS_TV
+  for (id<CHHapticPatternPlayer> player in _rumblePlayers.allValues) {
+    [player stopAtTime:CHHapticTimeImmediate error:nil];
+  }
+#endif
   [_configuredControllers removeAllObjects];
+#if TARGET_OS_TV
+  [_hapticEngines removeAllObjects];
+  [_rumblePlayers removeAllObjects];
+#endif
   _slots = {};
+#if TARGET_OS_TV
+  _rumbleActive = {};
+#endif
   {
     std::scoped_lock lock(_stateMutex);
     _states = {};
@@ -211,7 +241,15 @@ SunPadInputState KartPadAdaptPhysicalControllerSample(
     GCController *controller = _configuredControllers[key];
     controller.extendedGamepad.valueChangedHandler = nil;
     controller.playerIndex = GCControllerPlayerIndexUnset;
+#if TARGET_OS_TV
+    [_rumblePlayers[key] stopAtTime:CHHapticTimeImmediate error:nil];
+#endif
     [_configuredControllers removeObjectForKey:key];
+#if TARGET_OS_TV
+    [_hapticEngines removeObjectForKey:key];
+    [_rumblePlayers removeObjectForKey:key];
+    _rumbleActive[change.slot] = NO;
+#endif
     {
       std::scoped_lock lock(_stateMutex);
       _states[change.slot] = {};
@@ -258,4 +296,88 @@ SunPadInputState KartPadAdaptPhysicalControllerSample(
   return count;
 }
 
+- (BOOL)setRumbleForPlayer:(NSUInteger)player enabled:(BOOL)enabled {
+#if TARGET_OS_TV
+  __block BOOL handled = NO;
+  void (^applyRumble)(void) = ^{
+    if (!self->_started || player >= SunPadControllerSlots::kMaxPlayers) return;
+    const uintptr_t instance = self->_slots.InstanceAt(player);
+    if (instance == 0) return;
+    GCController *controller = self->_configuredControllers[@(instance)];
+    if (controller == nil || controller.haptics == nil) return;
+    handled = YES;
+    NSNumber *key = @(instance);
+    if (enabled == self->_rumbleActive[player]) return;
+    if (!enabled) {
+      [self->_rumblePlayers[key] stopAtTime:CHHapticTimeImmediate error:nil];
+      self->_rumbleActive[player] = NO;
+      return;
+    }
+
+    NSError *error = nil;
+    CHHapticEngine *engine = self->_hapticEngines[key];
+    id<CHHapticPatternPlayer> playerObject = self->_rumblePlayers[key];
+    if (engine != nil && playerObject != nil &&
+        [engine startAndReturnError:&error] &&
+        [playerObject startAtTime:CHHapticTimeImmediate error:&error]) {
+      self->_rumbleActive[player] = YES;
+      return;
+    }
+    [self->_rumblePlayers removeObjectForKey:key];
+    [self->_hapticEngines removeObjectForKey:key];
+
+    engine = [controller.haptics createEngineWithLocality:GCHapticsLocalityDefault];
+    if (engine == nil || ![engine startAndReturnError:&error]) {
+      SunPadLog(@"controller rumble unavailable for player=%lu: %@",
+                static_cast<unsigned long>(player + 1),
+                error.localizedDescription ?: @"no haptic engine");
+      handled = NO;
+      return;
+    }
+    engine.playsHapticsOnly = YES;
+    NSArray<CHHapticEventParameter *> *parameters = @[
+      [[CHHapticEventParameter alloc]
+          initWithParameterID:CHHapticEventParameterIDHapticIntensity value:1.0f],
+      [[CHHapticEventParameter alloc]
+          initWithParameterID:CHHapticEventParameterIDHapticSharpness value:0.1f],
+    ];
+    CHHapticEvent *event = [[CHHapticEvent alloc]
+        initWithEventType:CHHapticEventTypeHapticContinuous
+               parameters:parameters
+             relativeTime:0.0
+                 duration:GCHapticDurationInfinite];
+    CHHapticPattern *pattern = [[CHHapticPattern alloc]
+        initWithEvents:@[event] parameters:@[] error:&error];
+    playerObject = pattern == nil
+        ? nil : [engine createPlayerWithPattern:pattern error:&error];
+    if (playerObject == nil ||
+        ![playerObject startAtTime:CHHapticTimeImmediate error:&error]) {
+      SunPadLog(@"controller rumble start failed for player=%lu: %@",
+                static_cast<unsigned long>(player + 1),
+                error.localizedDescription ?: @"unknown haptic error");
+      handled = NO;
+      return;
+    }
+    self->_hapticEngines[key] = engine;
+    self->_rumblePlayers[key] = playerObject;
+    self->_rumbleActive[player] = YES;
+  };
+  if (NSThread.isMainThread) {
+    applyRumble();
+  } else {
+    dispatch_sync(dispatch_get_main_queue(), applyRumble);
+  }
+  return handled;
+#else
+  (void)player;
+  (void)enabled;
+  return NO;
+#endif
+}
+
 @end
+
+extern "C" bool KartPadMobileSetRumbleForPlayer(unsigned int player, bool enabled) {
+  return [[KartPadPhysicalControllers sharedControllers]
+      setRumbleForPlayer:player enabled:enabled ? YES : NO];
+}

--- a/patches/wiicompiled-tvos-runtime.patch
+++ b/patches/wiicompiled-tvos-runtime.patch
@@ -36,7 +36,7 @@
          _DISABLE_STRING_ANNOTATION _DISABLE_VECTOR_ANNOTATION TARGET_PC)
      target_compile_features(${target} PRIVATE cxx_std_20)
      mkw_apply_common_compile_options(${target})
-@@ -390,7 +390,104 @@
+@@ -390,7 +390,105 @@
          XCODE_ATTRIBUTE_SUPPORTS_MACCATALYST NO
          XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2")
  endif()

--- a/patches/wiicompiled-tvos-runtime.patch
+++ b/patches/wiicompiled-tvos-runtime.patch
@@ -117,7 +117,8 @@
 +        target_link_libraries(${target} PRIVATE MINIZIP::minizip
 +            "-framework UIKit" "-framework CoreGraphics"
 +            "-framework QuartzCore" "-framework Metal"
-+            "-framework GameController" "-framework Foundation")
++            "-framework GameController" "-framework CoreHaptics"
++            "-framework Foundation")
 +        set_target_properties(${target} PROPERTIES
 +            OUTPUT_NAME "${output_name}"
 +            MACOSX_BUNDLE TRUE
@@ -339,3 +340,50 @@
          if (!fixtureActive && mobileConnected) {
              classicButtons |= mobileInput.buttons;
              coreButtons |= CoreButtonsForClassic(mobileInput.buttons);
+diff --git a/src/hle/input/pad.cpp b/src/hle/input/pad.cpp
+--- a/src/hle/input/pad.cpp
++++ b/src/hle/input/pad.cpp
+@@ -10,4 +10,10 @@
+ #include <cstring>
+ 
+ #include <SDL3/SDL_scancode.h>
++#if defined(__APPLE__)
++#include <TargetConditionals.h>
++#if TARGET_OS_TV
++#include "kartpad_mobile_runtime_host.h"
++#endif
++#endif
+ #include <dolphin/pad.h>
+@@ -127,3 +133,8 @@
+ extern "C" void PAD__ControlMotor_HLE(int32_t chan, uint32_t command)
+ {
++#if defined(__APPLE__) && TARGET_OS_TV
++    if (KartPadMobileSetRumbleForPlayer(static_cast<uint32_t>(chan), command == 1u)) {
++        return;
++    }
++#endif
+     if (!Wup028Adapter::SetRumble(static_cast<uint32_t>(chan), command == PAD_MOTOR_RUMBLE)) {
+diff --git a/src/hle/input/wpad.cpp b/src/hle/input/wpad.cpp
+--- a/src/hle/input/wpad.cpp
++++ b/src/hle/input/wpad.cpp
+@@ -5,4 +5,10 @@
+ #include <cstdint>
+ #include <cstring>
+ 
++#if defined(__APPLE__)
++#include <TargetConditionals.h>
++#if TARGET_OS_TV
++#include "kartpad_mobile_runtime_host.h"
++#endif
++#endif
+ void NandQueueIosCallback(uint32_t callbackPtr, int32_t result, uint32_t callbackArg);
+@@ -131,4 +137,9 @@
+ extern "C" void WPADControlMotor_HLE(uint32_t chan, uint32_t command)
+ {
++#if defined(__APPLE__) && TARGET_OS_TV
++    if (KartPadMobileSetRumbleForPlayer(chan, command == 1u)) {
++        return;
++    }
++#endif
+     (void)chan;
+     (void)command;

--- a/runtime/include/kartpad_mobile_runtime_host.h
+++ b/runtime/include/kartpad_mobile_runtime_host.h
@@ -45,4 +45,7 @@ bool KartPadMobileReadClassicInput(KartPadMobileClassicInputSnapshot *snapshot);
 bool KartPadMobileReadClassicInputForPlayer(
     unsigned int player, KartPadMobileClassicInputSnapshot *snapshot);
 
+// Maps the guest WPAD motor state to the selected Apple controller.
+bool KartPadMobileSetRumbleForPlayer(unsigned int player, bool enabled);
+
 }

--- a/scripts/audit-tvos-app.sh
+++ b/scripts/audit-tvos-app.sh
@@ -72,6 +72,7 @@ for required in \
   _KartPadMobileSelectedRuntimeProfile \
   _KartPadMobileRuntimeHostInstall \
   _KartPadMobileReadClassicInputForPlayer \
+  _KartPadMobileSetRumbleForPlayer \
   '_OBJC_CLASS_$_KartPadPhysicalControllers' \
   '_OBJC_CLASS_$_SDLUIKitSceneDelegate'; do
   rg -F -q "${required}" <<<"${symbols}" || {

--- a/tests/test_tvos_contract.py
+++ b/tests/test_tvos_contract.py
@@ -161,6 +161,24 @@ class TvOSContractTests(unittest.TestCase):
         self.assertTrue((ROOT / "docs/INSTALL_TVOS.md").is_file())
         self.assertTrue((ROOT / "docs/releases/v0.4.1.md").is_file())
 
+    def test_tvos_physical_controller_rumble_routes_to_native_haptics(self):
+        controllers = (
+            ROOT / "apple/mobile/KartPadPhysicalControllers.mm"
+        ).read_text()
+        self.assertIn("#import <CoreHaptics/CoreHaptics.h>", controllers)
+        self.assertIn("GCHapticsLocalityDefault", controllers)
+        self.assertIn("CHHapticEventTypeHapticContinuous", controllers)
+        self.assertIn("GCHapticDurationInfinite", controllers)
+        self.assertIn("KartPadMobileSetRumbleForPlayer", controllers)
+        runtime_patch = (
+            ROOT / "patches/wiicompiled-tvos-runtime.patch"
+        ).read_text()
+        self.assertIn("WPADControlMotor_HLE", runtime_patch)
+        self.assertIn("PAD__ControlMotor_HLE", runtime_patch)
+        self.assertIn("KartPadMobileSetRumbleForPlayer", runtime_patch)
+        self.assertIn("-framework CoreHaptics", runtime_patch)
+        self.assertIn("#if defined(__APPLE__) && TARGET_OS_TV", runtime_patch)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- expose a narrow tvOS rumble bridge from the shared Apple controller manager
- map Wii `WPAD` and GameCube `PAD` motor commands to the selected Bluetooth controller
- keep the existing controller/input path unchanged on iOS and non-tvOS targets
- cache one Core Haptics engine/player per controller and stop it on disconnect or shutdown

## Validation

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=builder python3 -m unittest -v tests.test_tvos_contract` (9 tests)
- `./scripts/verify-patch-hunks.py patches/*.patch` (341 hunks)
- `git diff --check`
- confirmed the PR diff contains no settings or aspect-ratio additions

The physical Apple TV play session confirms the existing controller input path, but physical haptic output was not separately measured. No game data, ISO, runtime artifacts, signing material, or published app bundle is included.