### PR TITLE
Android A2: bridge guest rumble to SDL controllers

### DIFF
--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -792,8 +792,12 @@ staging the validated ignored DATA directory outside the APK, setting its
 app-private path, and using the new Aurora-to-Classic SDL controller bridge to
 prove a complete controller-driven player race, results, and save/relaunch
 without weakening the package privacy boundary. The bridge's deterministic
-source-only contract passes on both page-size lanes, but no controller
-acceptance is claimed until an actual controller is attached.
+source-only contract passes on both page-size lanes, and Android
+`WPADControlMotor` now routes Start/Stop output to the same resolved SDL pad.
+No controller input or rumble acceptance is claimed until actual hardware is
+attached. Do not repeat the rejected retail-KPAD RKG replay unchanged: even
+the exact Baby Mario / Nanobike / Manual staff configuration diverged by guest
+time 8.580.
 
 The A0 commands and sanitized result are recorded in
 [`android/README.md`](../android/README.md) and

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -102,14 +102,18 @@ not block offline Retro Rewind support.
    metadata and the macOS-proven SNES Mario Circuit 3 stream also diverge on
    Android and must not be used as completion evidence. Aurora's discovered
    SDL pads now feed the Android Classic/KPAD path through a deterministic
-   mapping contract, but no controller was attached, so this is implementation
-   and compile evidence only. Establish a complete
+   mapping contract, and `WPADControlMotor` now reaches that same resolved pad
+   through a fail-closed SDL rumble bridge. No controller was attached, so
+   input and tactile behavior remain implementation/compile evidence only. A
+   temporary exact-configuration retail-KPAD RKG replay also diverged by guest
+   time 8.580 and was removed; do not repeat it unchanged. Establish a complete
    player race, results, post-race save/relaunch,
    then repeat with a real controller and physical Android hardware. Evidence
    is in `docs/artifacts/2026-09-03/android/a2-emulator-boot-lifecycle.md` and
    `docs/artifacts/2026-09-03/android/a2-debug-input-replay.md`, plus
    `docs/artifacts/2026-09-03/android/a2-keyboard-steer-diagnostic.md` and
-   `docs/artifacts/2026-09-03/android/a2-sdl-controller-bridge.md`. A2
+   `docs/artifacts/2026-09-03/android/a2-sdl-controller-bridge.md`, plus
+   `docs/artifacts/2026-09-03/android/a2-sdl-controller-rumble.md`. A2
    remains open.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -1879,3 +1879,36 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   controller was attached, so live controller and physical-device acceptance
   remain open. No APK/AAB or private input was published. Evidence:
   `docs/artifacts/2026-09-03/android/a2-sdl-controller-bridge.md`.
