### PR TITLE
Harden tvOS compiler baseline and align mobile aspect state

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,7 @@ narrower performance, audio, motion, and controller refinements can continue.
 | [`docs/STATUS.md`](docs/STATUS.md) | Accepted evidence, current risks, and honest open work |
 | [`docs/PERF.md`](docs/PERF.md) | Performance measurement contract and acceptance gates |
 | [`docs/KNOWN-ISSUES.md`](docs/KNOWN-ISSUES.md) | Known limitations and current workarounds |
+| [`docs/TECH-DEBT.md`](docs/TECH-DEBT.md) | Maintainer-owned follow-ups and the evidence required before they can ship |
 | [`docs/IOS-THREE-DOT-MENU-FIX.md`](docs/IOS-THREE-DOT-MENU-FIX.md) | Reusable UIKit menu appearance, lifecycle repair, and validation checklist |
 | [`docs/FUTURE-FEATURES.md`](docs/FUTURE-FEATURES.md) | Researched but deferred product features, beginning with RetroAchievements |
 | [`docs/releases/NEXT.md`](docs/releases/NEXT.md) | Living Preview 5 validation and publication record |

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -1,0 +1,100 @@
+# Technical debt
+
+This file records useful engineering directions that have not cleared KartPad's
+acceptance gates. An entry is not a release promise, an accepted implementation,
+or evidence that the feature works. External pull requests listed here are source
+material only; any follow-up is maintainer-owned and must pass the gates below on
+its exact submitted artifact.
+
+## tvOS A12 compiler baseline
+
+Status: implementation in progress.
+
+The tvOS WiiCompiled targets should use a generic AArch64 CPU baseline and
+explicitly disable RCpc instruction selection. `-mcpu=generic` alone is not
+sufficient with the tested Apple Clang toolchain: it can still emit RCpc loads
+that fault on the A12 Apple TV. Other Apple targets retain the existing Apple M2
+tuning.
+
+Acceptance requires all of the following:
+
+- the generated tvOS Xcode project contains `-mcpu=generic` and
+  `-Xclang -target-feature -Xclang -rcpc` for every WiiCompiled runtime target;
+- the relevant runtime objects and final executable contain no unsupported RCpc
+  load instructions;
+- the exact resulting app boots, reaches the title screen, produces audio, and
+  completes a race on an A12 Apple TV; and
+- macOS and iOS build behavior remains unchanged.
+
+Source: pull request [#31](https://github.com/chrissotraidis/kartpad/pull/31)
+and its physical-device follow-up. The submitted pull-request head did not
+include the RCpc fix.
+
+## tvOS settings and aspect presentation
+
+Status: design split required.
+
+A Settings bundle could eventually expose presentation preferences, and the
+aspect-ratio behavior should be made explicit. Those are separate decisions from
+the first-run controller and launch-mode flow. The current controller-required
+screen and mode chooser remain part of the tvOS safety and acceptance contract;
+they must not disappear as a side effect of adding preferences.
+
+Acceptance requires all of the following:
+
+- controller-required messaging and input gating remain intact;
+- preference defaults, relaunch behavior, and migration are deterministic;
+- 4:3, 16:9, and fill presentation are verified in menus and gameplay without
+  clipping or stretching regressions;
+- the runtime's reported aspect ratio agrees with the selected presentation; and
+- iPhone and iPad presentation behavior remains unchanged.
+
+Source: pull request [#32](https://github.com/chrissotraidis/kartpad/pull/32).
+
+## tvOS controller rumble
+
+Status: hardware experiment required.
+
+Core Haptics may provide controller rumble on supported tvOS controllers, but
+the engine lifecycle has to be treated as recoverable state. Cached player state
+must not suppress a restart after the engine resets, stops, the controller
+disconnects, or the system sleeps.
+
+Acceptance requires all of the following:
+
+- reset and stopped handlers reconcile the engine and cached active-player state;
+- unsupported controllers and haptic localities fail safely;
+- start, update, stop, disconnect, reconnect, interruption, and sleep/wake paths
+  are exercised;
+- the emulation path remains non-blocking; and
+- physical controllers confirm observable output for representative game events.
+
+Source: pull request [#33](https://github.com/chrissotraidis/kartpad/pull/33).
+
+## Dolby Pro Logic II to multichannel LPCM
+
+Status: audio experiment required.
+
+Decoded multichannel output may be useful when tvOS exposes a compatible route,
+but it must preserve the existing stereo path and cannot be accepted from channel
+plumbing alone. The exact app must demonstrate meaningful rear-channel content
+and correct channel ordering on physical output hardware.
+
+Acceptance requires all of the following:
+
+- stereo remains the deterministic fallback for unsupported or changing routes;
+- the physical run uses the exact submitted source and compiler baseline;
+- front and rear channel mapping is verified with non-zero, audible content;
+- route changes, pause/resume, underruns, latency, and a sustained soak pass; and
+- documentation avoids center or LFE claims unless those channels are actually
+  decoded and verified.
+
+Source: pull request [#35](https://github.com/chrissotraidis/kartpad/pull/35).
+
+## Integration order
+
+1. Establish and physically accept the A12 compiler baseline.
+2. Treat aspect semantics as a focused change that preserves controller safety.
+3. Evaluate haptics and multichannel audio as independent hardware experiments.
+4. Rebase each experiment independently and resolve its runtime-host conflicts
+   before combining any accepted work.

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -1,14 +1,15 @@
 # Technical debt
 
-This file records useful engineering directions that have not cleared KartPad's
-acceptance gates. An entry is not a release promise, an accepted implementation,
-or evidence that the feature works. External pull requests listed here are source
-material only; any follow-up is maintainer-owned and must pass the gates below on
-its exact submitted artifact.
+This file records useful engineering directions that have not fully cleared
+KartPad's acceptance gates. An entry is not a release promise or evidence that a
+feature works on untested hardware. External pull requests listed here are source
+material only; any follow-up is maintainer-owned and its completed and remaining
+gates are stated explicitly below.
 
 ## tvOS A12 compiler baseline
 
-Status: implementation in progress.
+Status: defensive compiler hardening implemented; physical A12 compatibility
+unverified.
 
 The tvOS WiiCompiled targets should use a generic AArch64 CPU baseline and
 explicitly disable RCpc instruction selection. `-mcpu=generic` alone is not
@@ -16,15 +17,18 @@ sufficient with the tested Apple Clang toolchain: it can still emit RCpc loads
 that fault on the A12 Apple TV. Other Apple targets retain the existing Apple M2
 tuning.
 
-Acceptance requires all of the following:
+Completed integration evidence:
 
 - the generated tvOS Xcode project contains `-mcpu=generic` and
   `-Xclang -target-feature -Xclang -rcpc` for every WiiCompiled runtime target;
-- the relevant runtime objects and final executable contain no unsupported RCpc
-  load instructions;
-- the exact resulting app boots, reaches the title screen, produces audio, and
-  completes a race on an A12 Apple TV; and
-- macOS and iOS build behavior remains unchanged.
+- the final tvOS executable contains no unsupported RCpc load instructions;
+- the complete unsigned tvOS build and app audit pass; and
+- the complete iOS Simulator build and app audit pass without changing its CPU
+  tuning.
+
+An A12 compatibility claim still requires the exact resulting app to boot, reach
+the title screen, produce audio, and complete a race on an A12 Apple TV. Until
+such evidence is available, the change is described only as compiler hardening.
 
 Source: pull request [#31](https://github.com/chrissotraidis/kartpad/pull/31)
 and its physical-device follow-up. The submitted pull-request head did not
@@ -32,13 +36,17 @@ include the RCpc fix.
 
 ## tvOS settings and aspect presentation
 
-Status: design split required.
+Status: aspect-state consistency implemented; presentation choices remain deferred.
 
 A Settings bundle could eventually expose presentation preferences, and the
 aspect-ratio behavior should be made explicit. Those are separate decisions from
 the first-run controller and launch-mode flow. The current controller-required
 screen and mode chooser remain part of the tvOS safety and acceptance contract;
 they must not disappear as a side effect of adding preferences.
+
+The mobile settings bridge now reports the selected aspect mode through the
+guest `SCGetAspectRatio` result. This removes a deterministic state mismatch
+without adding new tvOS settings UI or changing the accepted launch flow.
 
 Acceptance requires all of the following:
 
@@ -93,7 +101,8 @@ Source: pull request [#35](https://github.com/chrissotraidis/kartpad/pull/35).
 
 ## Integration order
 
-1. Establish and physically accept the A12 compiler baseline.
+1. Retain the statically verified A12 compiler hardening and keep physical
+   compatibility explicitly unclaimed unless exact-artifact evidence arrives.
 2. Treat aspect semantics as a focused change that preserves controller safety.
 3. Evaluate haptics and multichannel audio as independent hardware experiments.
 4. Rebase each experiment independently and resolve its runtime-host conflicts

--- a/patches/wiicompiled-apple-runtime.patch
+++ b/patches/wiicompiled-apple-runtime.patch
@@ -222,12 +222,17 @@ diff -ruN --exclude=.git --exclude=third_party --exclude=build a/cmake/PublicPro
 
      set(MKW_WII_BOOTSTRAP_SOURCE_DIR "${MKW_RUNTIME_SOURCE_DIR}/assets/wii")
      if(NOT EXISTS "${MKW_WII_BOOTSTRAP_SOURCE_DIR}/shared2/wc24")
-@@ -287,6 +291,6 @@
+@@ -287,6 +291,11 @@
      mkw_retro_rewind_functions WiiCompiled RetroRewind)
  foreach(target IN LISTS MKW_ALL_BUILD_TARGETS)
      if(TARGET ${target})
 -        target_compile_options(${target} PRIVATE -march=x86-64-v3)
-+        target_compile_options(${target} PRIVATE -mcpu=apple-m2)
++        if(CMAKE_SYSTEM_NAME STREQUAL "tvOS")
++            target_compile_options(${target} PRIVATE
++                "SHELL:-mcpu=generic -Xclang -target-feature -Xclang -rcpc")
++        else()
++            target_compile_options(${target} PRIVATE -mcpu=apple-m2)
++        endif()
      endif()
  endforeach()
 diff -ruN --exclude=.git --exclude=third_party --exclude=build a/include/audio_backend.h b/include/audio_backend.h

--- a/patches/wiicompiled-ios-settings-bridge.patch
+++ b/patches/wiicompiled-ios-settings-bridge.patch
@@ -106,6 +106,37 @@ index db9be6c..1fb9754 100644
      // Wait for the frame worker's DONE phase: it has replayed the previous frame's ImGui draw lists
      // and started the next ImGui frame, so all overlay callers can now safely issue ImGui commands.
      aurora_wait_for_frame_worker();
+diff --git a/src/hle/sc.cpp b/src/hle/sc.cpp
+--- a/src/hle/sc.cpp
++++ b/src/hle/sc.cpp
+@@ -1,6 +1,12 @@
+ #include "hle_stubs.h"
+ 
++#if defined(__APPLE__)
++#include <TargetConditionals.h>
++#if TARGET_OS_IOS || TARGET_OS_TV
++#include "kartpad_mobile_runtime_host.h"
++#endif
++#endif
+ #include "console_identity.h"
+ #include <cstdlib>
+ #include <cstddef>
+ #include <cstdint>
+@@ -32,6 +38,13 @@
+ // 0x801B1BE4 -> SCGetAspectRatio()
+ // Returns: 0 = 4:3, 1 = 16:9
+ extern "C" uint32_t SCGetAspectRatio_HLE()
+ {
+-    return RuntimeConfigFile::WidescreenEnabled(true) ? 1u : 0u;
++    bool widescreen = RuntimeConfigFile::WidescreenEnabled(true);
++#if defined(__APPLE__) && (TARGET_OS_IOS || TARGET_OS_TV)
++    KartPadMobileRuntimeSettings settings{};
++    if (KartPadMobileReadRuntimeSettings(&settings)) {
++        widescreen = settings.aspectRatioMode != 0;
++    }
++#endif
++    return widescreen ? 1u : 0u;
+ }
 diff --git a/src/dynamic_aspect.cpp b/src/dynamic_aspect.cpp
 index 5c1601c..0a56fc2 100644
 --- a/src/dynamic_aspect.cpp

--- a/scripts/audit-tvos-app.sh
+++ b/scripts/audit-tvos-app.sh
@@ -46,6 +46,11 @@ done
 build_metadata="$(xcrun vtool -show-build "${binary}")"
 test "$(awk '/platform/{print $2; exit}' <<<"${build_metadata}")" = "${expected_platform}"
 test "$(awk '/minos/{print $2; exit}' <<<"${build_metadata}")" = "17.0"
+if [[ "${expected_platform}" = "TVOS" ]] &&
+   xcrun llvm-objdump -d "${binary}" | rg -i '\bldap(?:r|ur)[a-z]*\b' >/dev/null; then
+  echo "ERROR: tvOS app contains an A12-incompatible RCpc load instruction" >&2
+  exit 69
+fi
 
 for forbidden in '*.wbfs' '*.iso' '*.rvz' '*.wia' '*.gcz' 'rksys.dat' \
                  '*.mobileprovision' 'opening.bnr' 'banner.bin' 'icon.bin' \

--- a/scripts/build-tvos-game-app.sh
+++ b/scripts/build-tvos-game-app.sh
@@ -95,6 +95,14 @@ cmake -S "${runtime_source}" -B "${xcode_build}" -G Xcode \
   -DMKW_KARTPAD_REPO_ROOT="${repo_root}" \
   -DMKW_KARTPAD_MINIZIP_SOURCE_DIR="${minizip_source}" \
   -DMKW_TRANSLATED_COMPILE_JOBS=2
+if [[ "${sdk}" = "appletvos" ]]; then
+  project="${xcode_build}/mkw_recompiled.xcodeproj/project.pbxproj"
+  if ! rg -F -q -- "'-mcpu=generic' -Xclang -target-feature -Xclang -rcpc" \
+      "${project}"; then
+    echo "ERROR: tvOS runtime targets are missing the A12-safe compiler baseline" >&2
+    exit 69
+  fi
+fi
 cmake --build "${xcode_build}" --config Release --target KartPadDual -- \
   -quiet -sdk "${sdk}" CODE_SIGNING_ALLOWED=NO
 

--- a/tests/test_tvos_contract.py
+++ b/tests/test_tvos_contract.py
@@ -42,6 +42,15 @@ class TvOSContractTests(unittest.TestCase):
         self.assertNotIn("-mcpu=apple-m2", tvos_options)
         self.assertIn("-mcpu=apple-m2", non_tvos_options)
 
+    def test_mobile_aspect_setting_reaches_the_guest_system_config(self):
+        patch = (ROOT / "patches/wiicompiled-ios-settings-bridge.patch").read_text()
+        sc_bridge = patch.split("diff --git a/src/hle/sc.cpp", 1)[1].split(
+            "diff --git a/src/dynamic_aspect.cpp", 1
+        )[0]
+        self.assertIn("TARGET_OS_IOS || TARGET_OS_TV", sc_bridge)
+        self.assertIn("KartPadMobileReadRuntimeSettings(&settings)", sc_bridge)
+        self.assertIn("widescreen = settings.aspectRatioMode != 0", sc_bridge)
+
     def test_tvos_host_uses_purgeable_cache_storage(self):
         host = (ROOT / "apple/tvos/KartPadTVRuntimeHost.mm").read_text()
         self.assertIn("NSCachesDirectory", host)

--- a/tests/test_tvos_contract.py
+++ b/tests/test_tvos_contract.py
@@ -28,6 +28,20 @@ class TvOSContractTests(unittest.TestCase):
         self.assertIn("MINIZIP::minizip", patch)
         self.assertIn("KARTPAD_TVOS_BUNDLE_IDENTIFIER", patch)
 
+    def test_tvos_runtime_uses_an_a12_safe_cpu_baseline(self):
+        patch = (ROOT / "patches/wiicompiled-apple-runtime.patch").read_text()
+        compiler_options = patch.split(
+            '+        if(CMAKE_SYSTEM_NAME STREQUAL "tvOS")', 1
+        )[1]
+        tvos_options = compiler_options.split("+        else()", 1)[0]
+        non_tvos_options = compiler_options.split("+        else()", 1)[1].split(
+            "+        endif()", 1
+        )[0]
+        self.assertIn("-mcpu=generic", tvos_options)
+        self.assertIn("-Xclang -target-feature -Xclang -rcpc", tvos_options)
+        self.assertNotIn("-mcpu=apple-m2", tvos_options)
+        self.assertIn("-mcpu=apple-m2", non_tvos_options)
+
     def test_tvos_host_uses_purgeable_cache_storage(self):
         host = (ROOT / "apple/tvos/KartPadTVRuntimeHost.mm").read_text()
         self.assertIn("NSCachesDirectory", host)
@@ -116,6 +130,10 @@ class TvOSContractTests(unittest.TestCase):
         diagnostics = (ROOT / "scripts/collect-tvos-diagnostics.sh").read_text()
         self.assertIn("CODE_SIGNING_ALLOWED=NO", build)
         self.assertIn("KartPadDual", build)
+        self.assertIn(
+            "'-mcpu=generic' -Xclang -target-feature -Xclang -rcpc", build
+        )
+        self.assertIn("A12-incompatible RCpc load instruction", audit)
         dawn = (ROOT / "scripts/build-dawn-tvos.sh").read_text()
         self.assertIn("-ffile-prefix-map=${repo_root}=KartPad", dawn)
         self.assertIn("TVOS", audit)


### PR DESCRIPTION
## Summary

- add a maintainer-owned technical-debt register for the useful ideas from #31, #32, #33, and #35
- use a generic tvOS CPU baseline and explicitly disable RCpc instruction selection
- fail the tvOS build if Xcode drops either Clang forwarding token
- fail the physical-tvOS app audit if the final executable contains RCpc load instructions
- make the guest SCGetAspectRatio result follow the existing iOS/tvOS host aspect setting without adding Settings.bundle or changing controller/launch UI

## Validation

- patch hunk verification: passed (339 hunks)
- tvOS contract tests: 10 passed
- builder tests: 20 passed
- full unsigned AppleTVOS build and strengthened app audit: passed
- generated compiler response: -mcpu=generic -Xclang -target-feature -Xclang -rcpc
- final tvOS executable RCpc scan: clear
- full dual-mode iOS Simulator build and app audit: passed

## Evidence boundary

This is safe to integrate as compiler hardening and a deterministic aspect-state consistency fix. It does not establish or claim physical A12 compatibility. Rumble, tvOS Settings UI, and multichannel audio remain deferred pending hardware-observable evidence.