### PR TITLE
Android: suspend controller bridge across lifecycle loss

### DIFF
--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -18,7 +18,8 @@
 - **Decision:** A1 is green. A2 packages the complete 29,065-function Original
   runtime and now cold-starts through translated constructors and Vulkan using
   versioned public resources plus Context-derived app-private config/cache/
-  NAND paths. Continue A2 with private DATA staging and controller-driven
+  NAND paths. Its SDL controller bridge now also fails neutral and stops rumble
+  across Android surface loss/backgrounding. Continue A2 with controller-driven
   gameplay; keep emulator and physical-device claims separate.
 
 KartPad can be ported to Android without changing its defining architecture.
@@ -794,6 +795,9 @@ prove a complete controller-driven player race, results, and save/relaunch
 without weakening the package privacy boundary. The bridge's deterministic
 source-only contract passes on both page-size lanes, and Android
 `WPADControlMotor` now routes Start/Stop output to the same resolved SDL pad.
+Surface loss/backgrounding suspends the bridge and stops active rumble; a
+corrected API 36 process retained its PID through four such cycles, although
+one preceding process ended silently after one cycle and remains unexplained.
 No controller input or rumble acceptance is claimed until actual hardware is
 attached. Do not repeat the rejected retail-KPAD RKG replay unchanged: even
 the exact Baby Mario / Nanobike / Manual staff configuration diverged by guest

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -103,7 +103,11 @@ not block offline Retro Rewind support.
    Android and must not be used as completion evidence. Aurora's discovered
    SDL pads now feed the Android Classic/KPAD path through a deterministic
    mapping contract, and `WPADControlMotor` now reaches that same resolved pad
-   through a fail-closed SDL rumble bridge. No controller was attached, so
+   through a fail-closed SDL rumble bridge. Surface loss/backgrounding now
+   makes that bridge neutral, rejects new rumble starts, and stops active
+   rumble; a corrected process retained its PID through four emulator cycles.
+   One earlier corrected process ended silently after one cycle and remains an
+   unexplained non-reproduced exit. No controller was attached, so
    input and tactile behavior remain implementation/compile evidence only. A
    temporary exact-configuration retail-KPAD RKG replay also diverged by guest
    time 8.580 and was removed; do not repeat it unchanged. Establish a complete
@@ -113,7 +117,8 @@ not block offline Retro Rewind support.
    `docs/artifacts/2026-09-03/android/a2-debug-input-replay.md`, plus
    `docs/artifacts/2026-09-03/android/a2-keyboard-steer-diagnostic.md` and
    `docs/artifacts/2026-09-03/android/a2-sdl-controller-bridge.md`, plus
-   `docs/artifacts/2026-09-03/android/a2-sdl-controller-rumble.md`. A2
+   `docs/artifacts/2026-09-03/android/a2-sdl-controller-rumble.md`, plus
+   `docs/artifacts/2026-09-03/android/a2-controller-lifecycle.md`. A2
    remains open.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -1912,3 +1912,42 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   physical Android acceptance remain open. No APK/AAB or private data was
   published. Evidence:
   `docs/artifacts/2026-09-03/android/a2-sdl-controller-rumble.md`.
