### PR TITLE
Record v0.4.2 release evidence

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -2,16 +2,19 @@
 
 ## Current state
 
-KartPad `v0.4.0` is published as the second stable community release from
-`369159153bef0d045edf5cc1cf3b1b444b36a284`. The iPhone/iPad app 0.4.0 build
-15 IPA has SHA-256
-`af80c2bc6fcabdb4eee84aed05254eccef76d7e6bbf83f2c7f21101168c665c8`;
-the experimental tvOS app 0.4.0 build 3 IPA has SHA-256
-`9ee2a9b05bff56261d4d4986eca54840e98ade8ae0abd3ac623c1f2393dcf5cc`.
+KartPad `v0.4.2` is published as the latest stable community release from
+`776a2a6a0e367b6d06f627c983f5da4a565ea104`. The iPhone/iPad app 0.4.2 build
+16 IPA has SHA-256
+`4c498de9a858bf9d59e6f082ebbe7a34e64935831601dc0981de42be8a8d473e`;
+the experimental tvOS app 0.4.2 build 5 IPA has SHA-256
+`0802f7e572da3df9b8daf5b09b45717584fad33c07d8be4ba5c6d8fadceaab3f`.
 Both exact-main builds and two independent packages per platform pass. Fresh
-anonymous downloads match the local bytes, checksums, provenance, and audits.
-GitHub marks this non-prerelease as **Latest**. Physical Apple TV acceptance
-remains open.
+hosted downloads match the local bytes, checksums, provenance, and audits.
+The release keeps iPhone/iPad as the accepted community path and carries the
+tvOS cache-root fix, generic AArch64 baseline, RCpc exclusion and binary audit,
+plus shared aspect-state synchronization. Physical testing of the exact tvOS
+artifact remains open, so A12 compatibility and supported Apple TV operation
+are not claimed.
 
 The `codex/iphone-touch-layout-editor` candidate captures the maintainer's
 current physical-iPhone control positions as the default for untouched iPhone
@@ -95,7 +98,7 @@ not block offline Retro Rewind support.
 1. Begin Android A0 on the authorized second machine using
    `docs/ANDROID-GOAL-LOOP.md`: bootstrap pinned tools and prove the source-only
    ARM64 SDL/JNI/Vulkan fixture before private game integration.
-2. Collect the first physical Apple TV report against `v0.4.0` using
+2. Collect a physical Apple TV report against the exact `v0.4.2` asset using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook
    Air cursor/settings retest requested against Preview 5.

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -26,12 +26,22 @@ limitations when its exact artifact passes every preview gate below.
 - [x] Use the generic tvOS CPU baseline with RCpc explicitly disabled
 - [x] Fail closed if Xcode drops the compiler forwarding sequence or the final
       tvOS executable contains an RCpc load instruction
-- [ ] Build and audit exact merged-source iOS 0.4.2 build 16 and tvOS build 5
-- [ ] Package both IPAs twice byte-identically and pass fresh extraction audits
-- [ ] Publish the stable tag, both IPAs, and `SHA256SUMS`
-- [ ] Verify fresh hosted downloads byte-for-byte and re-audit them
+- [x] Build and audit exact merged-source iOS 0.4.2 build 16 and tvOS build 5
+- [x] Package both IPAs twice byte-identically and pass fresh extraction audits
+- [x] Publish the stable tag, both IPAs, and `SHA256SUMS`
+- [x] Verify fresh hosted downloads byte-for-byte and re-audit them
 - [ ] Receive physical acceptance for the exact tvOS artifact before claiming
       A12 compatibility or supported Apple TV functionality
+
+Published source: `776a2a6a0e367b6d06f627c983f5da4a565ea104`.
+iPhone/iPad executable SHA-256:
+`fc9801af64251af68431ca04ce73c76d397cfff4d478c55c66c708cb86fcf704`.
+iPhone/iPad IPA SHA-256:
+`4c498de9a858bf9d59e6f082ebbe7a34e64935831601dc0981de42be8a8d473e`.
+tvOS executable SHA-256:
+`ceea40f50dd06d7a1ec7d37ee84cb620a5af74ec885cfb25babc9792583c0f30`.
+tvOS IPA SHA-256:
+`0802f7e572da3df9b8daf5b09b45717584fad33c07d8be4ba5c6d8fadceaab3f`.
 
 ## 0.4.1 tvOS storage hotfix candidate
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -25,11 +25,12 @@ platform, dependency, symbol, privacy, and private-data audit. An external Apple
 TV 4K (3rd generation) run on tvOS 26.5/26.6 accepted playable Original and
 Retro Rewind video, audio, menus, and Extended Gamepad input after moving the
 runtime from unwritable Application Support to Caches. The `v0.4.1` tvOS-only