+
+## 2026-09-03 — Android A2 SDL controller rumble
+
+- Replaced Android's `WPADControlMotor` no-op with a narrow Aurora output API
+  using the same explicit-port / sole-unassigned-player-one resolution rule as
+  the accepted SDL input snapshot. Capability, connection, and SDL errors fail
+  closed; Start uses configured low/high intensity and Stop is immediate.
+- Added a pure host contract proving only WPAD command `1` enables rumble.
+  Commands `0` and unknown values stop it. The Apple path is unchanged.
+- Fresh preparation applies two new incremental patches and reproduces the
+  three modified upstream files byte-for-byte. The complete private Original
+  ARM64 graph compiled and linked in 8m19s; after centralizing input/output
+  assignment in one resolver, the exact final source rebuilt and relinked in
+  11s.
+- The strict audit passes on the local-only 103,433,440-byte APK, SHA-256
+  `3044e148e320236b0b71d4cf86ff8a5b158a896c75671f215a5da8c0faf23ad0`.
+  Its stripped 83,536,472-byte `libmain.so` is
+  `57856f61c5e1e162c0525b1d757eed46ccd27aaacf7a9bf287a20b78472954ad`.
+  Host CTest, debug lint, release Kotlin compile, storage contract, repository
+  safety, patch verification, and diff checks pass. The broad source verifier
+  again stopped only after accepting 412 hunks and three pins because the
+  ignored `rr-pulsar` checkout has the known unrelated pin mismatch.
+- A temporary retail-KPAD replay hypothesis was tested and removed. The first
+  mismatched Luigi Circuit run hit a wall at 14.346; an exact Baby Mario / PAL
+  Nanobike / Manual N64 Mario Raceway run still diverged by 8.580. No forced
+  finish was used. The marker, private RKG, source experiment, and emulator were
+  removed or stopped, so this path must not be treated as completion evidence.
+- Classification: **Pass for rumble implementation, deterministic command
+  semantics, patch reproduction, private link, and audit only.** No controller
+  was attached, so live rumble/input, complete player race/results/save, and
+  physical Android acceptance remain open. No APK/AAB or private data was
+  published. Evidence:
+  `docs/artifacts/2026-09-03/android/a2-sdl-controller-rumble.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -113,6 +113,18 @@ disconnect/reconnect, rumble, race, and physical-device acceptance remain
 open. Evidence:
 [`docs/artifacts/2026-09-03/android/a2-sdl-controller-bridge.md`](artifacts/2026-09-03/android/a2-sdl-controller-bridge.md).
 
+Mario Kart's Android `WPADControlMotor` path now drives the same resolved SDL
+controller with fail-closed Start/Stop rumble semantics; Apple behavior is
+unchanged. The host contract, fresh patch reproduction, full private ARM64
+link, lint, storage contract, and strict package/privacy audit pass. The exact
+local-only 103,433,440-byte APK has SHA-256
+`3044e148e320236b0b71d4cf86ff8a5b158a896c75671f215a5da8c0faf23ad0`.
+No controller was attached, so tactile output and controller-driven gameplay
+remain unaccepted. A temporary retail-KPAD RKG experiment also diverged with
+an exact selectable staff configuration and was removed; it is not a product
+or completion path. A2 remains open. Evidence:
+[`docs/artifacts/2026-09-03/android/a2-sdl-controller-rumble.md`](artifacts/2026-09-03/android/a2-sdl-controller-rumble.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-03/android/a2-sdl-controller-rumble.md
+++ b/docs/artifacts/2026-09-03/android/a2-sdl-controller-rumble.md
@@ -1,0 +1,77 @@
+# Android A2 SDL controller rumble
+
+Date: 2026-09-03
+
+Base checkpoint: `623b75f` (`codex/android-a2-sdl-controller`)
+
+Targets: host command contract and the private Original ARM64 runtime link
+
+## Falsifiable subgoal
+
+Route Mario Kart's Android `WPADControlMotor` output to the same SDL controller
+selection used by the accepted Aurora-to-Classic input bridge, without changing
+Apple behavior or claiming tactile acceptance without controller hardware.
+
+## Implemented contract
+
+Aurora now exposes a narrow start/stop rumble call beside its SDL-free input
+snapshot. It uses the same controller resolution rule as input: an explicit
+port assignment wins, and player one may use exactly one unassigned controller
+until the native assignment UI exists. The request fails closed when the
+controller is absent, disconnected, lacks rumble support, or SDL rejects it.
+
+Android `WPADControlMotor` command `1` starts both motors at the controller's
+configured intensities; command `0` stops them with zero intensity and zero
+duration. Unknown commands also stop output rather than accidentally starting
+it. An active request uses SDL's maximum duration and remains active until the
+guest sends Stop, the controller is removed, or Aurora shuts down. The
+non-Android HLE remains the existing no-op.
+
+## Verification
+
+- `kartpad.android.gamepad-contract` passes Stop, Rumble, and unknown-command
+  cases in addition to the existing button, trigger, stick, and deadzone
+  contract.
+- Both incremental patches dry-run against a clean pre-rumble prepared tree.
+  A fresh complete preparation applies them and reproduces the modified Aurora
+  header, Aurora implementation, and WiiCompiled `wpad.cpp` byte-for-byte.
+- The full 29,065-function private Original ARM64 graph compiles and links
+  through Gradle. After centralizing input/output assignment in one resolver,
+  the exact final source rebuilt and relinked successfully. The local-only APK
+  is 103,433,440 bytes with SHA-256
+  `3044e148e320236b0b71d4cf86ff8a5b158a896c75671f215a5da8c0faf23ad0`.
+  Its stripped 83,536,472-byte `libmain.so` has SHA-256
+  `57856f61c5e1e162c0525b1d757eed46ccd27aaacf7a9bf287a20b78472954ad`.
+- The strict APK audit passes its ABI, 16 KiB alignment, dependency, symbol,
+  permission, asset allowlist, and private-data/path checks. Runtime storage,
+  debug lint, release Kotlin compilation, repository safety, patch verification,
+  and `git diff --check` pass.
+- The broad source verifier accepted all 412 patch hunks and the WiiCompiled,
+  SunPad, and WheelWizard pins, then stopped at the pre-existing ignored
+  `rr-pulsar` checkout mismatch (`b566a5d` present versus `29e76d4` locked).
+  This branch does not touch that checkout or its lock.
+
+No controller was available, so actual motor capability, intensity, Stop,
+disconnect, pause, and reconnect behavior remain unaccepted. No APK/AAB,
+private data, translated source, RKG, save, log, or game capture was published.
+
+## Rejected replay diagnostic
+
+A temporary uncommitted diagnostic exposed RKG samples through the translated
+retail KPAD calculator instead of replacing it. It synchronized and moved the
+player, but the mismatched Luigi Circuit run reached a wall at 14.346 seconds.
+A second run used the exact selectable N64 Mario Raceway staff configuration
+(Baby Mario, PAL Nanobike/Bit Bike, Manual) and still diverged off course by
+8.580 seconds. No forced finish was enabled. The marker, private RKG, source
+experiment, app process, and emulator were removed or stopped afterward.
+
+This falsifies the hypothesis that the earlier Android player-fixture failure
+was only a character/vehicle mismatch. The experiment is not retained as a
+product path and is not race-completion evidence.
+
+## Classification
+
+**Pass for deterministic rumble-command semantics, reproducible SDL output
+integration, private compile/link/package, and package privacy.** Live rumble,
+complete controller-driven race/results/save, and physical Android acceptance
+remain open, so A2 remains incomplete.

--- a/patches/aurora-android-gamepad-rumble.patch
+++ b/patches/aurora-android-gamepad-rumble.patch
@@ -1,0 +1,75 @@
+diff --git a/include/aurora/input.hpp b/include/aurora/input.hpp
+--- a/include/aurora/input.hpp
++++ b/include/aurora/input.hpp
+@@ -34,4 +34,10 @@
+ bool read_standard_gamepad_state(uint32_t player, bool allowSingleUnassigned,
+                                  StandardGamepadState* state) noexcept;
+ 
++// Starts or stops rumble on the controller resolved by the same assignment
++// rule as read_standard_gamepad_state. Returns false when no suitable
++// rumble-capable controller exists or SDL rejects the request.
++bool set_standard_gamepad_rumble(uint32_t player, bool allowSingleUnassigned,
++                                 bool enabled) noexcept;
++
+ }  // namespace aurora::input
+diff --git a/lib/input.cpp b/lib/input.cpp
+--- a/lib/input.cpp
++++ b/lib/input.cpp
+@@ -349,13 +349,8 @@
+   return nullptr;
+ }
+ 
+-bool read_standard_gamepad_state(uint32_t player, bool allowSingleUnassigned,
+-                                 StandardGamepadState* state) noexcept {
+-  if (state == nullptr) {
+-    return false;
+-  }
+-  *state = {};
+-
++static GameController* resolve_standard_gamepad(
++    uint32_t player, bool allowSingleUnassigned) noexcept {
+   GameController* controller = get_controller_for_player(player);
+   if (controller == nullptr && player == 0 && allowSingleUnassigned &&
+       g_GameControllers.size() == 1) {
+@@ -364,6 +359,18 @@
+       controller = &candidate;
+     }
+   }
++  return controller;
++}
++
++bool read_standard_gamepad_state(uint32_t player, bool allowSingleUnassigned,
++                                 StandardGamepadState* state) noexcept {
++  if (state == nullptr) {
++    return false;
++  }
++  *state = {};
++
++  GameController* controller =
++      resolve_standard_gamepad(player, allowSingleUnassigned);
+   if (controller == nullptr || controller->m_controller == nullptr ||
+       !SDL_GamepadConnected(controller->m_controller)) {
+     return false;
+@@ -399,6 +406,22 @@
+   return true;
+ }
+ 
++bool set_standard_gamepad_rumble(uint32_t player, bool allowSingleUnassigned,
++                                 bool enabled) noexcept {
++  GameController* controller =
++      resolve_standard_gamepad(player, allowSingleUnassigned);
++  if (controller == nullptr || controller->m_controller == nullptr ||
++      !controller->m_hasRumble ||
++      !SDL_GamepadConnected(controller->m_controller)) {
++    return false;
++  }
++
++  const uint16_t low = enabled ? controller->m_rumbleIntensityLow : 0;
++  const uint16_t high = enabled ? controller->m_rumbleIntensityHigh : 0;
++  return SDL_RumbleGamepad(controller->m_controller, low, high,
++                           enabled ? 0xffffffffu : 0u);
++}
++
+ Sint32 get_instance_for_player(uint32_t player) noexcept {
+   for (const auto& [which, controller] : g_GameControllers) {
+     if (player_index(which) == player) {

--- a/patches/wiicompiled-android-sdl-rumble.patch
+++ b/patches/wiicompiled-android-sdl-rumble.patch
@@ -1,0 +1,30 @@
+diff --git a/src/hle/input/wpad.cpp b/src/hle/input/wpad.cpp
+--- a/src/hle/input/wpad.cpp
++++ b/src/hle/input/wpad.cpp
+@@ -5,6 +5,11 @@
+ #include <cstdint>
+ #include <cstring>
+ 
++#if defined(__ANDROID__)
++#include <aurora/input.hpp>
++#include "kartpad/android/gamepad_contract.h"
++#endif
++
+ void NandQueueIosCallback(uint32_t callbackPtr, int32_t result, uint32_t callbackArg);
+ extern "C" bool KPAD_IsKeyboardChannelConnected(uint32_t chan);
+ 
+@@ -130,8 +135,14 @@
+ 
+ extern "C" void WPADControlMotor_HLE(uint32_t chan, uint32_t command)
+ {
++#if defined(__ANDROID__)
++    aurora::input::set_standard_gamepad_rumble(
++        chan, chan == 0,
++        kartpad::android::WpadMotorCommandEnablesRumble(command));
++#else
+     (void)chan;
+     (void)command;
++#endif
+ }
+ PPC_NATIVE_OVERRIDE(801C0EC4, WPADControlMotor_HLE, void, (uint32_t chan, uint32_t command), (chan, command));
+ 

--- a/runtime/include/kartpad/android/gamepad_contract.h
+++ b/runtime/include/kartpad/android/gamepad_contract.h
@@ -55,6 +55,12 @@ struct ClassicInputState {
 
 inline constexpr int32_t kStickDeadzone = 8000;
 inline constexpr int32_t kTriggerThreshold = 16000;
+inline constexpr uint32_t kWpadMotorStop = 0;
+inline constexpr uint32_t kWpadMotorRumble = 1;
+
+inline constexpr bool WpadMotorCommandEnablesRumble(uint32_t command) {
+  return command == kWpadMotorRumble;
+}
 
 inline float NormalizeStickAxis(int16_t raw) {
   const int32_t value = raw;

--- a/runtime/tests/android_gamepad_contract_tests.cpp
+++ b/runtime/tests/android_gamepad_contract_tests.cpp
@@ -53,6 +53,11 @@ int main() {
   passed &= Require(MapGamepadToClassic(buttons).buttons == 0,
                     "triggers must remain released below the threshold");
 
+  passed &= Require(!WpadMotorCommandEnablesRumble(kWpadMotorStop) &&
+                        WpadMotorCommandEnablesRumble(kWpadMotorRumble) &&
+                        !WpadMotorCommandEnablesRumble(2),
+                    "only the WPAD rumble command may enable controller output");
+
   RawGamepadState axes;
   axes.connected = true;
   axes.left_x = 32767;

--- a/scripts/prepare-android-game-runtime.sh
+++ b/scripts/prepare-android-game-runtime.sh
@@ -36,6 +36,8 @@ patch --batch -p1 -d "$runtime_source/aurora-main" < \
   "$repo_root/patches/aurora-android-public-sdl-surface-lock.patch"
 patch --batch -p1 -d "$runtime_source/aurora-main" < \
   "$repo_root/patches/aurora-android-gamepad-snapshot.patch"
+patch --batch -p1 -d "$runtime_source/aurora-main" < \
+  "$repo_root/patches/aurora-android-gamepad-rumble.patch"
 patch --batch -p1 -d "$runtime_source" < \
   "$repo_root/patches/wiicompiled-android-runtime.patch"
 patch --batch -p1 -d "$runtime_source" < \
@@ -46,6 +48,8 @@ patch --batch -p1 -d "$runtime_source" < \
   "$repo_root/patches/wiicompiled-android-keyboard-steer.patch"
 patch --batch -p1 -d "$runtime_source" < \
   "$repo_root/patches/wiicompiled-android-sdl-controller.patch"
+patch --batch -p1 -d "$runtime_source" < \
+  "$repo_root/patches/wiicompiled-android-sdl-rumble.patch"
 
 generated_link="$(dirname "$runtime_source")/generated"
 if [[ -e "$generated_link" && ! -L "$generated_link" ]]; then


### PR DESCRIPTION
## Summary
- route Android WPAD motor Start/Stop through Aurora's resolved SDL controller
- share controller resolution between input and output and fail closed on unsupported hardware
- add command-contract coverage, reproducible runtime patches, and sanitized A2 evidence

## Validation
- kartpad.android.gamepad-contract
- fresh private runtime preparation with byte-identical patched files
- full ARM64 Original runtime build and exact final incremental rebuild
- strict Android APK audit, storage contract, lint, release Kotlin compile, and repository safety

No APK/AAB or private game data was published. Live rumble and controller acceptance remain open until hardware is available.