+
+## 2026-09-03 — Android A2 controller lifecycle gate
+
+- Added one Aurora lifecycle gate shared by Android's standard-gamepad input
+  and rumble APIs. Surface loss or backgrounding makes snapshots neutral,
+  rejects new rumble starts, and sends zero intensity to every active
+  rumble-capable pad; stop remains legal while suspended.
+- Serialized the bridge with controller add/remap/remove/shutdown so the
+  Android UI thread cannot stop rumble through a controller pointer while the
+  SDL event thread closes it. SDL background controller events remain enabled
+  so releases during backgrounding are retained.
+- The first ARM64 compile exposed a missing public Aurora input include. The
+  first live launch then exposed a surface-before-Aurora initialization race
+  that left the bridge suspended. Both were corrected before acceptance;
+  initialization now derives state from the existing surface/background
+  atomics.
+- A corrected run logged the bridge active. One process later ended
+  silently after its first resume without an Android fatal record. A fresh
+  exact-final process retained PID `2293` through four HOME/surface recreation
+  cycles with exactly four suspend/resume pairs and no Android fatal or
+  `SIGABRT`; the
+  earlier exit remains unexplained and is not counted as passing evidence.
+- Host controller contract, clean patch dry-run, fresh exact source
+  reproduction, private ARM64 compile/link, debug lint, release Kotlin compile,
+  storage contract, package/privacy audit, repository safety, and diff checks
+  pass. The broad verifier accepts 426 hunks and three pins before the known
+  ignored `rr-pulsar` checkout/lock mismatch. The exact local-only APK is
+  103,434,720 bytes at SHA-256
+  `2c9c62b88277f34b27b481e254a25dd37936144d5c78a7db10eedb36c75e7145`;
+  its 83,537,752-byte stripped `libmain.so` is
+  `cf6b61932ef465c12135095ccfeb058c490fa2886f502d116c5dbeb9b87e0f24`.
+  The lifecycle patch SHA-256 is
+  `949aca693d660e966d0c3a8a6c10956e0f0aef0cc4488b8e10c6b96f01eee3a0`.
+- Classification: **Pass for lifecycle-gated controller bridge implementation,
+  exact reproduction, ARM64 link, and bounded emulator execution only.** No
+  controller was attached, so real neutral input, motor stop, controller race,
+  and physical Android acceptance remain open. No APK/AAB or private data was
+  published. Evidence:
+  `docs/artifacts/2026-09-03/android/a2-controller-lifecycle.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -125,6 +125,20 @@ an exact selectable staff configuration and was removed; it is not a product
 or completion path. A2 remains open. Evidence:
 [`docs/artifacts/2026-09-03/android/a2-sdl-controller-rumble.md`](artifacts/2026-09-03/android/a2-sdl-controller-rumble.md).
 
+Android surface loss and backgrounding now suspend that shared SDL controller
+bridge: snapshots fail neutral, new rumble starts fail closed, and active
+rumble is stopped before surface release. Controller add/remove and the
+cross-thread lifecycle callback are serialized so a removed pad cannot be
+used during shutdown. A corrected API 36 cold launch starts with the bridge
+active, and one process retained its PID through four HOME/surface recreation
+cycles with exactly four suspend/resume pairs and no Android fatal. One prior
+corrected process ended silently after a single cycle and remains an
+unexplained non-reproduced exit. Fresh patch reproduction, private ARM64
+compile/link, lint, storage and package/privacy audits pass. No controller was
+attached, so actual neutral input and motor-stop behavior remain unaccepted.
+Evidence:
+[`docs/artifacts/2026-09-03/android/a2-controller-lifecycle.md`](artifacts/2026-09-03/android/a2-controller-lifecycle.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-03/android/a2-controller-lifecycle.md
+++ b/docs/artifacts/2026-09-03/android/a2-controller-lifecycle.md
@@ -1,0 +1,90 @@
+# Android A2 controller lifecycle evidence
+
+Date: 2026-09-03
+
+Base checkpoint: `396fbcc` (`codex/android-a2-sdl-rumble`)
+
+Host: Apple Silicon macOS 26.6.2
+
+Target: `KartPad_API_36_ARM64`, Android API 36, `arm64-v8a`, 4,096-byte
+pages, gfxstream with host lavapipe
+
+## Falsifiable subgoal
+
+Make Android controller reads fail neutral while the app is backgrounded or
+its native surface is unavailable, reject new rumble starts at the same
+boundary, and stop any active rumble before the surface is released. Keep
+SDL's background controller events enabled so a release that occurs while the
+app is backgrounded is not lost.
+
+## Implementation
+
+Aurora now owns one lifecycle gate for the public standard-gamepad snapshot
+and rumble APIs. The gate is derived from both Android surface readiness and
+foreground state. Suspension makes every standard-gamepad snapshot neutral,
+rejects rumble starts, and sends a zero-intensity stop to every open
+rumble-capable pad. Stop commands remain legal while suspended.
+
+The Android UI thread can change surface readiness while SDL processes a
+controller add/remove event. A narrow mutex therefore serializes the public
+snapshot/rumble/lifecycle bridge with controller add, remap, removal, and
+shutdown, so suspension cannot use a gamepad pointer while removal closes it.
+Other Aurora controller behavior and the Apple patch stack are unchanged.
+
+## Failure-driven correction
+
+The first ARM64 compile rejected the new calls because `window.cpp` included
+only Aurora's private input header. Adding the explicit public
+`aurora/input.hpp` include fixed that integration error.
+
+The first live cold launch then logged only `Standard gamepads suspended`.
+Android had already created the surface before Aurora initialized, and an
+unconditional initialization-time suspend overwrote that authoritative state.
+Initialization now derives the gate from the current surface and background
+atomics. A corrected run logged `Standard gamepads resumed`; on the exact final
+artifact, the first HOME action emitted a state-changing `Standard gamepads
+suspended` marker, proving the bridge had been active before backgrounding.
+
+One corrected process ended without an Android fatal record roughly eighteen
+seconds after its first resume. A fresh process then retained the same PID
+through four consecutive HOME / surface-destroy / foreground cycles and
+reported exactly four suspend/resume pairs. The earlier silent exit is kept as
+an unexplained, non-reproduced event; it is not attributed to this change and
+is not counted as passing evidence.
+
+## Verification
+
+- The host `kartpad.android.gamepad-contract` test passes.
+- The lifecycle patch dry-runs cleanly on the exact pre-change rumble source.
+- A fresh complete Android runtime preparation applies the lifecycle patch;
+  its modified Aurora header, input source, and window source are byte-for-byte
+  identical to the tested tree.
+- The complete private Original ARM64 runtime rebuilds and relinks.
+- Exact final emulator process: PID `2293` retained across four cycles, four
+  `Standard gamepads suspended` markers, four `Standard gamepads resumed`
+  markers, and matching SDL `surfaceDestroyed` / `nativePause` /
+  `surfaceCreated` / `nativeResume` transitions.
+- The final run contains no Android fatal or `SIGABRT` record.
+- Debug lint, release Kotlin compilation, runtime storage-layout contract,
+  repository safety, patch whitespace, and strict APK audit pass.
+- The broad source verifier accepts 426 hunks across 46 patches plus the
+  WiiCompiled, SunPad, and WheelWizard pins, then stops at the pre-existing
+  ignored `rr-pulsar` checkout/lock mismatch.
+- Lifecycle patch SHA-256:
+  `949aca693d660e966d0c3a8a6c10956e0f0aef0cc4488b8e10c6b96f01eee3a0`.
+- Final local-only APK: 103,434,720 bytes, SHA-256
+  `2c9c62b88277f34b27b481e254a25dd37936144d5c78a7db10eedb36c75e7145`.
+- Extracted stripped `libmain.so`: 83,537,752 bytes, SHA-256
+  `cf6b61932ef465c12135095ccfeb058c490fa2886f502d116c5dbeb9b87e0f24`.
+
+No APK/AAB, private game data, save, controller identifier, or capture was
+published.
+
+## Honest classification
+
+**Pass for lifecycle-gated controller input/rumble implementation, exact patch
+reproduction, ARM64 compile/link, and an emulator execution trace through four
+surface-loss cycles.** No controller was attached, so this does not prove a
+real pad becomes neutral, a physical rumble motor stops, controller
+disconnect/reconnect behavior, a complete race, or physical Android hardware.
+A2 remains open.

--- a/patches/aurora-android-gamepad-lifecycle.patch
+++ b/patches/aurora-android-gamepad-lifecycle.patch
@@ -1,0 +1,176 @@
+--- a/include/aurora/input.hpp
++++ b/include/aurora/input.hpp
+@@ -40,4 +40,9 @@
+ bool set_standard_gamepad_rumble(uint32_t player, bool allowSingleUnassigned,
+                                  bool enabled) noexcept;
+ 
++// Enables or suspends the standard gamepad bridge. Suspension makes snapshots
++// neutral immediately and stops any active rumble before Android releases its
++// native surface. Rumble stop requests remain accepted while suspended.
++void set_standard_gamepads_active(bool active) noexcept;
++
+ }  // namespace aurora::input
+--- a/lib/input.cpp
++++ b/lib/input.cpp
+@@ -14,6 +14,8 @@
+ #include <absl/container/flat_hash_map.h>
+ #include <algorithm>
+ #include <array>
++#include <atomic>
++#include <mutex>
+ #include <string>
+ #include <utility>
+ 
+@@ -24,6 +26,9 @@
+ absl::flat_hash_map<Uint32, GameController> g_GameControllers;
+ 
+ namespace {
++std::atomic_bool g_standardGamepadsActive{true};
++std::mutex g_standardGamepadBridgeMutex;
++
+ constexpr uint32_t kPortPreferencesMagic = SBIG('CPRT');
+ constexpr uint32_t kPortPreferencesVersion = 2;
+ constexpr uint32_t kMaxPersistedStringLength = 256;
+@@ -369,6 +374,11 @@
+   }
+   *state = {};
+ 
++  std::scoped_lock lock(g_standardGamepadBridgeMutex);
++  if (!g_standardGamepadsActive.load(std::memory_order_acquire)) {
++    return false;
++  }
++
+   GameController* controller =
+       resolve_standard_gamepad(player, allowSingleUnassigned);
+   if (controller == nullptr || controller->m_controller == nullptr ||
+@@ -408,6 +418,11 @@
+ 
+ bool set_standard_gamepad_rumble(uint32_t player, bool allowSingleUnassigned,
+                                  bool enabled) noexcept {
++  std::scoped_lock lock(g_standardGamepadBridgeMutex);
++  if (enabled &&
++      !g_standardGamepadsActive.load(std::memory_order_acquire)) {
++    return false;
++  }
+   GameController* controller =
+       resolve_standard_gamepad(player, allowSingleUnassigned);
+   if (controller == nullptr || controller->m_controller == nullptr ||
+@@ -420,6 +435,25 @@
+   const uint16_t high = enabled ? controller->m_rumbleIntensityHigh : 0;
+   return SDL_RumbleGamepad(controller->m_controller, low, high,
+                            enabled ? 0xffffffffu : 0u);
++}
++
++void set_standard_gamepads_active(bool active) noexcept {
++  std::scoped_lock lock(g_standardGamepadBridgeMutex);
++  const bool previous =
++      g_standardGamepadsActive.exchange(active, std::memory_order_acq_rel);
++  if (previous == active) {
++    return;
++  }
++
++  if (!active) {
++    for (const auto& [instance, controller] : g_GameControllers) {
++      (void)instance;
++      if (controller.m_controller != nullptr && controller.m_hasRumble) {
++        SDL_RumbleGamepad(controller.m_controller, 0, 0, 0);
++      }
++    }
++  }
++  Log.info("Standard gamepads {}", active ? "resumed" : "suspended");
+ }
+ 
+ Sint32 get_instance_for_player(uint32_t player) noexcept {
+@@ -433,6 +467,7 @@
+ }
+ 
+ SDL_JoystickID add_controller(SDL_JoystickID which) noexcept {
++  std::scoped_lock lock(g_standardGamepadBridgeMutex);
+   if (g_GameControllers.contains(which)) {
+     return which;
+   }
+@@ -467,6 +502,7 @@
+ }
+ 
+ bool refresh_controller(SDL_JoystickID instance) noexcept {
++  std::scoped_lock lock(g_standardGamepadBridgeMutex);
+   const auto it = g_GameControllers.find(instance);
+   if (it == g_GameControllers.end()) {
+     return false;
+@@ -480,6 +516,7 @@
+ }
+ 
+ void remove_controller(Uint32 instance) noexcept {
++  std::scoped_lock lock(g_standardGamepadBridgeMutex);
+   if (auto it = g_GameControllers.find(instance); it != g_GameControllers.end()) {
+     SDL_CloseGamepad(it->second.m_controller);
+     g_GameControllers.erase(it);
+@@ -576,6 +613,7 @@
+ }
+ 
+ void shutdown() noexcept {
++  std::scoped_lock lock(g_standardGamepadBridgeMutex);
+   // Upon shutdown we want to ensure all controllers are in a default state, so force all rumble supporting controllers
+   // to shut off their rumble motors.
+   for (const auto& controller : g_GameControllers) {
+--- a/lib/window.cpp
++++ b/lib/window.cpp
+@@ -8,6 +8,7 @@
+ #include <aurora/aurora.h>
+ #include <aurora/event.h>
+ #include <aurora/gfx.h>
++#include <aurora/input.hpp>
+ #include <aurora/render_size_limits.hpp>
+ #include <SDL3/SDL_error.h>
+ #include <SDL3/SDL_events.h>
+@@ -219,11 +219,20 @@
+     g_nativeResizePending.store(true, std::memory_order_release);
+     break;
+ #if defined(SDL_PLATFORM_ANDROID) || defined(SDL_PLATFORM_APPLE)
++  case SDL_EVENT_WILL_ENTER_BACKGROUND:
+   case SDL_EVENT_WINDOW_MINIMIZED:
+-    g_backgrounded.store(true, std::memory_order_relaxed);
++    g_backgrounded.store(true, std::memory_order_release);
++#if defined(SDL_PLATFORM_ANDROID)
++    input::set_standard_gamepads_active(false);
++#endif
+     break;
++  case SDL_EVENT_DID_ENTER_FOREGROUND:
+   case SDL_EVENT_WINDOW_RESTORED:
+-    g_backgrounded.store(false, std::memory_order_relaxed);
++    g_backgrounded.store(false, std::memory_order_release);
++#if defined(SDL_PLATFORM_ANDROID)
++    input::set_standard_gamepads_active(
++        g_surfaceReady.load(std::memory_order_acquire));
++#endif
+     break;
+ #endif
+   default:
+@@ -483,6 +492,12 @@
+       SDL_GetError());
+   TRY(SDL_InitSubSystem(SDL_INIT_EVENTS | SDL_INIT_VIDEO), "Error initializing SDL: {}", SDL_GetError());
+ 
++#if defined(SDL_PLATFORM_ANDROID)
++  input::set_standard_gamepads_active(
++      g_surfaceReady.load(std::memory_order_acquire) &&
++      !g_backgrounded.load(std::memory_order_acquire));
++#endif
++
+ #if !defined(_WIN32) && !defined(__APPLE__)
+   TRY(SDL_SetHint(SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, "0"), "Error setting {}: {}",
+       SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, SDL_GetError());
+@@ -603,7 +618,13 @@
+   return size.native_fb_width == width && size.native_fb_height == height;
+ }
+ 
+-void set_surface_ready(bool ready) noexcept { g_surfaceReady.store(ready, std::memory_order_release); }
++void set_surface_ready(bool ready) noexcept {
++  g_surfaceReady.store(ready, std::memory_order_release);
++#if defined(SDL_PLATFORM_ANDROID)
++  input::set_standard_gamepads_active(
++      ready && !g_backgrounded.load(std::memory_order_acquire));
++#endif
++}
+ 
+ SurfaceLock::SurfaceLock() noexcept {
+ #if defined(SDL_PLATFORM_ANDROID)

--- a/scripts/prepare-android-game-runtime.sh
+++ b/scripts/prepare-android-game-runtime.sh
@@ -38,6 +38,8 @@ patch --batch -p1 -d "$runtime_source/aurora-main" < \
   "$repo_root/patches/aurora-android-gamepad-snapshot.patch"
 patch --batch -p1 -d "$runtime_source/aurora-main" < \
   "$repo_root/patches/aurora-android-gamepad-rumble.patch"
+patch --batch -p1 -d "$runtime_source/aurora-main" < \
+  "$repo_root/patches/aurora-android-gamepad-lifecycle.patch"
 patch --batch -p1 -d "$runtime_source" < \
   "$repo_root/patches/wiicompiled-android-runtime.patch"
 patch --batch -p1 -d "$runtime_source" < \


### PR DESCRIPTION
## Summary
- suspend Aurora standard-gamepad snapshots while Android is backgrounded or its surface is unavailable
- reject rumble starts and stop active motors at the same lifecycle boundary
- serialize lifecycle shutdown with controller add/remap/remove and document exact emulator evidence

## Verification
- host `kartpad.android.gamepad-contract` CTest
- clean patch dry-run and fresh prepared-source byte comparison
- complete private Original ARM64 incremental compile/link
- exact API 36 / 4 KiB APK retained one PID across four HOME/surface recreation cycles with four suspend/resume pairs
- debug lint and release Kotlin compile
- runtime storage-layout contract
- strict APK/package/privacy audit
- repository safety and diff checks
- broad source verifier accepted 426 hunks across 46 patches and three pins, then stopped at the pre-existing ignored `rr-pulsar` checkout/lock mismatch

No controller was attached, so physical input/rumble acceptance remains open. No APK/AAB or private data was published.