-hotfix incorporates that path correction. The 0.4.2 candidate adds a generic
+hotfix incorporates that path correction. The 0.4.2 release adds a generic
 compiler baseline, explicitly disables RCpc instructions, and rejects those
-instructions during final-binary audit; exact public-artifact retesting,
-save recovery, sleep/wake, multi-controller, and sustained performance remain
-open. Apple TV support is therefore still experimental. The candidate includes
+instructions during final-binary audit; physical testing of the exact public
+artifact, save recovery, sleep/wake, multi-controller, and sustained
+performance remain open. Apple TV support is therefore still experimental. The
+release includes
 an original three-layer tvOS icon and Top Shelf image compiled into its audited
 asset catalog. The
 authoritative scope, build procedure, storage boundary, and external-testing
@@ -38,15 +39,23 @@ gate are in
 
 ## Current goal
 
-**0.4.2 is in release validation.** It refreshes the accepted iPhone/iPad path
-as app 0.4.2 build 16 and the experimental tvOS path as app 0.4.2 build 5. The
+**0.4.2 is published as the latest stable community release.** The `v0.4.2`
+tag dereferences to audited source commit
+`776a2a6a0e367b6d06f627c983f5da4a565ea104`. It refreshes the accepted
+iPhone/iPad path as app 0.4.2 build 16 and the experimental tvOS path as app
+0.4.2 build 5. The
 shared mobile runtime now reports the host-selected aspect mode through the
 guest system configuration. tvOS additionally uses a generic AArch64 compiler
 baseline with RCpc disabled and a fail-closed final-binary instruction audit.
 The release does not add tvOS Settings UI, controller rumble, or multichannel
 audio, and it does not claim physical A12 acceptance. Exact merged-source
-builds, deterministic packages, publication, and hosted verification remain
-release gates.
+builds and app audits passed; two packages per platform were byte-identical.
+Fresh hosted downloads matched the local files and passed checksum, ZIP,
+private-data, signing-residue, provenance, and app audits. The iPhone/iPad IPA
+SHA-256 is
+`4c498de9a858bf9d59e6f082ebbe7a34e64935831601dc0981de42be8a8d473e`;
+the experimental tvOS IPA SHA-256 is
+`0802f7e572da3df9b8daf5b09b45717584fad33c07d8be4ba5c6d8fadceaab3f`.
 
 **0.4.1 tvOS storage hotfix is published.** The `v0.4.1` tag dereferences to
 source commit `d0e77d5c9bc48a7f1f6aaedf79fd00d5e616dc0c`. Its tvOS app 0.4.1

--- a/docs/releases/NEXT.md
+++ b/docs/releases/NEXT.md
@@ -34,11 +34,20 @@ saves. Version 0.4.2 does not alter those host paths.
 
 ## Release gates
 
-- [ ] Merge and verify the complete release source on `main`.
-- [ ] Rebuild exact merged source as iOS 0.4.2 build 16 and tvOS build 5.
-- [ ] Pass full tests, source/safety checks, patch verification, and app audits.
-- [ ] Package each IPA twice deterministically and compare bytes.
-- [ ] Audit exact IPAs and embedded provenance/notices.
-- [ ] Tag the audited source and publish both IPAs plus `SHA256SUMS`.
-- [ ] Download hosted assets, byte-compare, checksum-verify, and re-audit.
-- [ ] Verify remote `main` and the dereferenced tag.
+- [x] Merge and verify the complete release source on `main`.
+- [x] Rebuild exact merged source as iOS 0.4.2 build 16 and tvOS build 5.
+- [x] Pass full tests, source/safety checks, patch verification, and app audits.
+- [x] Package each IPA twice deterministically and compare bytes.
+- [x] Audit exact IPAs and embedded provenance/notices.
+- [x] Tag the audited source and publish both IPAs plus `SHA256SUMS`.
+- [x] Download hosted assets, byte-compare, checksum-verify, and re-audit.
+- [x] Verify remote `main` and the dereferenced tag.
+
+Published source: `776a2a6a0e367b6d06f627c983f5da4a565ea104`.
+iPhone/iPad IPA SHA-256:
+`4c498de9a858bf9d59e6f082ebbe7a34e64935831601dc0981de42be8a8d473e`.
+Experimental tvOS IPA SHA-256:
+`0802f7e572da3df9b8daf5b09b45717584fad33c07d8be4ba5c6d8fadceaab3f`.
+
+Physical acceptance of the exact tvOS release remains open and is required
+before any A12 compatibility or supported Apple TV claim.


### PR DESCRIPTION
Records the published v0.4.2 source, executable and IPA hashes, deterministic packaging result, hosted byte comparison, and remaining physical tvOS acceptance boundary.