### PR TITLE
Android A2: expose debug state trace and prove emulator race

### DIFF
--- a/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
@@ -18,6 +18,7 @@ class KartPadActivity : SDLActivity() {
             Os.setenv("KARTPAD_ANDROID_FILES_DIR", filesDir.absolutePath, true)
             Os.setenv("KARTPAD_ANDROID_CACHE_DIR", cacheDir.absolutePath, true)
             configureDebugRkgInput()
+            configureDebugStateTrace()
         }
         super.onCreate(savedInstanceState)
         val overlay = KartPadOverlayView(this)
@@ -69,11 +70,29 @@ class KartPadActivity : SDLActivity() {
         }
     }
 
+    private fun configureDebugStateTrace() {
+        if (!BuildConfig.DEBUG) return
+
+        val marker = File(filesDir, DEBUG_STATE_TRACE_MARKER_RELATIVE_PATH)
+        if (marker.isFile) {
+            val output = File(filesDir, DEBUG_STATE_TRACE_RELATIVE_PATH)
+            output.parentFile?.mkdirs()
+            Os.setenv("KARTPAD_STATE_TRACE", output.absolutePath, true)
+            Log.i(TAG, "Debug app-private state trace enabled")
+        } else {
+            Os.unsetenv("KARTPAD_STATE_TRACE")
+        }
+    }
+
     companion object {
         private const val TAG = "KartPadFixture"
         private const val DEBUG_RKG_RELATIVE_PATH = "KartPad/Diagnostics/TestInput.rkg"
         private const val DEBUG_RKG_KEYBOARD_STEER_RELATIVE_PATH =
             "KartPad/Diagnostics/TestInput.keyboard-steer"
+        private const val DEBUG_STATE_TRACE_MARKER_RELATIVE_PATH =
+            "KartPad/Diagnostics/StateTrace.enable"
+        private const val DEBUG_STATE_TRACE_RELATIVE_PATH =
+            "KartPad/Diagnostics/StateTrace.csv"
         private const val MIN_RKG_BYTES = 0x90L
         private const val MAX_RKG_BYTES = 1024L * 1024L
         private val RKG_MAGIC = byteArrayOf('R'.code.toByte(), 'K'.code.toByte(), 'G'.code.toByte(), 'D'.code.toByte())

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -789,17 +789,21 @@ AArch64 scheduler/register stress pass on both pinned AVDs. A2's private
 Its exact public resources install before SDL loads, and a cleared API 36
 launch reaches translated constructors and Vulkan using only app-private
 config/cache/NAND paths before the expected missing-DVD failure. Continue A2 by
-staging the validated ignored DATA directory outside the APK, setting its
-app-private path, and using the new Aurora-to-Classic SDL controller bridge to
-prove a complete controller-driven player race, results, and save/relaunch
-without weakening the package privacy boundary. The bridge's deterministic
+staging the validated ignored DATA directory outside the APK and setting its
+app-private path. One content-free trace feedback run now proves a complete
+three-lap emulator player race and retail results through ordinary Android key
+events without guest-state writes. Next reproduce post-race save creation and
+controller input after cold relaunch, then use the Aurora-to-Classic SDL
+controller bridge to repeat the complete race without weakening the package
+privacy boundary. The bridge's deterministic
 source-only contract passes on both page-size lanes, and Android
 `WPADControlMotor` now routes Start/Stop output to the same resolved SDL pad.
 Surface loss/backgrounding suspends the bridge and stops active rumble; a
 corrected API 36 process retained its PID through four such cycles, although
 one preceding process ended silently after one cycle and remains unexplained.
-No controller input or rumble acceptance is claimed until actual hardware is
-attached. Do not repeat the rejected retail-KPAD RKG replay unchanged: even
+No attached-controller input or rumble acceptance is claimed until actual
+hardware is attached. Do not repeat the rejected retail-KPAD RKG replay
+unchanged: even
 the exact Baby Mario / Nanobike / Manual staff configuration diverged by guest
 time 8.580.
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -98,9 +98,12 @@ not block offline Retro Rewind support.
    survives repeated title/demo and live-race surface recreation, and sustains
    a clean retail staff replay. The debug-only app-private RKG bridge works,
    and an Android-only marker can replace only its steering with the debug
-   keyboard stick, but neither route completes a race. Exact GCN Mario Circuit
-   metadata and the macOS-proven SNES Mario Circuit 3 stream also diverge on
-   Android and must not be used as completion evidence. Aurora's discovered
+   keyboard stick. Those fixed replays diverge, but a content-free native
+   trace feedback run using ordinary Android key events completed all three
+   N64 Mario Raceway laps and reached retail results. The game declined ghost
+   saving, and injected keys did not advance the title after its cold relaunch,
+   so post-race save creation and controller-after-relaunch remain open.
+   Aurora's discovered
    SDL pads now feed the Android Classic/KPAD path through a deterministic
    mapping contract, and `WPADControlMotor` now reaches that same resolved pad
    through a fail-closed SDL rumble bridge. Surface loss/backgrounding now
@@ -108,17 +111,19 @@ not block offline Retro Rewind support.
    rumble; a corrected process retained its PID through four emulator cycles.
    One earlier corrected process ended silently after one cycle and remains an
    unexplained non-reproduced exit. No controller was attached, so
-   input and tactile behavior remain implementation/compile evidence only. A
+   attached-controller input and tactile behavior remain implementation/compile
+   evidence only. A
    temporary exact-configuration retail-KPAD RKG replay also diverged by guest
    time 8.580 and was removed; do not repeat it unchanged. Establish a complete
-   player race, results, post-race save/relaunch,
-   then repeat with a real controller and physical Android hardware. Evidence
+   reproducible post-race save/relaunch, then repeat the complete race with a
+   real controller and physical Android hardware. Evidence
    is in `docs/artifacts/2026-09-03/android/a2-emulator-boot-lifecycle.md` and
    `docs/artifacts/2026-09-03/android/a2-debug-input-replay.md`, plus
    `docs/artifacts/2026-09-03/android/a2-keyboard-steer-diagnostic.md` and
    `docs/artifacts/2026-09-03/android/a2-sdl-controller-bridge.md`, plus
    `docs/artifacts/2026-09-03/android/a2-sdl-controller-rumble.md`, plus
-   `docs/artifacts/2026-09-03/android/a2-controller-lifecycle.md`. A2
+   `docs/artifacts/2026-09-03/android/a2-controller-lifecycle.md`, plus
+   `docs/artifacts/2026-09-03/android/a2-state-trace-player-race.md`. A2
    remains open.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -1951,3 +1951,33 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   and physical Android acceptance remain open. No APK/AAB or private data was
   published. Evidence:
   `docs/artifacts/2026-09-03/android/a2-controller-lifecycle.md`.
+
+## 2026-09-03 — Android A2 complete trace-guided emulator race
+
+- Added a debug-only Android marker that binds the existing content-free
+  native state trace to a fixed app-private output before SDL starts. Marker
+  absence clears the environment variable; release builds do not inspect it.
+- A local feedback loop read only position, velocity, orientation, speed, and
+  stage counters, then emitted ordinary Android `U`/`M`/`A`/`D` key events
+  through the existing Classic/KPAD path. It never wrote guest state or forced
+  checkpoints, laps, or finish. Supervised normal-input recoveries spent one
+  collected mushroom and reversed/steered away from the final outer wall.
+- Mario completed all three N64 Mario Raceway Time Trial laps. Native stage 4
+  and a retail `05:17.517` result were visible; the summarizer accepts one
+  19,032-sample race segment from race time 240 through 19,271 and finish.
+- The game reported `Ghost data could not be saved.`, so no new ghost or race
+  record save is claimed. A force-stop/cold relaunch retained the staged save
+  byte-for-byte and reached title, but injected keys did not then advance the
+  title despite app focus. Controller-after-relaunch remains open.
+- One earlier restart in the same session ended silently without Java fatal,
+  signal, tombstone, or OOM; a controlled retry completed the race. The exact
+  pre-test save was restored by matching SHA-256, all app-private diagnostic
+  files were removed, and the emulator was stopped.
+- Debug/release Kotlin compilation, lint, full private ARM64 build, and strict
+  package/privacy audit pass. The local-only APK is 103,434,784 bytes with
+  SHA-256
+  `94b7049a855cba90f9040f55fd56c894c989186832b3f63eb67ac29e48d4584a`.
+  Classification: **Pass for the trace gate and a complete normal-input
+  emulator race/results; open for post-race save, controller-after-relaunch,
+  real controller/rumble, audible audio, and physical hardware.** Evidence:
+  `docs/artifacts/2026-09-03/android/a2-state-trace-player-race.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -139,6 +139,21 @@ attached, so actual neutral input and motor-stop behavior remain unaccepted.
 Evidence:
 [`docs/artifacts/2026-09-03/android/a2-controller-lifecycle.md`](artifacts/2026-09-03/android/a2-controller-lifecycle.md).
 
+An app-private debug marker now exposes the existing content-free native
+state trace at a fixed sandbox path before SDL starts. On the API 36 ARM64
+emulator, a feedback driver consumed only that trace and emitted ordinary
+Android keyboard events through the Classic/KPAD bridge. Mario completed all
+three N64 Mario Raceway Time Trial laps, reached native finish stage 4, and
+displayed retail results for `05:17.517`; the strict trace summarizer accepts
+one 19,032-sample race segment from countdown through finish. No guest-state
+write or forced finish was used. The game reported that ghost data could not
+be saved, and injected keys did not advance the title after the subsequent
+cold relaunch, so post-race save creation and controller-after-relaunch remain
+open. The original in-sandbox save was restored byte-for-byte and all debug
+markers were removed. A2 also remains open for attached-controller input and
+rumble, audible audio, and physical Android hardware. Evidence:
+[`docs/artifacts/2026-09-03/android/a2-state-trace-player-race.md`](artifacts/2026-09-03/android/a2-state-trace-player-race.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-03/android/a2-state-trace-player-race.md
+++ b/docs/artifacts/2026-09-03/android/a2-state-trace-player-race.md
@@ -1,0 +1,83 @@
+# Android A2 state-trace player race
+
+Date: 2026-09-03
+
+## Subgoal
+
+Expose the existing content-free native race-state trace to Android debug
+builds through an app-private, marker-gated path, then use only ordinary
+Android keyboard events through the shipping Classic/KPAD input bridge to
+complete a player race and reach retail results.
+
+## Implementation
+
+`KartPadActivity` now recognizes the debug-only app-private marker
+`KartPad/Diagnostics/StateTrace.enable` before SDL starts. When present it
+sets `KARTPAD_STATE_TRACE` to the fixed app-private output
+`KartPad/Diagnostics/StateTrace.csv`; when absent it clears the variable.
+Release builds never inspect the marker. The trace contains only counters,
+stage, position, velocity, quaternion, speed, and movement-direction values.
+It contains no game content, controller recording, save data, or identifiers.
+
+The exact final game APK is 103,434,784 bytes with SHA-256
+`94b7049a855cba90f9040f55fd56c894c989186832b3f63eb67ac29e48d4584a`.
+Debug and release Kotlin compilation, lint, the complete private ARM64 link,
+and the strict package/privacy audit pass.
+
+## Emulator result
+
+An API 36 / 4 KiB ARM64 AVD cold-launched the Original profile and entered an
+ordinary Time Trial on N64 Mario Raceway. A local feedback driver read only
+the content-free trace and emitted normal `U`/`M`/`A`/`D` Android key events;
+it did not write guest state, force a checkpoint, change lap state, or force a
+finish. One supervised recovery spent a legitimately collected mushroom
+through the normal Left Shift / Classic L item binding. A second supervised
+reverse-and-steer recovery freed the kart from the final outer wall.
+
+The retail game reached stage 4 after all three laps. The private trace has
+24,279 total samples and SHA-256
+`c25c769fcbf9ceff50c74f4063ce7ee633b72cfab691138a46a98f9724f7a0b7`.
+`scripts/summarize-mkw-state-trace.py --require-complete` accepts one
+19,032-sample race segment from race time 240 through 19,271 and the following
+finish stage. The visible results screen reported:
+
+- total `05:17.517`;
+- lap 1 `01:32.876`;
+- lap 2 `01:20.695`; and
+- lap 3 `02:23.946`.
+
+The finish and results captures remain ignored and private. Their SHA-256
+values are respectively
+`0b1cdefaa6d1c344d4e122d50b75e7f173e07c2c27d7545154a93f30a8ab2ce5`
+and
+`69c34998ae3e4bc7f30ed1b6dbe9fc809f77c1c45c5d5870c6771a7e518c9245`.
+
+The runtime stayed alive throughout the extended race. The same test session
+also reproduced one silent process exit during an earlier startup/restart;
+Android recorded no Java exception, fatal signal, tombstone, or OOM, and a
+controlled retry completed the race. This remains unresolved.
+
+## Relaunch and save boundary
+
+The game displayed `Ghost data could not be saved.` after the result, so this
+run is not evidence that a new Time Trial ghost or race record was committed.
+The staged save did remain byte-identical across a force-stop and cold
+relaunch, and the fresh process reached the title screen. Injected keyboard
+events then failed to advance the title in that fresh process despite the app
+retaining focus. Controller-after-cold-relaunch therefore remains a defect,
+not a passing result.
+
+Before shutdown, the exact pre-test in-sandbox save was restored. Its backup
+and restored SHA-256 both matched
+`aafe8b72a6a3ce823d13095a3237adaae9f540f975e6e04a7f4dd47fba188dd1`.
+The RKG, keyboard-steer, trace marker, trace output, and temporary save backup
+were removed from the app sandbox. No private file or APK/AAB was published.
+
+## Classification
+
+**Pass** for the debug app-private trace gate and for one complete
+normal-input emulator player race through retail finish and results.
+
+**Inconclusive/open** for post-race save creation, controller input after cold
+relaunch, attached SDL-controller input/rumble, audible audio, physical Android
+hardware, and release readiness. A2 remains open.


### PR DESCRIPTION
## Summary
- expose the existing content-free native state trace through a debug-only app-private Android marker
- prove one complete three-lap N64 Mario Raceway Time Trial through ordinary Android keyboard events and the Classic/KPAD bridge
- record strict trace/results evidence and preserve the remaining A2 boundaries

## Verification
- exact game APK: 103,434,784 bytes, SHA-256 `94b7049a855cba90f9040f55fd56c894c989186832b3f63eb67ac29e48d4584a`
- `scripts/audit-android-package.sh android/app/build/outputs/apk/debug/app-debug.apk`
- `scripts/check-repo-safety.sh`
- `python3 scripts/summarize-mkw-state-trace.py --self-test`
- debug/release Kotlin compilation and debug lint
- private native trace accepted one 19,032-sample race segment through stage 4; visible result `05:17.517`

## Boundaries
- the game reported that ghost data could not be saved, so post-race save creation is not claimed
- injected keyboard input did not advance the title after the subsequent cold relaunch
- no attached controller or physical Android device was available
- the exact pre-test save was restored and every app-private diagnostic marker was removed
- no APK/AAB or private evidence was published
