### PR TITLE
Android A2: make SDL controller polling guest-fiber safe

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -68,6 +68,22 @@ serial. A pass is only preflight evidence: the printed manual rows still
 require a hands-on physical race, save/relaunch, lifecycle checks, listening,
 and tactile rumble confirmation.
 
+Keep a full session log only in an ignored private path, then create a bounded
+publishable signal summary without copying arbitrary log lines:
+
+```sh
+./scripts/summarize-android-a2-session.py --require-signal-matrix \
+  private/android-a2-physical-session.log
+```
+
+Strict mode accepts only one capture (or standard input) and requires
+controller connection, initialized and non-silent SDL audio with submitted
+bytes, one complete surface pause/resume cycle, and no fatal signature. Its
+strict lifecycle row also requires the standard-gamepad suspend/resume pair.
+Its result is automated runtime evidence only; audible quality, tactile
+rumble, race completion, saved-result reload, and performance remain hands-on
+checks.
+
 On an Apple Silicon Mac, explicitly install the pinned public toolchain and
 AVDs, then verify it:
 

--- a/android/README.md
+++ b/android/README.md
@@ -84,6 +84,22 @@ Its result is automated runtime evidence only; audible quality, tactile
 rumble, race completion, saved-result reload, and performance remain hands-on
 checks.
 
+For the physical run, the preferred two-phase wrapper avoids writing raw
+logcat to the host at all:
+
+```sh
+./scripts/capture-android-a2-session.sh start
+# Complete the controller race, lifecycle, listening, and rumble checks.
+./scripts/capture-android-a2-session.sh summarize \
+  > .android-bootstrap/android-a2-physical-runtime-signals.json
+```
+
+`start` records only the device's log timestamp in the ignored bootstrap
+directory. `summarize` requests logs from that timestamp for KartPad's package
+UID, streams them directly through the strict sanitizer, and emits only JSON
+on stdout. ADB errors are suppressed or serial-redacted. Review the JSON before
+copying it into a publishable evidence directory.
+
 On an Apple Silicon Mac, explicitly install the pinned public toolchain and
 AVDs, then verify it:
 

--- a/android/README.md
+++ b/android/README.md
@@ -46,10 +46,27 @@ With an already validated ignored RMCP01 DATA directory staged separately in
 that private storage, the API 36 emulator now boots and renders the Original
 title/demo loop. Six consecutive HOME/foreground surface generations retained
 one process and resumed presentation; three more did the same in a live race,
-and a saved license survived three cold launches. See
-`docs/artifacts/2026-09-03/android/a2-emulator-boot-lifecycle.md` for the exact
-evidence and open failures. A2 remains open: the complete race/results,
-save/relaunch, real-controller, and physical-device rows are not yet proven.
+and a saved license survived three cold launches. A controller-driven emulator
+run also completed a three-lap race, saved a ghost, and visibly reloaded it
+after force-stop/relaunch. See
+`docs/artifacts/2026-09-04/android/a2-controller-complete-race-save.md` for the
+latest evidence and open failures. A2 remains open for a physical Android
+device and controller, tactile rumble, audible output, and performance.
+
+Before changing or installing anything on a physical device, connect exactly
+one authorized ADB target and run the read-only A2 intake check:
+
+```sh
+./scripts/check-android-physical-device.sh
+./scripts/test-android-physical-device-preflight.sh
+```
+
+The check rejects emulators and unsupported API, ABI, page-size, or free-space
+configurations. It reports whether Android currently exposes a controller
+source, the KartPad package, and Vulkan inventory without printing the ADB
+serial. A pass is only preflight evidence: the printed manual rows still
+require a hands-on physical race, save/relaunch, lifecycle checks, listening,
+and tactile rumble confirmation.
 
 On an Apple Silicon Mac, explicitly install the pinned public toolchain and
 AVDs, then verify it:

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -20,9 +20,11 @@
   versioned public resources plus Context-derived app-private config/cache/
   NAND paths. Its SDL controller bridge now also fails neutral and stops rumble
   across Android surface loss/backgrounding, survives virtual hotplug/reconnect,
-  and accepts short controller presses after a controller-attached cold launch.
-  Continue A2 with a complete controller-driven race/save; keep emulator and
-  physical-device claims separate.
+  accepts short controller presses after a controller-attached cold launch,
+  and completes a three-lap controller-driven emulator race with a durable
+  ghost that reloads after force-stop/relaunch. Continue A2 on a real
+  controller and physical Android device; keep emulator and physical-device
+  claims separate.
 
 KartPad can be ported to Android without changing its defining architecture.
 The Android build should contain the same ahead-of-time translated Original
@@ -790,14 +792,11 @@ AArch64 scheduler/register stress pass on both pinned AVDs. A2's private
 29,065-function Original runtime compiles, links, and packages through Gradle.
 Its exact public resources install before SDL loads, and a cleared API 36
 launch reaches translated constructors and Vulkan using only app-private
-config/cache/NAND paths before the expected missing-DVD failure. Continue A2 by
-staging the validated ignored DATA directory outside the APK and setting its
-app-private path. One content-free trace feedback run now proves a complete
-three-lap emulator player race and retail results through ordinary Android key
-events without guest-state writes. Next reproduce post-race save creation and
-controller input after cold relaunch, then use the Aurora-to-Classic SDL
-controller bridge to repeat the complete race without weakening the package
-privacy boundary. The bridge's deterministic source-only contract passes on
+config/cache/NAND paths before the expected missing-DVD failure. Validated
+ignored DATA staged outside the APK now boots the complete game. One content-
+free trace feedback run first proved a complete three-lap emulator player race
+and retail results through ordinary Android key events without guest-state
+writes. The bridge's deterministic source-only contract passes on
 both page-size lanes, and Android `WPADControlMotor` routes Start/Stop output
 to the same resolved SDL pad. A temporary emulator virtual gamepad now proves
 Android InputReader/SDL discovery, mapped button and analog input, disconnect,
@@ -805,8 +804,12 @@ reconnect, and same-PID HOT background/foreground behavior. That test exposed
 and fixed ART CheckJNI aborts caused by Java-backed SDL polling from switched
 Wii guest-fiber stacks; Android polling is now scheduler-stack-only and KPAD
 reads cached event state. The earlier cold-title input observation was a
-cadence false alarm. Continue with a natural controller-driven complete race,
-post-race save/relaunch, and physical Bluetooth/USB controller plus rumble;
+cadence false alarm. The same exact APK now also completes a three-lap
+controller-driven N64 Mario Raceway run at `04:28.063`, saves the KartPad
+ghost, retains the changed save hash across a controller-attached force-stop
+and cold launch, and visibly reloads the record. Continue with a physical
+Bluetooth/USB controller plus tactile rumble, audible-output confirmation,
+performance acceptance, and the complete run on physical Android hardware;
 the emulator virtual pad is not physical acceptance. Do not repeat the
 rejected retail-KPAD RKG replay unchanged: even
 the exact Baby Mario / Nanobike / Manual staff configuration diverged by guest

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -795,15 +795,18 @@ three-lap emulator player race and retail results through ordinary Android key
 events without guest-state writes. Next reproduce post-race save creation and
 controller input after cold relaunch, then use the Aurora-to-Classic SDL
 controller bridge to repeat the complete race without weakening the package
-privacy boundary. The bridge's deterministic
-source-only contract passes on both page-size lanes, and Android
-`WPADControlMotor` now routes Start/Stop output to the same resolved SDL pad.
-Surface loss/backgrounding suspends the bridge and stops active rumble; a
-corrected API 36 process retained its PID through four such cycles, although
-one preceding process ended silently after one cycle and remains unexplained.
-No attached-controller input or rumble acceptance is claimed until actual
-hardware is attached. Do not repeat the rejected retail-KPAD RKG replay
-unchanged: even
+privacy boundary. The bridge's deterministic source-only contract passes on
+both page-size lanes, and Android `WPADControlMotor` routes Start/Stop output
+to the same resolved SDL pad. A temporary emulator virtual gamepad now proves
+Android InputReader/SDL discovery, mapped button and analog input, disconnect,
+reconnect, and same-PID HOT background/foreground behavior. That test exposed
+and fixed ART CheckJNI aborts caused by Java-backed SDL polling from switched
+Wii guest-fiber stacks; Android polling is now scheduler-stack-only and KPAD
+reads cached event state. The earlier cold-title input observation was a
+cadence false alarm. Continue with a natural controller-driven complete race,
+post-race save/relaunch, and physical Bluetooth/USB controller plus rumble;
+the emulator virtual pad is not physical acceptance. Do not repeat the
+rejected retail-KPAD RKG replay unchanged: even
 the exact Baby Mario / Nanobike / Manual staff configuration diverged by guest
 time 8.580.
 

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -821,6 +821,12 @@ rejected retail-KPAD RKG replay unchanged: even
 the exact Baby Mario / Nanobike / Manual staff configuration diverged by guest
 time 8.580.
 
+For that physical run, retain raw logcat only in an ignored path and use
+`scripts/summarize-android-a2-session.py --require-signal-matrix` to emit the
+bounded controller/audio/lifecycle/fatal-signal record. The strict summary is
+supporting evidence only; audible quality, tactile rumble, race/save behavior,
+and performance remain hands-on acceptance.
+
 The A0 commands and sanitized result are recorded in
 [`android/README.md`](../android/README.md) and
 [`a0-source-only-fixture.md`](artifacts/2026-09-03/android/a0-source-only-fixture.md).

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -2,7 +2,7 @@
 
 ## Status and decision
 
-- **Assessment updated:** 3 September 2026.
+- **Assessment updated:** 4 September 2026.
 - **Assessment type:** repository review plus A0 source-only implementation and
   ARM64 emulator execution.
 - **Runtime proof:** A0 passes. The local non-playable source-only APK now also
@@ -25,6 +25,12 @@
   ghost that reloads after force-stop/relaunch. Continue A2 on a real
   controller and physical Android device; keep emulator and physical-device
   claims separate.
+
+The next physical session starts with the read-only
+`scripts/check-android-physical-device.sh` intake gate. Its mocked contract
+covers eleven supported and rejected device states and proves that the ADB
+serial is not emitted; the current host has no attached ADB target, so this
+does not satisfy a physical A2 row.
 
 KartPad can be ported to Android without changing its defining architecture.
 The Android build should contain the same ahead-of-time translated Original

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -28,7 +28,7 @@
 
 The next physical session starts with the read-only
 `scripts/check-android-physical-device.sh` intake gate. Its mocked contract
-covers eleven supported and rejected device states and proves that the ADB
+covers twelve supported and rejected device states and proves that the ADB
 serial is not emitted; the current host has no attached ADB target, so this
 does not satisfy a physical A2 row.
 
@@ -826,6 +826,11 @@ For that physical run, retain raw logcat only in an ignored path and use
 bounded controller/audio/lifecycle/fatal-signal record. The strict summary is
 supporting evidence only; audible quality, tactile rumble, race/save behavior,
 and performance remain hands-on acceptance.
+
+Prefer `scripts/capture-android-a2-session.sh start|summarize` for the actual
+session: it keeps raw logcat in Android's volatile buffer, scopes retrieval to
+KartPad's UID from a device-sourced timestamp, and streams directly into that
+strict sanitizer without emitting the UID or ADB serial.
 
 The A0 commands and sanitized result are recorded in
 [`android/README.md`](../android/README.md) and

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -19,8 +19,10 @@
   runtime and now cold-starts through translated constructors and Vulkan using
   versioned public resources plus Context-derived app-private config/cache/
   NAND paths. Its SDL controller bridge now also fails neutral and stops rumble
-  across Android surface loss/backgrounding. Continue A2 with controller-driven
-  gameplay; keep emulator and physical-device claims separate.
+  across Android surface loss/backgrounding, survives virtual hotplug/reconnect,
+  and accepts short controller presses after a controller-attached cold launch.
+  Continue A2 with a complete controller-driven race/save; keep emulator and
+  physical-device claims separate.
 
 KartPad can be ported to Android without changing its defining architecture.
 The Android build should contain the same ahead-of-time translated Original

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -101,8 +101,13 @@ not block offline Retro Rewind support.
    keyboard stick. Those fixed replays diverge, but a content-free native
    trace feedback run using ordinary Android key events completed all three
    N64 Mario Raceway laps and reached retail results. The game declined ghost
-   saving, and injected keys did not advance the title after its cold relaunch,
-   so post-race save creation and controller-after-relaunch remain open.
+   saving. A later controller-only pass navigated the full Time Trial setup and
+   entered live N64 Mario Raceway. A controller retained across cold process
+   startup exposed deferred SDL polling and short-edge collapse; scheduler-
+   fiber handoff plus a one-snapshot press latch now let exact uninstrumented
+   250 ms taps advance cold title/intro, Select License, and Main Menu.
+   Controller-after-relaunch is therefore green on the emulator, while a
+   complete controller-driven race and post-race save/relaunch remain open.
    Aurora's discovered
    SDL pads now feed the Android Classic/KPAD path through a deterministic
    mapping contract, and `WPADControlMotor` now reaches that same resolved pad
@@ -110,9 +115,9 @@ not block offline Retro Rewind support.
    makes that bridge neutral, rejects new rumble starts, and stops active
    rumble; a corrected process retained its PID through four emulator cycles.
    One earlier corrected process ended silently after one cycle and remains an
-   unexplained non-reproduced exit. No controller was attached, so
-   attached-controller input and tactile behavior remain implementation/compile
-   evidence only. A
+   unexplained non-reproduced exit. Virtual attached-controller input and
+   lifecycle behavior now pass on the emulator; tactile output and all physical
+   controller/device behavior remain unaccepted. A
    temporary exact-configuration retail-KPAD RKG replay also diverged by guest
    time 8.580 and was removed; do not repeat it unchanged. Establish a complete
    reproducible post-race save/relaunch, then repeat the complete race with a
@@ -123,7 +128,9 @@ not block offline Retro Rewind support.
    `docs/artifacts/2026-09-03/android/a2-sdl-controller-bridge.md`, plus
    `docs/artifacts/2026-09-03/android/a2-sdl-controller-rumble.md`, plus
    `docs/artifacts/2026-09-03/android/a2-controller-lifecycle.md`, plus
-   `docs/artifacts/2026-09-03/android/a2-state-trace-player-race.md`. A2
+   `docs/artifacts/2026-09-03/android/a2-state-trace-player-race.md`, plus
+   `docs/artifacts/2026-09-03/android/a2-virtual-controller-hotplug.md`, plus
+   `docs/artifacts/2026-09-03/android/a2-controller-cold-relaunch.md`. A2
    remains open.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -130,7 +130,12 @@ not block offline Retro Rewind support.
    `scripts/check-android-physical-device.sh` before installing or mutating the
    first device; it rejects emulators/unsupported hardware and redacts the ADB
    serial. Its eleven-case contract passes, while the live host currently has no
-   ADB target. Evidence is in
+   ADB target. Retain the physical session's raw log only in an ignored path,
+   then run the strict session summarizer documented in `android/README.md`
+   against it. Strict mode requires the automated
+   controller/audio/lifecycle/crash-free signals in that single capture but
+   does not replace listening, tactile, race/save, or performance judgment.
+   Evidence is in
    `docs/artifacts/2026-09-03/android/a2-emulator-boot-lifecycle.md` and
    `docs/artifacts/2026-09-03/android/a2-debug-input-replay.md`, plus
    `docs/artifacts/2026-09-03/android/a2-keyboard-steer-diagnostic.md` and
@@ -141,7 +146,8 @@ not block offline Retro Rewind support.
    `docs/artifacts/2026-09-03/android/a2-virtual-controller-hotplug.md`, plus
    `docs/artifacts/2026-09-03/android/a2-controller-cold-relaunch.md`, plus
    `docs/artifacts/2026-09-04/android/a2-controller-complete-race-save.md` and
-   `docs/artifacts/2026-09-04/android/a2-physical-device-preflight.md`.
+   `docs/artifacts/2026-09-04/android/a2-physical-device-preflight.md`, plus
+   `docs/artifacts/2026-09-04/android/a2-runtime-signal-sanitizer.md`.
    A2 remains open.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -129,10 +129,11 @@ not block offline Retro Rewind support.
    separate non-acceptance observation. Run
    `scripts/check-android-physical-device.sh` before installing or mutating the
    first device; it rejects emulators/unsupported hardware and redacts the ADB
-   serial. Its eleven-case contract passes, while the live host currently has no
-   ADB target. Retain the physical session's raw log only in an ignored path,
-   then run the strict session summarizer documented in `android/README.md`
-   against it. Strict mode requires the automated
+   serial. Its twelve-case contract passes, while the live host currently has no
+   ADB target. Use `scripts/capture-android-a2-session.sh start` immediately
+   before the run and its `summarize` phase afterward; the tested wrapper keeps
+   raw logcat off the host, scopes retrieval to KartPad's UID, and sends it
+   directly through the strict sanitizer. Strict mode requires the automated
    controller/audio/lifecycle/crash-free signals in that single capture but
    does not replace listening, tactile, race/save, or performance judgment.
    Evidence is in
@@ -147,7 +148,8 @@ not block offline Retro Rewind support.
    `docs/artifacts/2026-09-03/android/a2-controller-cold-relaunch.md`, plus
    `docs/artifacts/2026-09-04/android/a2-controller-complete-race-save.md` and
    `docs/artifacts/2026-09-04/android/a2-physical-device-preflight.md`, plus
-   `docs/artifacts/2026-09-04/android/a2-runtime-signal-sanitizer.md`.
+   `docs/artifacts/2026-09-04/android/a2-runtime-signal-sanitizer.md` and
+   `docs/artifacts/2026-09-04/android/a2-uid-scoped-capture.md`.
    A2 remains open.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -106,8 +106,12 @@ not block offline Retro Rewind support.
    startup exposed deferred SDL polling and short-edge collapse; scheduler-
    fiber handoff plus a one-snapshot press latch now let exact uninstrumented
    250 ms taps advance cold title/intro, Select License, and Main Menu.
-   Controller-after-relaunch is therefore green on the emulator, while a
-   complete controller-driven race and post-race save/relaunch remain open.
+   Controller-after-relaunch is therefore green on the emulator. The same
+   exact APK subsequently completed all three N64 Mario Raceway laps through
+   Android's virtual InputReader/SDL controller path at `04:28.063`, reached
+   results, saved the KartPad ghost, retained the changed save hash across a
+   force-stop/cold launch with the controller attached, and visibly reloaded
+   that result.
    Aurora's discovered
    SDL pads now feed the Android Classic/KPAD path through a deterministic
    mapping contract, and `WPADControlMotor` now reaches that same resolved pad
@@ -119,9 +123,10 @@ not block offline Retro Rewind support.
    lifecycle behavior now pass on the emulator; tactile output and all physical
    controller/device behavior remain unaccepted. A
    temporary exact-configuration retail-KPAD RKG replay also diverged by guest
-   time 8.580 and was removed; do not repeat it unchanged. Establish a complete
-   reproducible post-race save/relaunch, then repeat the complete race with a
-   real controller and physical Android hardware. Evidence
+   time 8.580 and was removed; do not repeat it unchanged. Repeat the complete
+   race with a real controller and physical Android hardware, verify tactile
+   rumble and audible output there, and retain emulator performance as a
+   separate non-acceptance observation. Evidence
    is in `docs/artifacts/2026-09-03/android/a2-emulator-boot-lifecycle.md` and
    `docs/artifacts/2026-09-03/android/a2-debug-input-replay.md`, plus
    `docs/artifacts/2026-09-03/android/a2-keyboard-steer-diagnostic.md` and
@@ -130,8 +135,9 @@ not block offline Retro Rewind support.
    `docs/artifacts/2026-09-03/android/a2-controller-lifecycle.md`, plus
    `docs/artifacts/2026-09-03/android/a2-state-trace-player-race.md`, plus
    `docs/artifacts/2026-09-03/android/a2-virtual-controller-hotplug.md`, plus
-   `docs/artifacts/2026-09-03/android/a2-controller-cold-relaunch.md`. A2
-   remains open.
+   `docs/artifacts/2026-09-03/android/a2-controller-cold-relaunch.md`, plus
+   `docs/artifacts/2026-09-04/android/a2-controller-complete-race-save.md`.
+   A2 remains open.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -126,8 +126,12 @@ not block offline Retro Rewind support.
    time 8.580 and was removed; do not repeat it unchanged. Repeat the complete
    race with a real controller and physical Android hardware, verify tactile
    rumble and audible output there, and retain emulator performance as a
-   separate non-acceptance observation. Evidence
-   is in `docs/artifacts/2026-09-03/android/a2-emulator-boot-lifecycle.md` and
+   separate non-acceptance observation. Run
+   `scripts/check-android-physical-device.sh` before installing or mutating the
+   first device; it rejects emulators/unsupported hardware and redacts the ADB
+   serial. Its eleven-case contract passes, while the live host currently has no
+   ADB target. Evidence is in
+   `docs/artifacts/2026-09-03/android/a2-emulator-boot-lifecycle.md` and
    `docs/artifacts/2026-09-03/android/a2-debug-input-replay.md`, plus
    `docs/artifacts/2026-09-03/android/a2-keyboard-steer-diagnostic.md` and
    `docs/artifacts/2026-09-03/android/a2-sdl-controller-bridge.md`, plus
@@ -136,7 +140,8 @@ not block offline Retro Rewind support.
    `docs/artifacts/2026-09-03/android/a2-state-trace-player-race.md`, plus
    `docs/artifacts/2026-09-03/android/a2-virtual-controller-hotplug.md`, plus
    `docs/artifacts/2026-09-03/android/a2-controller-cold-relaunch.md`, plus
-   `docs/artifacts/2026-09-04/android/a2-controller-complete-race-save.md`.
+   `docs/artifacts/2026-09-04/android/a2-controller-complete-race-save.md` and
+   `docs/artifacts/2026-09-04/android/a2-physical-device-preflight.md`.
    A2 remains open.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -1981,3 +1981,44 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   emulator race/results; open for post-race save, controller-after-relaunch,
   real controller/rumble, audible audio, and physical hardware.** Evidence:
   `docs/artifacts/2026-09-03/android/a2-state-trace-player-race.md`.
+
+## 2026-09-03 — Android A2 virtual-controller hotplug and JNI fiber ownership
+
+- Created a temporary ignored `/dev/uinput` Xbox-compatible controller on the
+  API 36 ARM64 emulator. Android InputReader and SDL discovered it through the
+  production controller path; no application-side controller state was
+  injected.
+- Pre-fix PID `4204` aborted under ART CheckJNI on the first south-button event.
+  `SDL_GamepadConnected` forced Java-backed device polling from WiiCompiled's
+  switched guest-fiber stack, invalidating ART's JNI transition-frame
+  reference. Caching event-backed button/axis state fixed game-side reads, but
+  a second hotplug on PID `4658` reproduced the same abort directly from
+  `aurora::window::poll_events` during `AdvanceDueRetraces`.
+- The exact correction makes standard KPAD reads pure cached snapshots, queues
+  rumble for safe polling, exposes the original scheduler-fiber boundary, and
+  permits Android SDL polling only on that stack. Aurora's opportunistic
+  Android pump is disabled; other platforms retain existing behavior.
+- Final PID `5007` survived connect, mapped button input, analog selection,
+  disconnect, reconnect, HOME/background, HOT same-PID foreground, post-resume
+  input, and final disconnect. The log recorded the expected core
+  `0x00000800` / Classic `0x00000010` trigger and no CheckJNI, Java, or native
+  fatal record.
+- A normally paced same-process keyboard retry also advanced the earlier cold
+  title through license selection to Main Menu, correcting that observation as
+  a cadence false alarm. The prior `05:17.517` ghost-save message is consistent
+  with the native slow-run recorder-overflow precedent, but no post-race save
+  is claimed.
+- Fresh preparation reproduces all seven changed upstream files exactly. Host
+  controller contract, ARM64 build/link/package, lint, release Kotlin compile,
+  storage contract, repository safety, SunPad snapshot, diff check, and strict
+  APK/privacy audit pass. The source verifier accepts 444 hunks across 48
+  patches before the known unrelated ignored `rr-pulsar` pin mismatch.
+- The local-only 103,437,088-byte APK has SHA-256
+  `44cbeed7bdca40541bdee71b944ffce17ee63fba10c05dca9777f0fe04f6a715`;
+  its stripped 83,540,120-byte `libmain.so` is
+  `67449ea532d61a17580f941b38ba74f52a2ea3cacf9d331a49bcf3143b69294a`.
+  Classification: **Pass for emulator controller input/analog/hotplug,
+  reconnect, and HOT lifecycle behavior; open for a natural controller-driven
+  race/save and all physical-controller/hardware rows.** No APK/AAB or private
+  data was published. Evidence:
+  `docs/artifacts/2026-09-03/android/a2-virtual-controller-hotplug.md`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2086,3 +2086,24 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   physical Android hardware.** No APK/AAB or private data was published.
   Evidence:
   `docs/artifacts/2026-09-04/android/a2-controller-complete-race-save.md`.
+
+## 2026-09-04 — Android A2 physical-device intake gate
+
+- Rechecked ADB after the complete emulator checkpoint; no physical device or
+  emulator was attached, so no install, app-data mutation, or physical
+  acceptance attempt was made.
+- Added a read-only physical-device preflight that requires exactly one
+  authorized target, rejects emulators, verifies API 28+, `arm64-v8a`, 4 KiB
+  or 16 KiB pages, and 4 GiB free on `/data`, and records sanitized model,
+  controller-source, installed-package, and Vulkan-inventory state.
+- The preflight never prints the ADB serial, controller names, or Vulkan JSON.
+  Its eleven-case fake-ADB contract covers pass, optional inventory absence,
+  absent/unauthorized targets, emulator, mid-probe disconnect, unsupported
+  API/ABI/page size, low space, and missing-controller notice; every case also
+  checks that the sentinel serial is absent.
+- Classification: **Pass for deterministic, privacy-safe physical-device
+  intake tooling; physical Android acceptance not run.** A2 remains open for
+  the real-device controller race/save/relaunch, lifecycle, audible audio,
+  tactile rumble, and performance rows. No APK/AAB or private data was
+  published. Evidence:
+  `docs/artifacts/2026-09-04/android/a2-physical-device-preflight.md`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2052,3 +2052,37 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   every physical-controller/device row.** No APK/AAB or private data was
   published. Evidence:
   `docs/artifacts/2026-09-03/android/a2-controller-cold-relaunch.md`.
+
+## 2026-09-04 — Android A2 complete controller race and durable ghost
+
+- Reused the exact local-only cold-input APK, SHA-256
+  `2c11450996f33a35ba3aa85dcf16c1c467bf6fd4a0943edef966557639d7a6e7`,
+  with validated ignored RMCP01 data and an isolated all-cups save in the API
+  36 ARM64 emulator sandbox.
+- Kept the temporary Xbox-compatible `/dev/uinput` device on Android's real
+  InputReader/SDL/Aurora/Classic/KPAD path. A host feedback loop read only the
+  opt-in content-free state trace and emitted ordinary controller analog and
+  button events; it never wrote guest state or forced completion.
+- Mario / Standard Kart M / Automatic completed all three N64 Mario Raceway
+  laps at `04:28.063` (`01:23.445`, `01:19.112`, `01:45.506`). The trace moved
+  from stage 2 to stage 4 at race timer tick `16308`, and retail results stated
+  `Saved ghost data for KartPad!`.
+- The save changed from pre-race SHA-256
+  `40f5d5ae5ad93c39253559628a34359aa4627ebdc1b04605327cf2c59a5ff7e1`
+  to `23c15850daace1587661aa07a99f08e450313963b469e683f13ae5dc0d6af005`.
+  A force-stop/controller-attached cold launch retained the post-race hash,
+  logged controller channel 0 connected on new PID `10983`, and displayed the
+  `04:28.063` KartPad ghost in the course list and ghost chooser.
+- The accepted run began fresh at a temporary 1280x720 AVD override after the
+  original 2400x1080 surface proved too slow for a practical feedback run. The
+  override, marker, live trace, controller, app, shared exports, and emulator
+  were all cleaned up. An earlier `-wipe-data` mistake affected only the
+  disposable AVD sandbox; independent private inputs and the isolated fixture
+  were restaged, and no tracked, published, physical-device, or maintainer save
+  was affected.
+- Classification: **Pass for a complete controller-driven emulator race,
+  results, ghost save, cold relaunch, and visible saved-result reload; open for
+  physical controller/rumble, audible-output confirmation, performance, and
+  physical Android hardware.** No APK/AAB or private data was published.
+  Evidence:
+  `docs/artifacts/2026-09-04/android/a2-controller-complete-race-save.md`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2097,10 +2097,10 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   or 16 KiB pages, and 4 GiB free on `/data`, and records sanitized model,
   controller-source, installed-package, and Vulkan-inventory state.
 - The preflight never prints the ADB serial, controller names, or Vulkan JSON.
-  Its eleven-case fake-ADB contract covers pass, optional inventory absence,
-  absent/unauthorized targets, emulator, mid-probe disconnect, unsupported
-  API/ABI/page size, low space, and missing-controller notice; every case also
-  checks that the sentinel serial is absent.
+  Its twelve-case fake-ADB contract covers pass, optional inventory absence,
+  absent/unauthorized targets, enumeration failure, emulator, mid-probe
+  disconnect, unsupported API/ABI/page size, low space, and missing-controller
+  notice; every case also checks that the sentinel serial is absent.
 - Classification: **Pass for deterministic, privacy-safe physical-device
   intake tooling; physical Android acceptance not run.** A2 remains open for
   the real-device controller race/save/relaunch, lifecycle, audible audio,
@@ -2131,3 +2131,25 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   row.** No APK/AAB, raw log, device identifier, controller name, save, or game
   data was published. Evidence:
   `docs/artifacts/2026-09-04/android/a2-runtime-signal-sanitizer.md`.
+
+## 2026-09-04 — Android A2 UID-scoped capture path
+
+- Added a two-phase physical-session wrapper. `start` runs the hardware
+  preflight and stores only the device's own log timestamp in the ignored
+  bootstrap directory; `summarize` reads KartPad-UID-scoped volatile logcat
+  from that point and streams it into the strict signal sanitizer.
+- Raw logcat never reaches a host file. The package UID and ADB serial are not
+  emitted, and direct logcat errors are replaced with a generic message because
+  ADB can echo its transport serial on disconnect.
+- The fake-ADB contract passes start, strict summary, arbitrary private-line
+  exclusion, and disconnect-error redaction. Bash syntax, repository safety,
+  and diff checks pass. A disposable API 36 boot independently confirmed the
+  real device-side `-T TIME` / `--uid=UIDS` options and exact UID/timestamp
+  invocation, then shut down without launching KartPad. The host still has no
+  physical ADB target, so the real capture command stopped before creating its
+  marker.
+- Classification: **Pass for the tested UID-scoped/raw-log-free capture path;
+  physical execution not run.** A2 remains open for all real-device and
+  hands-on rows. No APK/AAB, raw log, device identifier, package UID,
+  controller name, save, or game data was published. Evidence:
+  `docs/artifacts/2026-09-04/android/a2-uid-scoped-capture.md`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2107,3 +2107,27 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   tactile rumble, and performance rows. No APK/AAB or private data was
   published. Evidence:
   `docs/artifacts/2026-09-04/android/a2-physical-device-preflight.md`.
+
+## 2026-09-04 — Android A2 bounded runtime-signal evidence
+
+- Added a streaming allowlist-only Android session-log summarizer. It emits a
+  fixed content-free JSON schema for SDL audio initialization/non-silent/queue
+  counters, channel-zero controller events, lifecycle counts, and explicit
+  fatal-signature counts; it never copies arbitrary raw lines or source paths.
+- Strict mode accepts only one capture or stdin and requires controller,
+  non-silent submitted audio, a complete surface pause/resume plus gamepad-
+  suspension cycle, and no fatal signature. It deliberately does not claim
+  audible quality, tactile rumble, gameplay completion, save persistence, or
+  performance.
+- The self-test passes and rejects both malformed telemetry and a fatal signal.
+  A two-file strict invocation exits 2 rather than merging unrelated sessions.
+- Retrospective use on the exact controller-race console produced deterministic
+  sanitized JSON: 32 kHz stereo, peak 3,988, 194,856,192 submitted bytes, zero
+  post-start empty observations through 507,904 checks, 465 dropped blocks,
+  controller events, and no fatal signature. Its combined matrix is correctly
+  false because that one console lacks lifecycle events.
+- Classification: **Pass for bounded Android A2 runtime-log evidence; A2 still
+  open for the one-capture physical signal matrix and every hands-on physical
+  row.** No APK/AAB, raw log, device identifier, controller name, save, or game
+  data was published. Evidence:
+  `docs/artifacts/2026-09-04/android/a2-runtime-signal-sanitizer.md`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2022,3 +2022,33 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   race/save and all physical-controller/hardware rows.** No APK/AAB or private
   data was published. Evidence:
   `docs/artifacts/2026-09-03/android/a2-virtual-controller-hotplug.md`.
+
+## 2026-09-03 — Android A2 controller cold-relaunch handoff
+
+- The virtual InputReader/SDL controller navigated the entire Time Trial setup
+  and entered live N64 Mario Raceway, closing controller-driven race entry on
+  the emulator. A force-stop/relaunch with the controller still attached then
+  exposed a real cold-input failure while rendering continued.
+- Guest-fiber SDL polls were safely rejected but their work was lost. The
+  corrected WiiCompiled boundary sets a pending request and services it on the
+  original scheduler/JNI stack after a host-fiber return.
+- Diagnostic timing exposed a second issue: one deferred poll could batch a
+  down/up pair, leaving the level cache released before KPAD read it. Aurora
+  now retains event-backed press edges for one game snapshot while preserving
+  held levels.
+- On exact uninstrumented PID `6595`, with the virtual controller attached
+  before process startup, two deliberately short 250 ms taps advanced to
+  Select License and then Main Menu. The process stayed live with no CheckJNI
+  abort. One earlier clean-build launch independently hit the known
+  intermittent missing Mii callback at `MiiManager::Init+0x134`; controlled
+  retries remained live.
+- Fresh preparation reproduced the final changed source byte-for-byte. The
+  host gamepad contract, repository safety, overlay snapshot, diff check, full
+  ARM64 build, and strict package/privacy audit pass. The local-only
+  103,440,032-byte APK has SHA-256
+  `2c11450996f33a35ba3aa85dcf16c1c467bf6fd4a0943edef966557639d7a6e7`.
+  Classification: **Pass for emulator controller setup/race entry and cold
+  title/license/menu navigation; open for a complete controller race/save and
+  every physical-controller/device row.** No APK/AAB or private data was
+  published. Evidence:
+  `docs/artifacts/2026-09-03/android/a2-controller-cold-relaunch.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -212,7 +212,7 @@ acceptance. A2 remains open. Evidence:
 The first physical-device session now has a read-only, serial-redacting intake
 gate. It rejects emulators and unsupported API, ABI, page-size, or free-space
 configurations, and reports sanitized model plus controller-source,
-installed-package, and Vulkan-inventory state. Its eleven-case fake-ADB contract
+installed-package, and Vulkan-inventory state. Its twelve-case fake-ADB contract
 passes. The live host had no ADB target, so this is tooling evidence only and
 does not change A2's open physical acceptance rows. Evidence:
 [`docs/artifacts/2026-09-04/android/a2-physical-device-preflight.md`](artifacts/2026-09-04/android/a2-physical-device-preflight.md).
@@ -226,6 +226,14 @@ and no fatal signature while retaining 465 dropped blocks. The combined matrix
 correctly remains false because that capture lacks lifecycle events; none of
 this replaces listening or physical acceptance. Evidence:
 [`docs/artifacts/2026-09-04/android/a2-runtime-signal-sanitizer.md`](artifacts/2026-09-04/android/a2-runtime-signal-sanitizer.md).
+
+The physical session now also has a tested two-phase capture wrapper. It keeps
+raw logcat in Android's volatile buffer, scopes retrieval to KartPad's package
+UID and a device-sourced start timestamp, streams directly into the strict
+sanitizer, and emits neither UID nor ADB serial. Its start/summary/redaction
+contract passes. No device is attached, so physical execution remains open.
+Evidence:
+[`docs/artifacts/2026-09-04/android/a2-uid-scoped-capture.md`](artifacts/2026-09-04/android/a2-uid-scoped-capture.md).
 
 ## Native tvOS work
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # KartPad status
 
-Updated: 2026-09-03
+Updated: 2026-09-04
 
 ## Native Android work
 
@@ -191,6 +191,23 @@ controller-after-cold-launch navigation, not a complete controller race/save,
 physical controller, tactile rumble, audible output, performance, or physical
 Android acceptance. A2 remains open. Evidence:
 [`docs/artifacts/2026-09-03/android/a2-controller-cold-relaunch.md`](artifacts/2026-09-03/android/a2-controller-cold-relaunch.md).
+
+The exact same APK now also passes the complete controller-driven emulator
+race/save/relaunch gate. An InputReader/SDL virtual controller selected the
+Time Trial configuration and supplied every race acceleration and analog-
+steering input while a content-free state trace provided feedback only. Mario
+finished all three N64 Mario Raceway laps at `04:28.063`; the retail results
+screen reported `Saved ghost data for KartPad!`, and the trace transitioned
+from race stage 2 to results stage 4. The isolated save changed from SHA-256
+`40f5d5ae5ad93c39253559628a34359aa4627ebdc1b04605327cf2c59a5ff7e1`
+to `23c15850daace1587661aa07a99f08e450313963b469e683f13ae5dc0d6af005`.
+After a force-stop and controller-attached cold launch, the save retained that
+exact hash, the new process logged controller channel 0 connected, and both the
+course list and ghost chooser displayed KartPad's `04:28.063` record. This
+closes the emulator controller race/results/save/relaunch slice, not physical
+controller, rumble, audible output, performance, or physical-device
+acceptance. A2 remains open. Evidence:
+[`docs/artifacts/2026-09-04/android/a2-controller-complete-race-save.md`](artifacts/2026-09-04/android/a2-controller-complete-race-save.md).
 
 ## Native tvOS work
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -147,12 +147,27 @@ three N64 Mario Raceway Time Trial laps, reached native finish stage 4, and
 displayed retail results for `05:17.517`; the strict trace summarizer accepts
 one 19,032-sample race segment from countdown through finish. No guest-state
 write or forced finish was used. The game reported that ghost data could not
-be saved, and injected keys did not advance the title after the subsequent
-cold relaunch, so post-race save creation and controller-after-relaunch remain
-open. The original in-sandbox save was restored byte-for-byte and all debug
-markers were removed. A2 also remains open for attached-controller input and
-rumble, audible audio, and physical Android hardware. Evidence:
+be saved, consistent with the previously observed native recorder overflow on
+a slow unguided run; this is not post-race save proof. A later same-process
+cold-input retry advanced title, license, and Main Menu with normally spaced
+key events, correcting the earlier stuck-title observation. The original
+in-sandbox save was restored byte-for-byte and all debug markers were removed.
+A2 remains open for a natural controller race/save, audible audio, and
+physical Android hardware. Evidence:
 [`docs/artifacts/2026-09-03/android/a2-state-trace-player-race.md`](artifacts/2026-09-03/android/a2-state-trace-player-race.md).
+
+Android's real InputReader-to-SDL discovery path is now exercised with a
+temporary emulator virtual gamepad. The first hotplug exposed an ART CheckJNI
+abort: game-side SDL queries crossed into Java from a switched Wii guest-fiber
+stack. Event-backed controller snapshots, queued rumble, scheduler-only
+Android event polling, and removal of the opportunistic Android pump close
+both that query path and a separately reproduced reconnect crash. Exact-final
+PID `5007` retained button and analog input through connect, disconnect,
+reconnect, HOME/background, HOT foreground resume, post-resume input, and
+final disconnect without an Android fatal. This passes emulator controller
+hotplug and lifecycle behavior, not physical controller, motor, latency, OEM,
+or device-performance acceptance. A2 remains open. Evidence:
+[`docs/artifacts/2026-09-03/android/a2-virtual-controller-hotplug.md`](artifacts/2026-09-03/android/a2-virtual-controller-hotplug.md).
 
 ## Native tvOS work
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -169,6 +169,29 @@ hotplug and lifecycle behavior, not physical controller, motor, latency, OEM,
 or device-performance acceptance. A2 remains open. Evidence:
 [`docs/artifacts/2026-09-03/android/a2-virtual-controller-hotplug.md`](artifacts/2026-09-03/android/a2-virtual-controller-hotplug.md).
 
+A controller-only follow-up drove the complete Time Trial setup flow and
+entered live N64 Mario Raceway gameplay. Keeping the virtual controller
+attached across a force-stop/cold launch then exposed a second scheduler
+boundary: guest-fiber polls were safely skipped but never reliably serviced on
+Android's original JNI stack. Guest requests are now handed off to the
+scheduler fiber after a host-fiber return. Because one safe poll can collect a
+short press and release together, event-backed button presses are latched for
+one game snapshot so the edge is not collapsed. On the exact uninstrumented
+PID `6595`, a 250 ms south-button tap from a controller attached before process
+startup advanced to Select License, and another advanced to Main Menu. Fresh
+patch preparation reproduces the changed source byte-for-byte; the host
+gamepad contract, repository safety, overlay snapshot, diff check, full ARM64
+build, and strict package audit pass. The exact local-only APK is 103,440,032
+bytes with SHA-256
+`2c11450996f33a35ba3aa85dcf16c1c467bf6fd4a0943edef966557639d7a6e7`.
+One first launch of the clean scheduler build independently hit the known
+intermittent untranslated Mii callback at `MiiManager::Init+0x134`; a controlled
+retry and the final latch build remained live. This closes emulator
+controller-after-cold-launch navigation, not a complete controller race/save,
+physical controller, tactile rumble, audible output, performance, or physical
+Android acceptance. A2 remains open. Evidence:
+[`docs/artifacts/2026-09-03/android/a2-controller-cold-relaunch.md`](artifacts/2026-09-03/android/a2-controller-cold-relaunch.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -217,6 +217,16 @@ passes. The live host had no ADB target, so this is tooling evidence only and
 does not change A2's open physical acceptance rows. Evidence:
 [`docs/artifacts/2026-09-04/android/a2-physical-device-preflight.md`](artifacts/2026-09-04/android/a2-physical-device-preflight.md).
 
+A bounded Android session-log sanitizer now converts a private capture into an
+allowlist-only JSON signal summary. Its self-test passes and strict mode cannot
+merge separate logs. Applied retrospectively to the exact controller-race
+console, it confirms 32 kHz stereo initialization, non-silent PCM, 194,856,192
+submitted bytes with zero post-start empty observations, controller events,
+and no fatal signature while retaining 465 dropped blocks. The combined matrix
+correctly remains false because that capture lacks lifecycle events; none of
+this replaces listening or physical acceptance. Evidence:
+[`docs/artifacts/2026-09-04/android/a2-runtime-signal-sanitizer.md`](artifacts/2026-09-04/android/a2-runtime-signal-sanitizer.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -209,6 +209,14 @@ controller, rumble, audible output, performance, or physical-device
 acceptance. A2 remains open. Evidence:
 [`docs/artifacts/2026-09-04/android/a2-controller-complete-race-save.md`](artifacts/2026-09-04/android/a2-controller-complete-race-save.md).
 
+The first physical-device session now has a read-only, serial-redacting intake
+gate. It rejects emulators and unsupported API, ABI, page-size, or free-space
+configurations, and reports sanitized model plus controller-source,
+installed-package, and Vulkan-inventory state. Its eleven-case fake-ADB contract
+passes. The live host had no ADB target, so this is tooling evidence only and
+does not change A2's open physical acceptance rows. Evidence:
+[`docs/artifacts/2026-09-04/android/a2-physical-device-preflight.md`](artifacts/2026-09-04/android/a2-physical-device-preflight.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-03/android/a2-controller-cold-relaunch.md
+++ b/docs/artifacts/2026-09-03/android/a2-controller-cold-relaunch.md
@@ -1,0 +1,81 @@
+# Android A2 controller cold-relaunch evidence
+
+Date: 2026-09-03
+
+Branch: `codex/android-a2-cold-input`
+
+Target: `KartPad_API_36_ARM64`, Android API 36, `arm64-v8a`, 4,096-byte
+pages, gfxstream with host lavapipe
+
+## Falsifiable subgoal
+
+Keep a controller attached before process startup, cold-launch the complete
+Original runtime, and prove short controller taps reach title/license/menu
+without crossing JNI from a switched guest-fiber stack. Also establish that
+the same controller can navigate the complete Time Trial setup into live
+gameplay. Do not treat a virtual controller as physical-device acceptance.
+
+## Result and failures found
+
+Before the cold-launch correction, the temporary InputReader `/dev/uinput`
+controller navigated title, license, Main Menu, Single Player, Time Trials,
+character, vehicle, drift, course, and entered live N64 Mario Raceway. After a
+force-stop and relaunch with that controller still attached, controller and
+keyboard events were no longer consumed even though rendering continued.
+
+The prior JNI guard correctly refused Java-backed SDL polling on a Wii guest
+fiber, but it discarded the request. The narrow correction records a pending
+poll and services it on the original scheduler stack immediately after the
+host-fiber switch returns. This preserves the single authoritative Android SDL
+event pump and keeps JNI work on its valid stack.
+
+The first clean scheduler build accepted a controller tap when temporary
+event logging changed timing. The exact uninstrumented build did not reliably
+accept a short tap. One scheduler poll can collect both button-down and
+button-up before KPAD consumes the cached level, collapsing the press. The
+final correction therefore latches each event-backed button-down for one
+standard-gamepad snapshot while retaining the ordinary held-button level.
+
+## Exact-final execution
+
+The virtual controller existed before final PID `6595` started. No temporary
+button logging or diagnostic timing change was present. The process remained
+live while the translated game rendered. A deliberately short 250 ms
+south-button press/release advanced the intro/title path to **Select License**;
+a second 250 ms tap selected the existing license and visibly reached **Main
+Menu**. This proves cold-start discovery and two consecutive short edges on the
+production event-cache path.
+
+One earlier first launch of the clean scheduler build, PID `4997`, exited at a
+missing translated target with caller LR `0x80526ec8`
+(`MiiManager::Init+0x134`). That is the known independent intermittent Mii
+callback gap, not a controller or JNI failure. A controlled retry and the exact
+final latch build remained live. No CheckJNI abort was observed in the
+accepted run.
+
+## Verification
+
+- A fresh complete runtime preparation applied the final patch stack and
+  reproduced the four inspected Aurora/WiiCompiled files byte-for-byte.
+- The complete ARM64 runtime built and packaged successfully.
+- `kartpad.android.gamepad-contract`, repository safety, `git diff --check`,
+  the SunPad overlay snapshot, and the strict APK/privacy audit pass.
+- Aurora event-cache patch SHA-256:
+  `3adf33c3d2499be457c28121edc3a32b872a30bf965af24375a5c24b697025df`.
+- WiiCompiled scheduler-poll patch SHA-256:
+  `a818e58d8ef8ce96fe8e99695f9d368b5dc674c2b5fc95d2f0f019c97cf86ee9`.
+- Final local-only APK: 103,440,032 bytes, SHA-256
+  `2c11450996f33a35ba3aa85dcf16c1c467bf6fd4a0943edef966557639d7a6e7`.
+- Extracted stripped `libmain.so`: 83,543,064 bytes, SHA-256
+  `506ce89943e2e84a3ec7c9afd5ec4571d413d720bfa153ef70987de97e03210e`.
+
+No APK/AAB, private game data, save, NAND data, controller identifier, or
+capture was published.
+
+## Honest classification
+
+**Pass for controller-driven setup/race entry and controller-attached cold
+launch through title, license, and Main Menu on the ARM64 emulator.** A2 stays
+open for a complete natural controller-driven race, results, post-race save
+and relaunch, physical controller/rumble, audible-device confirmation,
+performance, and physical Android hardware.

--- a/docs/artifacts/2026-09-03/android/a2-state-trace-player-race.md
+++ b/docs/artifacts/2026-09-03/android/a2-state-trace-player-race.md
@@ -2,6 +2,15 @@
 
 Date: 2026-09-03
 
+> Subsequent correction (2026-09-03): the cold-relaunch input observation
+> below was a cadence false alarm. The same fresh process advanced through
+> title, license selection, and Main Menu with normally spaced events. A later
+> virtual-controller run also proved SDL button/analog input, disconnect,
+> reconnect, and hot lifecycle behavior; see
+> [`a2-virtual-controller-hotplug.md`](a2-virtual-controller-hotplug.md).
+> The ghost-save failure remains unaccepted as save proof and is consistent
+> with the native slow-run ghost-recorder overflow precedent.
+
 ## Subgoal
 
 Expose the existing content-free native race-state trace to Android debug

--- a/docs/artifacts/2026-09-03/android/a2-virtual-controller-hotplug.md
+++ b/docs/artifacts/2026-09-03/android/a2-virtual-controller-hotplug.md
@@ -76,10 +76,14 @@ behavior, OEM lifecycle, and device Vulkan performance remain untested.
 
 ## Adjacent corrections
 
-The earlier "cold relaunch input did not advance" observation was a cadence
-false alarm. On the unchanged fresh PID `4204`, five normally spaced Enter
-presses advanced title, license selection, and Main Menu while logging the
-expected core and Classic triggers.
+The earlier keyboard "cold relaunch input did not advance" observation was a
+cadence false alarm. On the unchanged fresh PID `4204`, five normally spaced
+Enter presses advanced title, license selection, and Main Menu while logging
+the expected core and Classic triggers. A later controller-attached cold
+relaunch was a separate real failure: safe guest-fiber polls were deferred but
+not serviced reliably, and a batched down/up pair could collapse before KPAD
+read it. That follow-up is corrected and evidenced separately in
+`a2-controller-cold-relaunch.md`.
 
 The completed `05:17.517` feedback race's `Ghost data could not be saved`
 message is consistent with the already documented native macOS result for a

--- a/docs/artifacts/2026-09-03/android/a2-virtual-controller-hotplug.md
+++ b/docs/artifacts/2026-09-03/android/a2-virtual-controller-hotplug.md
@@ -1,0 +1,122 @@
+# Android A2 virtual-controller hotplug evidence
+
+Date: 2026-09-03
+
+Base checkpoint: `f47ab98` (`codex/android-a2-cold-input`)
+
+Host: Apple Silicon macOS 26.6.2
+
+Target: `KartPad_API_36_ARM64`, Android API 36, `arm64-v8a`, 4,096-byte
+pages, gfxstream with host lavapipe
+
+## Falsifiable subgoal
+
+Exercise Android's real InputReader-to-SDL gamepad discovery path with a
+hotpluggable controller, prove button and analog input reach Mario Kart's
+Classic/KPAD channel, and retain the same process across disconnect,
+reconnect, background, and foreground. Treat emulator evidence as diagnostic;
+do not upgrade it to physical-controller acceptance.
+
+## Failure and root cause
+
+The emulator shell can create a temporary `/dev/uinput` Xbox-compatible
+gamepad. Android classified it as a keyboard, gamepad, and joystick and SDL
+opened it. On the first south-button event, pre-fix PID `4204` aborted under
+ART CheckJNI while `SDL_GamepadConnected` forced `SDL_UpdateJoysticks`, which
+called Java `InputDevice.getDevice` from WiiCompiled's switched guest-fiber
+stack. ART reported an invalid JNI transition-frame reference.
+
+The first correction made KPAD reads consume event-backed cached buttons and
+axes and queued rumble for the SDL event path. That allowed one hotplug,
+button navigation, analog navigation, and unplug. A second hotplug then
+reproduced the same abort in `aurora::window::poll_events`, reached from
+`AdvanceDueRetraces` on a non-scheduler guest fiber. This separated the two
+unsafe paths: both direct state queries and SDL event pumping could cross the
+JNI boundary from a substituted stack.
+
+The final correction:
+
+- makes the game-facing standard-controller snapshot a pure mutex-protected
+  cache read with no SDL or JNI calls;
+- updates that cache from SDL button and axis events;
+- queues KPAD rumble changes and flushes them during safe event polling;
+- exposes whether WiiCompiled is executing on its original scheduler fiber;
+- polls Android SDL events only on that fiber; and
+- disables Aurora's opportunistic Android event pump, because the guarded
+  poll path is the single authoritative pump.
+
+Other platforms retain their existing event-pump behavior. No Java check was
+disabled and no controller event was fabricated inside the application.
+
+## Exact-final emulator result
+
+Final PID `5007` survived all of the following in one run:
+
+1. virtual controller connect;
+2. south-button press/release reaching the Classic/KPAD channel as core
+   `0x00000800` and Classic `0x00000010`;
+3. disconnect;
+4. reconnect of the same virtual controller;
+5. repeated south-button navigation;
+6. HOME/background with the process retained;
+7. a HOT foreground resume with the same PID;
+8. post-resume controller input; and
+9. final disconnect.
+
+In the preceding exact-code run, repeated controller presses advanced from
+the title to the Main Menu and holding the left X axis moved the visible
+selection from Single Player to License Settings. The final log recorded
+connect, input samples, lifecycle suspension, disconnect, resume, reconnect,
+post-resume input, and final disconnect. Final logcat contained no CheckJNI
+abort, Java fatal exception, or native fatal signal.
+
+The controller has no physical motor, so queued rumble output remains compile
+and contract evidence only. Physical Bluetooth/USB identity, latency, motor
+behavior, OEM lifecycle, and device Vulkan performance remain untested.
+
+## Adjacent corrections
+
+The earlier "cold relaunch input did not advance" observation was a cadence
+false alarm. On the unchanged fresh PID `4204`, five normally spaced Enter
+presses advanced title, license selection, and Main Menu while logging the
+expected core and Classic triggers.
+
+The completed `05:17.517` feedback race's `Ghost data could not be saved`
+message is consistent with the already documented native macOS result for a
+slow unguided run whose ghost recorder overflowed. The Android controller work
+does not convert that inference into post-race save proof; A2's natural
+results/save/relaunch row remains open.
+
+## Verification
+
+- A fresh complete Android runtime preparation applies both new patches and
+  reproduces the seven tested Aurora/WiiCompiled files byte-for-byte.
+- The complete private ARM64 runtime compiles, links, and packages.
+- `kartpad.android.gamepad-contract`, runtime storage layout, repository
+  safety, `git diff --check`, debug lint, release Kotlin compilation, and the
+  strict APK/privacy audit pass.
+- The SunPad overlay snapshot remains byte-identical at
+  `e43f0ea6b797e5110787171957c9dc3c6213269c`.
+- The broad source verifier accepts 444 hunks across 48 patches and the
+  WiiCompiled, SunPad, and WheelWizard pins, then stops at the pre-existing
+  ignored `rr-pulsar` checkout/lock mismatch.
+- Aurora event-cache patch SHA-256:
+  `9a93ba14e23efbb64ced86aa6f8655d96b1c4c2e1120721957f586de6b03e178`.
+- WiiCompiled fiber-poll patch SHA-256:
+  `2de5d2b66d24a0f84d8ff20b6db0eeeaac9c00cf7ffb8fd06ebd79b58732010b`.
+- Final local-only APK: 103,437,088 bytes, SHA-256
+  `44cbeed7bdca40541bdee71b944ffce17ee63fba10c05dca9777f0fe04f6a715`.
+- Extracted stripped `libmain.so`: 83,540,120 bytes, SHA-256
+  `67449ea532d61a17580f941b38ba74f52a2ea3cacf9d331a49bcf3143b69294a`.
+
+No APK/AAB, private game data, save, NAND data, controller identifier, or
+capture was published.
+
+## Honest classification
+
+**Pass for emulator controller discovery, button input, analog input,
+disconnect/reconnect, hot background/foreground, JNI-safe event ownership,
+exact patch reproduction, and ARM64 packaging.** This is a virtual controller,
+not physical Android hardware. A2 remains open for a natural complete
+controller-driven race, results and post-race save/relaunch, physical
+controller/rumble, audible-device confirmation, and physical Android hardware.

--- a/docs/artifacts/2026-09-04/android/a2-controller-complete-race-save.md
+++ b/docs/artifacts/2026-09-04/android/a2-controller-complete-race-save.md
@@ -74,6 +74,14 @@ Kart M record.
 
 - The strict Android package/privacy audit passed again against the exact APK
   and reported the expected SHA-256.
+- A retrospective allowlist-only summary of the retained exact-race console
+  recorded 32 kHz stereo playback initialization, one non-silent sample event
+  with peak 3,988, 194,856,192 submitted bytes across 507,904 queue checks,
+  zero post-start empty observations, controller connect/disconnect events,
+  and no fatal signature. It intentionally reports the combined automated
+  signal matrix as false because this console did not contain the lifecycle
+  transitions proved in the separate lifecycle run. This is non-silent stream
+  evidence, not a claim that audible quality was judged.
 - The repository safety audit and `git diff --check` passed.
 - The retained private save copy matches the post-race and post-relaunch
   SHA-256 above.
@@ -100,6 +108,9 @@ trace, console, save, and screenshots remain ignored and unpublished.
 
 **Pass for a complete controller-driven emulator race, retail results, ghost
 save, controller-attached cold relaunch, byte-stable save persistence, and
-visible result reload.** A2 remains open for a real Bluetooth/USB controller,
-tactile rumble, audible-output confirmation, performance acceptance, and the
-complete run on physical Android hardware.
+visible result reload.** The same exact-race console now has a committed,
+content-free
+[runtime-signal summary](a2-controller-complete-runtime-signals.json). A2
+remains open for a real
+Bluetooth/USB controller, tactile rumble, audible-output confirmation,
+performance acceptance, and the complete run on physical Android hardware.

--- a/docs/artifacts/2026-09-04/android/a2-controller-complete-race-save.md
+++ b/docs/artifacts/2026-09-04/android/a2-controller-complete-race-save.md
@@ -1,0 +1,105 @@
+# Android A2 complete controller race/save evidence
+
+Date: 2026-09-04
+
+Branch: `codex/android-a2-cold-input`
+
+Target: `KartPad_API_36_ARM64`, Android API 36, `arm64-v8a`, 4,096-byte
+pages, gfxstream with host lavapipe
+
+## Falsifiable subgoal
+
+On the complete private Original runtime, use Android's ordinary
+InputReader-to-SDL controller path to drive a full three-lap race through
+results, create a durable post-race save, force-stop the process, relaunch with
+the controller already attached, and prove the result survived. Do not count a
+virtual emulator controller as physical-controller or physical-device
+acceptance.
+
+## Exact candidate and input boundary
+
+The run used the unchanged local-only 103,440,032-byte debug APK from the cold-
+input checkpoint, SHA-256
+`2c11450996f33a35ba3aa85dcf16c1c467bf6fd4a0943edef966557639d7a6e7`.
+Validated ignored RMCP01 data and the isolated test save existed only in the
+app sandbox. No APK/AAB was published.
+
+An ignored temporary `/dev/uinput` Xbox-compatible controller entered Android
+through InputReader, SDL discovery, Aurora's cached controller snapshot, and
+the production Classic/KPAD bridge. A host feedback loop read only the opt-in,
+content-free native state trace and emitted ordinary analog-axis/button events
+to that controller. It did not write guest state, inject application input,
+alter race completion, or force a finish. The single keyboard event used to
+leave the title attract loop was test setup only; character, vehicle, drift,
+cup, course, all race acceleration/steering, and post-relaunch course
+navigation used the controller path. The earlier cold-input checkpoint already
+separately proves short controller presses at title/license/menu.
+
+## Complete race and save result
+
+Mario / Standard Kart M / Automatic completed all three laps of N64 Mario
+Raceway. The retail results screen reported:
+
+- total: `04:28.063`;
+- lap 1: `01:23.445`;
+- lap 2: `01:19.112`;
+- lap 3: `01:45.506`; and
+- `Saved ghost data for KartPad!`.
+
+The state trace transitioned from live race stage 2 to results stage 4 at race
+timer tick `16308`. The retained private trace has 20,313 lines and SHA-256
+`299afe2b2a2b269341d639fa387a0452b61d193c16f113beaf9356d3d29bba4e`.
+It remains ignored and was not published.
+
+The isolated save changed from pre-race SHA-256
+`40f5d5ae5ad93c39253559628a34359aa4627ebdc1b04605327cf2c59a5ff7e1`
+to post-race SHA-256
+`23c15850daace1587661aa07a99f08e450313963b469e683f13ae5dc0d6af005`.
+Unlike the earlier slow keyboard run, the retail recorder accepted and saved
+this ghost.
+
+## Cold-relaunch proof
+
+The controller remained attached while the app was force-stopped and relaunched
+as new PID `10983`. The cold-start console records
+`Android SDL controller channel 0 connected` at line 171. Before navigating,
+the relaunched process read the same save SHA-256
+`23c15850daace1587661aa07a99f08e450313963b469e683f13ae5dc0d6af005`.
+Controller navigation returned to Shell Cup / N64 Mario Raceway, where both the
+course list and ghost chooser displayed KartPad's `04:28.063` result. The ghost
+chooser reported two available ghosts and showed the saved Mario / Standard
+Kart M record.
+
+## Verification
+
+- The strict Android package/privacy audit passed again against the exact APK
+  and reported the expected SHA-256.
+- The repository safety audit and `git diff --check` passed.
+- The retained private save copy matches the post-race and post-relaunch
+  SHA-256 above.
+- Process inspection after cleanup found no emulator, virtual controller, or
+  feedback-driver process.
+
+## Test discipline and cleanup
+
+The disposable AVD was reduced temporarily to 1280x720 after the original
+2400x1080 surface sustained only about 10--13 FPS; this restarted the activity,
+so the accepted race began in a fresh process at the lower emulator resolution.
+The override was reset afterward. An earlier `-wipe-data` cleanup mistake
+erased only this disposable AVD's prior app sandbox; validated private runtime
+inputs and the independent isolated save fixture remained intact and were
+restaged. No tracked, published, physical-device, or maintainer save was
+affected.
+
+After capture, the app was force-stopped, the virtual controller exited, the
+trace marker and live trace were removed, temporary shared exports were
+removed, the display override was reset, and the AVD was shut down. Private
+trace, console, save, and screenshots remain ignored and unpublished.
+
+## Honest classification
+
+**Pass for a complete controller-driven emulator race, retail results, ghost
+save, controller-attached cold relaunch, byte-stable save persistence, and
+visible result reload.** A2 remains open for a real Bluetooth/USB controller,
+tactile rumble, audible-output confirmation, performance acceptance, and the
+complete run on physical Android hardware.

--- a/docs/artifacts/2026-09-04/android/a2-controller-complete-runtime-signals.json
+++ b/docs/artifacts/2026-09-04/android/a2-controller-complete-runtime-signals.json
@@ -1,0 +1,41 @@
+{
+  "audio": {
+    "channel_counts": [
+      2
+    ],
+    "host_playback_events": 1,
+    "maximum_peak": 3988,
+    "most_advanced_queue_sample": {
+      "checks": 507904,
+      "dropped_blocks": 465,
+      "dropped_bytes": 178560,
+      "empty_before_push": 0,
+      "final": false,
+      "limit_bytes": 15360,
+      "maximum_queued_bytes": 15260,
+      "minimum_queued_bytes": 0,
+      "queued_bytes": 5916,
+      "submitted_bytes": 194856192
+    },
+    "non_silent_events": 1,
+    "queue_sample_count": 62,
+    "sample_rates_hz": [
+      32000
+    ]
+  },
+  "automated_signal_matrix_passed": false,
+  "controller": {
+    "channel_0_connected_events": 2,
+    "channel_0_disconnected_events": 1
+  },
+  "fatal_signature_counts": {},
+  "lifecycle": {
+    "gamepads_resumed": 0,
+    "gamepads_suspended": 0,
+    "native_pause": 0,
+    "native_resume": 0,
+    "surface_created": 0,
+    "surface_destroyed": 0
+  },
+  "schema_version": 1
+}

--- a/docs/artifacts/2026-09-04/android/a2-physical-device-preflight.md
+++ b/docs/artifacts/2026-09-04/android/a2-physical-device-preflight.md
@@ -1,0 +1,86 @@
+# Android A2 physical-device preflight
+
+Date: 2026-09-04
+Branch: `codex/android-a2-cold-input`
+Starting commit: `a520c34303140b5724af264739a072d42ee7f559`
+
+Host: macOS 26.6.2 (`25G83`), Apple Silicon arm64
+Dependency-lock SHA-256:
+`19c98a240293d3c0115ddd48d7aa4f5ae028c5904a94a4c3a378e5b9f9479ee6`
+
+## Result
+
+No physical Android device was attached to this host. `adb devices -l`
+returned no targets, so no install, launch, app-data mutation, or physical A2
+acceptance attempt was made. A2 remains open exactly as required by the goal
+loop.
+
+This checkpoint adds `scripts/check-android-physical-device.sh`, a read-only
+intake gate for the next hardware session. It requires exactly one authorized
+ADB target, rejects an emulator, and validates:
+
+- API 28 or newer and primary ABI `arm64-v8a`;
+- a supported 4 KiB or 16 KiB runtime page size;
+- at least 4 GiB free on `/data` for the A2 Original-mode staging/run;
+- sanitized manufacturer/model evidence;
+- informational installed-package and Vulkan-inventory state; and
+- the number of Android input devices advertising gamepad or joystick source
+  bits.
+
+The serial is used only for ADB command selection and is never printed. Input
+device names and Vulkan JSON are also not emitted. A missing controller is a
+notice rather than a false platform failure so the controller can be attached
+after USB debugging is established.
+
+## Contract test
+
+Command:
+
+```sh
+./scripts/test-android-physical-device-preflight.sh
+```
+
+Result:
+
+```text
+Android physical-device preflight contract passed (11 cases; ADB serial redacted).
+```
+
+The eleven isolated fake-ADB cases cover a passing 16 KiB ARM64 device,
+optional package/Vulkan inventory absence, missing controller notice, no
+target, unauthorized target, emulator rejection, mid-probe disconnect, API
+27, wrong ABI, unsupported page size, and insufficient free space. Every case
+also rejects accidental appearance of the sentinel ADB serial in command
+output, including an ADB error that contains it.
+
+The controller masks are the pinned NDK definitions from `android/input.h`:
+`AINPUT_SOURCE_GAMEPAD` (`0x00000401`) and `AINPUT_SOURCE_JOYSTICK`
+(`0x01000010`).
+
+Script SHA-256 values:
+
+```text
+f3b0708568b733a257c2cf391227e8e6949f6aa56c684d13a9aac47fcd4ceba1  scripts/check-android-physical-device.sh
+d7be203060a06c1c9b1f50e26e36e174ad949e08358989d7da2a78693430a4c5  scripts/test-android-physical-device-preflight.sh
+```
+
+## Live host classification
+
+Command:
+
+```sh
+./scripts/check-android-physical-device.sh
+```
+
+Result (expected with no hardware attached):
+
+```text
+ERROR: expected exactly one ready ADB target (ready=0 unavailable=0); no device serial was printed
+```
+
+Classification: **Pass for deterministic, privacy-safe physical-device
+preflight tooling; not run for physical Android acceptance.** The physical
+session must still confirm the app's SDL controller connection, a complete
+race/results/save/relaunch sequence, pause/resume, surface recreation, audible
+audio, tactile rumble, and acceptable performance. No APK/AAB or private data
+was published.

--- a/docs/artifacts/2026-09-04/android/a2-physical-device-preflight.md
+++ b/docs/artifacts/2026-09-04/android/a2-physical-device-preflight.md
@@ -43,15 +43,15 @@ Command:
 Result:
 
 ```text
-Android physical-device preflight contract passed (11 cases; ADB serial redacted).
+Android physical-device preflight contract passed (12 cases; ADB serial redacted).
 ```
 
-The eleven isolated fake-ADB cases cover a passing 16 KiB ARM64 device,
+The twelve isolated fake-ADB cases cover a passing 16 KiB ARM64 device,
 optional package/Vulkan inventory absence, missing controller notice, no
-target, unauthorized target, emulator rejection, mid-probe disconnect, API
-27, wrong ABI, unsupported page size, and insufficient free space. Every case
-also rejects accidental appearance of the sentinel ADB serial in command
-output, including an ADB error that contains it.
+target, unauthorized target, enumeration failure, emulator rejection,
+mid-probe disconnect, API 27, wrong ABI, unsupported page size, and
+insufficient free space. Every case also rejects accidental appearance of the
+sentinel ADB serial in command output, including ADB errors that contain it.
 
 The controller masks are the pinned NDK definitions from `android/input.h`:
 `AINPUT_SOURCE_GAMEPAD` (`0x00000401`) and `AINPUT_SOURCE_JOYSTICK`
@@ -60,8 +60,8 @@ The controller masks are the pinned NDK definitions from `android/input.h`:
 Script SHA-256 values:
 
 ```text
-f3b0708568b733a257c2cf391227e8e6949f6aa56c684d13a9aac47fcd4ceba1  scripts/check-android-physical-device.sh
-d7be203060a06c1c9b1f50e26e36e174ad949e08358989d7da2a78693430a4c5  scripts/test-android-physical-device-preflight.sh
+30e0588d06bb4676433bc7858ca0eff95fd8c7938c72cde1eeb60d259ac9d35c  scripts/check-android-physical-device.sh
+931abfe4d21a431126dfcc8ecf14c75d6da901ee5b8b95ed9df75e4e37022a7b  scripts/test-android-physical-device-preflight.sh
 ```
 
 ## Live host classification

--- a/docs/artifacts/2026-09-04/android/a2-runtime-signal-sanitizer.md
+++ b/docs/artifacts/2026-09-04/android/a2-runtime-signal-sanitizer.md
@@ -1,0 +1,78 @@
+# Android A2 runtime-signal sanitizer
+
+Date: 2026-09-04
+
+Branch: `codex/android-a2-cold-input`
+
+Starting commit: `669dee44f0b2809fbd3f415b9e20a234a0ee401b`
+
+## Falsifiable subgoal
+
+Turn a private Android session log into deterministic, content-free evidence
+without copying arbitrary lines, paths, device identifiers, game text, or
+controller names. Strict mode must not pass unless one capture contains the
+minimum automated controller, audio, lifecycle, and crash-free signals. It
+must not convert those signals into subjective audible, tactile, gameplay, or
+performance acceptance.
+
+## Implementation
+
+`scripts/summarize-android-a2-session.py` scans without retaining raw lines and
+emits only a fixed JSON schema containing:
+
+- SDL host playback event count, sample-rate/channel sets, non-silent event
+  count and maximum peak;
+- validated bounded queue counters and the most advanced sample;
+- controller channel-zero connection/disconnection counts;
+- SDL surface create/destroy and native pause/resume counts;
+- standard-gamepad suspend/resume counts; and
+- counts for an explicit fatal-signature allowlist.
+
+Malformed queue telemetry fails closed. `--require-signal-matrix` accepts only
+one capture or standard input and exits nonzero unless that capture includes a
+controller connection, playback initialization, non-silent PCM, submitted
+audio, one complete surface pause/resume cycle, the standard-gamepad
+suspend/resume pair, and no fatal marker. It does not assert a completed race,
+save, tactile rumble, audible quality, or acceptable performance.
+
+## Verification
+
+The embedded self-test passed a complete synthetic signal set, verified that
+an unrelated private line did not appear in serialized output, rejected a
+fatal signal, and rejected malformed queue telemetry. A separate missing-file
+check confirmed that errors do not echo the supplied private path:
+
+```text
+Android A2 session summarizer self-test passed
+```
+
+Strict mode correctly exited 1 for the retained exact-race console because it
+has no lifecycle markers. It exited 2 rather than combining that console with
+a separate lifecycle log into a false single-capture pass.
+
+The exact-race private console remains ignored and has SHA-256
+`1feeec9301ac8d7817e5b6030f871565faffd23df23c5b0f53673126ebfac27f`.
+The deterministic sanitized JSON is
+`a2-controller-complete-runtime-signals.json`, SHA-256
+`1192ecaa9bff6bdd9f6047b167b3fceee6583b724b78632b5a4a8fb7f8361b0e`.
+It records:
+
+- 32 kHz stereo host playback initialization;
+- one non-silent event with peak 3,988;
+- 194,856,192 submitted bytes and zero post-start empty observations through
+  507,904 queue checks;
+- 465 dropped blocks / 178,560 dropped bytes, retained as a performance
+  observation rather than hidden;
+- two controller connections and one disconnection; and
+- no allowlisted fatal signature.
+
+The combined automated matrix is correctly `false` because this exact-race
+console did not contain the separately tested lifecycle transitions. The
+sanitizer has SHA-256
+`f4423cbc1d849c5e5ed287bf6391182591ff7aa8924d9e024cb191a0c5f867bc`.
+
+Classification: **Pass for deterministic allowlist-only Android runtime-log
+sanitization and retrospective exact-race non-silent stream evidence; not a
+physical-device, audible-quality, tactile-rumble, race, save, lifecycle, or
+performance acceptance result.** No APK/AAB, raw log, device identifier,
+controller name, save, game data, or private capture was published.

--- a/docs/artifacts/2026-09-04/android/a2-uid-scoped-capture.md
+++ b/docs/artifacts/2026-09-04/android/a2-uid-scoped-capture.md
@@ -1,0 +1,88 @@
+# Android A2 UID-scoped physical-session capture
+
+Date: 2026-09-04
+
+Branch: `codex/android-a2-cold-input`
+
+Starting commit: `2d3024509198058ecbbbc283f86da8d093402db6`
+
+## Falsifiable subgoal
+
+Make the first physical A2 session collect one strict app-scoped signal matrix
+without saving raw logcat on the host, exposing the ADB serial or package UID,
+or accidentally combining different sessions. Do not automate or claim the
+hands-on race, audible-quality, tactile-rumble, or performance judgments.
+
+## Implementation
+
+`scripts/capture-android-a2-session.sh` has two explicit phases:
+
+1. `start` runs the physical-device preflight, requires the installed KartPad
+   package, queries the device's own log timestamp, and stores only that
+   timestamp in the ignored `.android-bootstrap/` directory.
+2. `summarize` reruns the preflight, resolves the KartPad package UID without
+   printing it, requests the volatile Android logs since that timestamp with
+   logcat's UID filter, and streams them directly into
+   `summarize-android-a2-session.py --require-signal-matrix`.
+
+Only fixed-schema sanitized JSON reaches stdout. Raw logcat is never written
+to a host file by the wrapper. Direct ADB failures are replaced with a generic
+error because ADB may include the transport serial in stderr; all other ADB
+commands pass through the existing serial-redacting boundary.
+
+The timestamp comes from Android rather than the Mac, avoiding host/device
+timezone skew. The package UID survives the required force-stop/relaunch, so
+one capture window can include the cold-relaunch portion of the same hands-on
+test.
+
+## Contract verification
+
+Commands:
+
+```sh
+bash -n scripts/capture-android-a2-session.sh \
+  scripts/test-capture-android-a2-session.sh
+./scripts/test-capture-android-a2-session.sh
+```
+
+Result:
+
+```text
+Android A2 UID-scoped capture contract passed (start, summarize, redaction).
+```
+
+The fake-ADB contract proves that `start` records the device timestamp, the
+UID-scoped `summarize` path produces a passing strict matrix, an arbitrary
+private game-text line is absent from JSON, and neither successful output nor
+a simulated disconnect error exposes the sentinel ADB serial.
+
+The pinned API 36 ARM64 AVD then verified the integration assumptions without
+launching KartPad: device-side `logcat --help` advertises `-T TIME` and
+`--uid=UIDS`, the installed debug package resolved to a numeric UID, the
+device-sourced timestamp matched the required 18-character shape, and the
+exact `logcat -d -v raw -T <time> --uid=<uid>` invocation exited successfully.
+Neither UID nor serial is recorded here. The AVD was shut down afterward.
+
+Script SHA-256 values:
+
+```text
+02af90c46ac50083fa7adfb91e4f99a8225c883c7a62115114bcf3a4b1549f12  scripts/capture-android-a2-session.sh
+8dc021015636f91ba316cab54cd1d5291cebce5b465e3715de3ef0bb1f456d58  scripts/test-capture-android-a2-session.sh
+```
+
+## Live-host result
+
+No physical ADB target was attached. Before the disposable integration check,
+the real `start` command stopped at the preflight without querying a UID or
+creating the marker:
+
+```text
+ERROR: expected exactly one ready ADB target (ready=0 unavailable=0); no device serial was printed
+```
+
+Classification: **Pass for a tested, UID-scoped, raw-log-free physical A2
+capture path; physical execution not run.** The actual device/controller,
+race/results/save/relaunch, pause/resume, surface recreation, audible output,
+tactile rumble, and performance gates remain open. No APK/AAB, raw log, device
+identifier, package UID, controller name, save, game data, or private capture
+was published.

--- a/patches/aurora-android-gamepad-event-cache.patch
+++ b/patches/aurora-android-gamepad-event-cache.patch
@@ -14,11 +14,12 @@
  
 --- a/lib/input.hpp
 +++ b/lib/input.hpp
-@@ -20,6 +20,13 @@
+@@ -20,6 +20,14 @@
    Sint32 m_index = -1;
    Sint32 m_playerIndex = -1;
    bool m_hasRumble = false;
 +  uint32_t m_standardButtons = 0;
++  uint32_t m_standardButtonPresses = 0;
 +  int16_t m_standardLeftX = 0;
 +  int16_t m_standardLeftY = 0;
 +  int16_t m_standardLeftTrigger = 0;
@@ -62,7 +63,7 @@
        controller = &candidate;
      }
    }
-@@ -381,38 +389,16 @@
+@@ -381,38 +389,17 @@
  
    GameController* controller =
        resolve_standard_gamepad(player, allowSingleUnassigned);
@@ -99,7 +100,8 @@
 -                                         SDL_GAMEPAD_AXIS_LEFT_TRIGGER);
 -  state->rightTrigger = SDL_GetGamepadAxis(controller->m_controller,
 -                                          SDL_GAMEPAD_AXIS_RIGHT_TRIGGER);
-+  state->buttons = controller->m_standardButtons;
++  state->buttons = controller->m_standardButtons | controller->m_standardButtonPresses;
++  controller->m_standardButtonPresses = 0;
 +  state->leftX = controller->m_standardLeftX;
 +  state->leftY = controller->m_standardLeftY;
 +  state->leftTrigger = controller->m_standardLeftTrigger;
@@ -127,7 +129,7 @@
  }
  
  void set_standard_gamepads_active(bool active) noexcept {
-@@ -446,16 +430,98 @@
+@@ -446,16 +430,99 @@
    }
  
    if (!active) {
@@ -187,6 +189,7 @@
 +  const uint32_t mask = standard_button_mask(button);
 +  if (pressed) {
 +    it->second.m_standardButtons |= mask;
++    it->second.m_standardButtonPresses |= mask;
 +  } else {
 +    it->second.m_standardButtons &= ~mask;
 +  }
@@ -228,7 +231,7 @@
  Sint32 get_instance_for_player(uint32_t player) noexcept {
    for (const auto& [which, controller] : g_GameControllers) {
      if (player_index(which) == player) {
-@@ -491,6 +557,7 @@
+@@ -491,6 +558,7 @@
      const auto props = SDL_GetGamepadProperties(ctrl);
      controller.m_hasRumble = SDL_GetBooleanProperty(props, SDL_PROP_GAMEPAD_CAP_RUMBLE_BOOLEAN, true);
      controller.m_hasRgbLed = SDL_GetBooleanProperty(props, SDL_PROP_GAMEPAD_CAP_RGB_LED_BOOLEAN, false);
@@ -236,7 +239,7 @@
      SDL_JoystickID instance = SDL_GetJoystickID(SDL_GetGamepadJoystick(ctrl));
      g_GameControllers[instance] = controller;
      ensure_player_index(g_GameControllers[instance]);
-@@ -510,6 +577,7 @@
+@@ -510,6 +578,7 @@
    // The SDL mapping changed underneath us; drop the cached PAD bindings so they
    // are rebuilt from the new one.
    it->second.m_mappingLoaded = false;
@@ -244,7 +247,7 @@
    ensure_player_index(it->second);
    apply_port_preferences();
    return true;
-@@ -518,6 +586,9 @@
+@@ -518,6 +587,9 @@
  void remove_controller(Uint32 instance) noexcept {
    std::scoped_lock lock(g_standardGamepadBridgeMutex);
    if (auto it = g_GameControllers.find(instance); it != g_GameControllers.end()) {
@@ -254,7 +257,7 @@
      SDL_CloseGamepad(it->second.m_controller);
      g_GameControllers.erase(it);
      apply_port_preferences();
-@@ -533,8 +604,7 @@
+@@ -533,8 +605,7 @@
  
  int32_t player_index(Uint32 instance) noexcept {
    if (auto it = g_GameControllers.find(instance); it != g_GameControllers.end()) {

--- a/patches/aurora-android-gamepad-event-cache.patch
+++ b/patches/aurora-android-gamepad-event-cache.patch
@@ -1,0 +1,310 @@
+--- a/include/aurora/input.hpp
++++ b/include/aurora/input.hpp
+@@ -34,9 +34,9 @@
+ bool read_standard_gamepad_state(uint32_t player, bool allowSingleUnassigned,
+                                  StandardGamepadState* state) noexcept;
+ 
+-// Starts or stops rumble on the controller resolved by the same assignment
++// Queues a rumble change for the controller resolved by the same assignment
+ // rule as read_standard_gamepad_state. Returns false when no suitable
+-// rumble-capable controller exists or SDL rejects the request.
++// rumble-capable controller exists. SDL applies the request during event polling.
+ bool set_standard_gamepad_rumble(uint32_t player, bool allowSingleUnassigned,
+                                  bool enabled) noexcept;
+ 
+--- a/lib/input.hpp
++++ b/lib/input.hpp
+@@ -20,6 +20,13 @@
+   Sint32 m_index = -1;
+   Sint32 m_playerIndex = -1;
+   bool m_hasRumble = false;
++  uint32_t m_standardButtons = 0;
++  int16_t m_standardLeftX = 0;
++  int16_t m_standardLeftY = 0;
++  int16_t m_standardLeftTrigger = 0;
++  int16_t m_standardRightTrigger = 0;
++  bool m_standardRumbleEnabled = false;
++  bool m_standardRumbleDirty = false;
+   PADDeadZones m_deadZones{
+       .emulateTriggers = true,
+       .useDeadzones = true,
+@@ -53,6 +60,9 @@
+ SDL_JoystickID add_controller(SDL_JoystickID which) noexcept;
+ bool refresh_controller(SDL_JoystickID instance) noexcept;
+ void remove_controller(Uint32 instance) noexcept;
++void update_standard_gamepad_button(Uint32 instance, Uint8 button, bool pressed) noexcept;
++void update_standard_gamepad_axis(Uint32 instance, Uint8 axis, Sint16 value) noexcept;
++void flush_standard_gamepad_rumble() noexcept;
+ Sint32 player_index(Uint32 instance) noexcept;
+ void set_player_index(Uint32 instance, Sint32 index) noexcept;
+ std::string controller_name(Uint32 instance) noexcept;
+--- a/lib/input.cpp
++++ b/lib/input.cpp
+@@ -356,11 +356,19 @@
+ 
+ static GameController* resolve_standard_gamepad(
+     uint32_t player, bool allowSingleUnassigned) noexcept {
+-  GameController* controller = get_controller_for_player(player);
++  GameController* controller = nullptr;
++  for (auto& [instance, candidate] : g_GameControllers) {
++    (void)instance;
++    if (candidate.m_playerIndex == static_cast<int32_t>(player)) {
++      controller = &candidate;
++      break;
++    }
++  }
+   if (controller == nullptr && player == 0 && allowSingleUnassigned &&
+       g_GameControllers.size() == 1) {
+     auto& [instance, candidate] = *g_GameControllers.begin();
+-    if (player_index(instance) < 0) {
++    (void)instance;
++    if (candidate.m_playerIndex < 0) {
+       controller = &candidate;
+     }
+   }
+@@ -381,38 +389,16 @@
+ 
+   GameController* controller =
+       resolve_standard_gamepad(player, allowSingleUnassigned);
+-  if (controller == nullptr || controller->m_controller == nullptr ||
+-      !SDL_GamepadConnected(controller->m_controller)) {
++  if (controller == nullptr || controller->m_controller == nullptr) {
+     return false;
+   }
+ 
+   state->connected = true;
+-  const auto add = [&](SDL_GamepadButton source,
+-                       StandardGamepadButton destination) {
+-    if (SDL_GetGamepadButton(controller->m_controller, source)) {
+-      state->buttons |= destination;
+-    }
+-  };
+-  add(SDL_GAMEPAD_BUTTON_SOUTH, kStandardGamepadSouth);
+-  add(SDL_GAMEPAD_BUTTON_EAST, kStandardGamepadEast);
+-  add(SDL_GAMEPAD_BUTTON_WEST, kStandardGamepadWest);
+-  add(SDL_GAMEPAD_BUTTON_NORTH, kStandardGamepadNorth);
+-  add(SDL_GAMEPAD_BUTTON_BACK, kStandardGamepadBack);
+-  add(SDL_GAMEPAD_BUTTON_START, kStandardGamepadStart);
+-  add(SDL_GAMEPAD_BUTTON_LEFT_SHOULDER, kStandardGamepadLeftShoulder);
+-  add(SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER, kStandardGamepadRightShoulder);
+-  add(SDL_GAMEPAD_BUTTON_DPAD_UP, kStandardGamepadDpadUp);
+-  add(SDL_GAMEPAD_BUTTON_DPAD_DOWN, kStandardGamepadDpadDown);
+-  add(SDL_GAMEPAD_BUTTON_DPAD_LEFT, kStandardGamepadDpadLeft);
+-  add(SDL_GAMEPAD_BUTTON_DPAD_RIGHT, kStandardGamepadDpadRight);
+-  state->leftX = SDL_GetGamepadAxis(controller->m_controller,
+-                                   SDL_GAMEPAD_AXIS_LEFTX);
+-  state->leftY = SDL_GetGamepadAxis(controller->m_controller,
+-                                   SDL_GAMEPAD_AXIS_LEFTY);
+-  state->leftTrigger = SDL_GetGamepadAxis(controller->m_controller,
+-                                         SDL_GAMEPAD_AXIS_LEFT_TRIGGER);
+-  state->rightTrigger = SDL_GetGamepadAxis(controller->m_controller,
+-                                          SDL_GAMEPAD_AXIS_RIGHT_TRIGGER);
++  state->buttons = controller->m_standardButtons;
++  state->leftX = controller->m_standardLeftX;
++  state->leftY = controller->m_standardLeftY;
++  state->leftTrigger = controller->m_standardLeftTrigger;
++  state->rightTrigger = controller->m_standardRightTrigger;
+   return true;
+ }
+ 
+@@ -426,15 +412,13 @@
+   GameController* controller =
+       resolve_standard_gamepad(player, allowSingleUnassigned);
+   if (controller == nullptr || controller->m_controller == nullptr ||
+-      !controller->m_hasRumble ||
+-      !SDL_GamepadConnected(controller->m_controller)) {
++      !controller->m_hasRumble) {
+     return false;
+   }
+ 
+-  const uint16_t low = enabled ? controller->m_rumbleIntensityLow : 0;
+-  const uint16_t high = enabled ? controller->m_rumbleIntensityHigh : 0;
+-  return SDL_RumbleGamepad(controller->m_controller, low, high,
+-                           enabled ? 0xffffffffu : 0u);
++  controller->m_standardRumbleEnabled = enabled;
++  controller->m_standardRumbleDirty = true;
++  return true;
+ }
+ 
+ void set_standard_gamepads_active(bool active) noexcept {
+@@ -446,16 +430,98 @@
+   }
+ 
+   if (!active) {
+-    for (const auto& [instance, controller] : g_GameControllers) {
++    for (auto& [instance, controller] : g_GameControllers) {
+       (void)instance;
+       if (controller.m_controller != nullptr && controller.m_hasRumble) {
+-        SDL_RumbleGamepad(controller.m_controller, 0, 0, 0);
++        controller.m_standardRumbleEnabled = false;
++        controller.m_standardRumbleDirty = true;
+       }
+     }
+   }
+   Log.info("Standard gamepads {}", active ? "resumed" : "suspended");
++}
++
++namespace {
++uint32_t standard_button_mask(Uint8 button) noexcept {
++  switch (static_cast<SDL_GamepadButton>(button)) {
++  case SDL_GAMEPAD_BUTTON_SOUTH: return kStandardGamepadSouth;
++  case SDL_GAMEPAD_BUTTON_EAST: return kStandardGamepadEast;
++  case SDL_GAMEPAD_BUTTON_WEST: return kStandardGamepadWest;
++  case SDL_GAMEPAD_BUTTON_NORTH: return kStandardGamepadNorth;
++  case SDL_GAMEPAD_BUTTON_BACK: return kStandardGamepadBack;
++  case SDL_GAMEPAD_BUTTON_START: return kStandardGamepadStart;
++  case SDL_GAMEPAD_BUTTON_LEFT_SHOULDER: return kStandardGamepadLeftShoulder;
++  case SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER: return kStandardGamepadRightShoulder;
++  case SDL_GAMEPAD_BUTTON_DPAD_UP: return kStandardGamepadDpadUp;
++  case SDL_GAMEPAD_BUTTON_DPAD_DOWN: return kStandardGamepadDpadDown;
++  case SDL_GAMEPAD_BUTTON_DPAD_LEFT: return kStandardGamepadDpadLeft;
++  case SDL_GAMEPAD_BUTTON_DPAD_RIGHT: return kStandardGamepadDpadRight;
++  default: return 0;
++  }
+ }
+ 
++void sample_standard_gamepad_state(GameController& controller) noexcept {
++  controller.m_standardButtons = 0;
++  for (int button = SDL_GAMEPAD_BUTTON_SOUTH; button < SDL_GAMEPAD_BUTTON_COUNT; ++button) {
++    const uint32_t mask = standard_button_mask(static_cast<Uint8>(button));
++    if (mask != 0 && SDL_GetGamepadButton(controller.m_controller, static_cast<SDL_GamepadButton>(button))) {
++      controller.m_standardButtons |= mask;
++    }
++  }
++  controller.m_standardLeftX = SDL_GetGamepadAxis(controller.m_controller, SDL_GAMEPAD_AXIS_LEFTX);
++  controller.m_standardLeftY = SDL_GetGamepadAxis(controller.m_controller, SDL_GAMEPAD_AXIS_LEFTY);
++  controller.m_standardLeftTrigger = SDL_GetGamepadAxis(controller.m_controller, SDL_GAMEPAD_AXIS_LEFT_TRIGGER);
++  controller.m_standardRightTrigger = SDL_GetGamepadAxis(controller.m_controller, SDL_GAMEPAD_AXIS_RIGHT_TRIGGER);
++}
++} // namespace
++
++void update_standard_gamepad_button(Uint32 instance, Uint8 button, bool pressed) noexcept {
++  std::scoped_lock lock(g_standardGamepadBridgeMutex);
++  const auto it = g_GameControllers.find(instance);
++  if (it == g_GameControllers.end()) {
++    return;
++  }
++  const uint32_t mask = standard_button_mask(button);
++  if (pressed) {
++    it->second.m_standardButtons |= mask;
++  } else {
++    it->second.m_standardButtons &= ~mask;
++  }
++}
++
++void update_standard_gamepad_axis(Uint32 instance, Uint8 axis, Sint16 value) noexcept {
++  std::scoped_lock lock(g_standardGamepadBridgeMutex);
++  const auto it = g_GameControllers.find(instance);
++  if (it == g_GameControllers.end()) {
++    return;
++  }
++  switch (static_cast<SDL_GamepadAxis>(axis)) {
++  case SDL_GAMEPAD_AXIS_LEFTX: it->second.m_standardLeftX = value; break;
++  case SDL_GAMEPAD_AXIS_LEFTY: it->second.m_standardLeftY = value; break;
++  case SDL_GAMEPAD_AXIS_LEFT_TRIGGER: it->second.m_standardLeftTrigger = value; break;
++  case SDL_GAMEPAD_AXIS_RIGHT_TRIGGER: it->second.m_standardRightTrigger = value; break;
++  default: break;
++  }
++}
++
++void flush_standard_gamepad_rumble() noexcept {
++  std::scoped_lock lock(g_standardGamepadBridgeMutex);
++  for (auto& [instance, controller] : g_GameControllers) {
++    (void)instance;
++    if (!controller.m_standardRumbleDirty || controller.m_controller == nullptr || !controller.m_hasRumble) {
++      continue;
++    }
++    const bool enabled = controller.m_standardRumbleEnabled &&
++                         g_standardGamepadsActive.load(std::memory_order_acquire);
++    const uint16_t low = enabled ? controller.m_rumbleIntensityLow : 0;
++    const uint16_t high = enabled ? controller.m_rumbleIntensityHigh : 0;
++    if (!SDL_RumbleGamepad(controller.m_controller, low, high, enabled ? 0xffffffffu : 0u)) {
++      Log.warn("Failed to {} standard gamepad rumble: {}", enabled ? "start" : "stop", SDL_GetError());
++    }
++    controller.m_standardRumbleDirty = false;
++  }
++}
++
+ Sint32 get_instance_for_player(uint32_t player) noexcept {
+   for (const auto& [which, controller] : g_GameControllers) {
+     if (player_index(which) == player) {
+@@ -491,6 +557,7 @@
+     const auto props = SDL_GetGamepadProperties(ctrl);
+     controller.m_hasRumble = SDL_GetBooleanProperty(props, SDL_PROP_GAMEPAD_CAP_RUMBLE_BOOLEAN, true);
+     controller.m_hasRgbLed = SDL_GetBooleanProperty(props, SDL_PROP_GAMEPAD_CAP_RGB_LED_BOOLEAN, false);
++    sample_standard_gamepad_state(controller);
+     SDL_JoystickID instance = SDL_GetJoystickID(SDL_GetGamepadJoystick(ctrl));
+     g_GameControllers[instance] = controller;
+     ensure_player_index(g_GameControllers[instance]);
+@@ -510,6 +577,7 @@
+   // The SDL mapping changed underneath us; drop the cached PAD bindings so they
+   // are rebuilt from the new one.
+   it->second.m_mappingLoaded = false;
++  sample_standard_gamepad_state(it->second);
+   ensure_player_index(it->second);
+   apply_port_preferences();
+   return true;
+@@ -518,6 +586,9 @@
+ void remove_controller(Uint32 instance) noexcept {
+   std::scoped_lock lock(g_standardGamepadBridgeMutex);
+   if (auto it = g_GameControllers.find(instance); it != g_GameControllers.end()) {
++    if (it->second.m_controller != nullptr && it->second.m_hasRumble) {
++      SDL_RumbleGamepad(it->second.m_controller, 0, 0, 0);
++    }
+     SDL_CloseGamepad(it->second.m_controller);
+     g_GameControllers.erase(it);
+     apply_port_preferences();
+@@ -533,8 +604,7 @@
+ 
+ int32_t player_index(Uint32 instance) noexcept {
+   if (auto it = g_GameControllers.find(instance); it != g_GameControllers.end()) {
+-    const int player = SDL_GetGamepadPlayerIndex(it->second.m_controller);
+-    return player >= 0 ? player : it->second.m_playerIndex;
++    return it->second.m_playerIndex;
+   }
+   return -1;
+ }
+--- a/lib/window.cpp
++++ b/lib/window.cpp
+@@ -321,6 +321,14 @@
+     });
+     break;
+   }
++  case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
++  case SDL_EVENT_GAMEPAD_BUTTON_UP:
++    input::update_standard_gamepad_button(event.gbutton.which, event.gbutton.button,
++                                          event.type == SDL_EVENT_GAMEPAD_BUTTON_DOWN);
++    break;
++  case SDL_EVENT_GAMEPAD_AXIS_MOTION:
++    input::update_standard_gamepad_axis(event.gaxis.which, event.gaxis.axis, event.gaxis.value);
++    break;
+   case SDL_EVENT_MOUSE_WHEEL:
+     input::set_mouse_scroll(event.wheel.x, event.wheel.y);
+     break;
+@@ -367,6 +375,7 @@
+   while (SDL_PollEvent(&event)) {
+     process_event(event);
+   }
++  input::flush_standard_gamepad_rumble();
+   g_events.push_back(AuroraEvent{
+       .type = AURORA_NONE,
+   });
+@@ -598,10 +607,18 @@
+ }
+ 
+ void pump_events() noexcept {
++#if defined(SDL_PLATFORM_ANDROID)
++  // Wii guest fibers replace the SDLThread stack without changing its pthread.
++  // ART JNI transition frames remain bound to the original stack, so Android's
++  // Java-backed SDL event pump must run only through the scheduler-guarded
++  // poll_events() path in WiiCompiled.
++  return;
++#else
+   if (g_window != nullptr) {
+     SDL_SyncWindow(g_window);
+   }
+   SDL_PumpEvents();
++#endif
+ }
+ 
+ bool native_resize_pending() noexcept { return g_nativeResizePending.load(std::memory_order_acquire); }

--- a/patches/wiicompiled-android-sdl-fiber-poll.patch
+++ b/patches/wiicompiled-android-sdl-fiber-poll.patch
@@ -1,0 +1,52 @@
+--- a/include/fiber_manager.h
++++ b/include/fiber_manager.h
+@@ -58,6 +58,11 @@
+     
+     // Check if fiber system is initialized
+     static bool IsInitialized();
++
++    // True only while execution is on the original host stack. Android JNI
++    // transition frames are stack-bound, so Java-calling SDL work must stay
++    // on this fiber rather than a switched guest thread stack.
++    static bool IsOnSchedulerFiber();
+     
+     // Create a fiber for a guest thread (called from OSCreateThread HLE).
+     // OSCreateThread's stackSize/priority are not passed: the host fiber models
+--- a/src/fiber_manager.cpp
++++ b/src/fiber_manager.cpp
+@@ -463,6 +463,14 @@
+ 
+ bool GuestFiberManager::IsInitialized() {
+     return s_initialized;
++}
++
++bool GuestFiberManager::IsOnSchedulerFiber() {
++#if defined(_WIN32) || defined(__APPLE__) || defined(__ANDROID__)
++    return !s_initialized || CurrentHostFiber() == s_schedulerFiber;
++#else
++    return true;
++#endif
+ }
+ 
+ bool GuestFiberManager::CreateGuestFiber(uint32_t guestThreadAddr, uint32_t entryPoint,
+--- a/include/aurora_events.h
++++ b/include/aurora_events.h
+@@ -2,6 +2,7 @@
+ 
+ #include "settings_overlay.h"
+ #include "runtime_config.h"
++#include "fiber_manager.h"
+ 
+ #include <aurora/aurora.h>
+ #include <aurora/event.h>
+@@ -140,5 +141,10 @@
+ 
+ // Poll Aurora events and update cached window/framebuffer dimensions.
+ inline void UpdateAuroraAndProcessEvents() {
++#if defined(__ANDROID__)
++    if (!Fiber::GuestFiberManager::IsOnSchedulerFiber()) {
++        return;
++    }
++#endif
+     ProcessAuroraEvents(aurora_update());
+ }

--- a/patches/wiicompiled-android-sdl-fiber-poll.patch
+++ b/patches/wiicompiled-android-sdl-fiber-poll.patch
@@ -14,7 +14,13 @@
      // OSCreateThread's stackSize/priority are not passed: the host fiber models
 --- a/src/fiber_manager.cpp
 +++ b/src/fiber_manager.cpp
-@@ -463,6 +463,14 @@
+@@ -1,4 +1,5 @@
+ #include "fiber_manager.h"
++#include "aurora_events.h"
+ #include "memory.h"
+ #include "abi_bridge.h"
+ #include "hle_stubs.h"
+@@ -463,6 +464,14 @@
  
  bool GuestFiberManager::IsInitialized() {
      return s_initialized;
@@ -29,6 +35,16 @@
  }
  
  bool GuestFiberManager::CreateGuestFiber(uint32_t guestThreadAddr, uint32_t entryPoint,
+@@ -715,5 +724,9 @@
+     // Switch to the target fiber (the target fiber will load its own context)
+     SwitchHostFiber(fiberHandle);
++#if defined(__ANDROID__)
++    // A guest fiber may have deferred Java-backed SDL work to this stack.
++    ServicePendingAuroraEventsOnScheduler();
++#endif
+     
+     // When we return here, the fiber that issued SwitchToThread has resumed.
+     // That does not automatically mean the previous guest thread became runnable
 --- a/include/aurora_events.h
 +++ b/include/aurora_events.h
 @@ -2,6 +2,7 @@
@@ -39,14 +55,30 @@
  
  #include <aurora/aurora.h>
  #include <aurora/event.h>
-@@ -140,5 +141,10 @@
+@@ -139,6 +140,26 @@
+ }
  
++#if defined(__ANDROID__)
++inline std::atomic_bool g_androidAuroraPollPending{false};
++#endif
++
  // Poll Aurora events and update cached window/framebuffer dimensions.
  inline void UpdateAuroraAndProcessEvents() {
 +#if defined(__ANDROID__)
 +    if (!Fiber::GuestFiberManager::IsOnSchedulerFiber()) {
++        g_androidAuroraPollPending.store(true, std::memory_order_release);
 +        return;
 +    }
++    g_androidAuroraPollPending.store(false, std::memory_order_release);
 +#endif
      ProcessAuroraEvents(aurora_update());
  }
++
++inline void ServicePendingAuroraEventsOnScheduler() {
++#if defined(__ANDROID__)
++    if (Fiber::GuestFiberManager::IsOnSchedulerFiber() &&
++        g_androidAuroraPollPending.exchange(false, std::memory_order_acq_rel)) {
++        ProcessAuroraEvents(aurora_update());
++    }
++#endif
++}

--- a/scripts/capture-android-a2-session.sh
+++ b/scripts/capture-android-a2-session.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+# shellcheck source=android-toolchain-versions.sh
+source "$repo_root/scripts/android-toolchain-versions.sh"
+
+sdk_root="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/Library/Android/sdk}}"
+adb="${KARTPAD_ADB:-$sdk_root/platform-tools/adb}"
+marker="${KARTPAD_ANDROID_A2_CAPTURE_MARKER:-$repo_root/.android-bootstrap/android-a2-physical-log-start.txt}"
+preflight="$repo_root/scripts/check-android-physical-device.sh"
+summarizer="$repo_root/scripts/summarize-android-a2-session.py"
+mode="${1:-}"
+
+if [[ "$mode" != start && "$mode" != summarize ]]; then
+  echo "usage: $0 start|summarize" >&2
+  exit 64
+fi
+
+KARTPAD_ADB="$adb" "$preflight" >&2
+
+set +e
+devices="$("$adb" devices -l 2>/dev/null)"
+devices_status=$?
+set -e
+if (( devices_status != 0 )); then
+  echo "ERROR: unable to revalidate the ADB target; no device serial was printed" >&2
+  exit "$devices_status"
+fi
+serial="$(printf '%s\n' "$devices" |
+  awk 'NR > 1 && $2 == "device" { print $1; exit }')"
+[[ -n "$serial" ]] || {
+  echo "ERROR: the preflight target disappeared" >&2
+  exit 1
+}
+
+adb_private() {
+  local output
+  local command_status
+  set +e
+  output="$("$adb" -s "$serial" "$@" 2>&1)"
+  command_status=$?
+  set -e
+  if (( command_status != 0 )); then
+    output="${output//$serial/<redacted>}"
+    echo "ERROR: ADB command failed: $output" >&2
+    return "$command_status"
+  fi
+  printf '%s\n' "$output" | tr -d '\r'
+}
+
+package_record="$(adb_private shell cmd package list packages -U dev.kartpad.android)"
+uid="$(printf '%s\n' "$package_record" |
+  sed -nE 's/^package:dev\.kartpad\.android uid:([0-9]+)$/\1/p')"
+[[ "$uid" =~ ^[0-9]+$ ]] || {
+  echo "ERROR: dev.kartpad.android is not installed for UID-scoped capture" >&2
+  exit 1
+}
+
+if [[ "$mode" == start ]]; then
+  device_time="$(adb_private shell date '+%m-%d_%H:%M:%S.000')"
+  start_time="${device_time/_/ }"
+  [[ "$start_time" =~ ^[0-9]{2}-[0-9]{2}[[:space:]][0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}$ ]] || {
+    echo "ERROR: device returned an invalid logcat start timestamp" >&2
+    exit 1
+  }
+  mkdir -p "$(dirname "$marker")"
+  umask 077
+  printf '%s\n' "$start_time" >"$marker"
+  echo "Android A2 UID-scoped capture window started; run the physical test, then invoke: $0 summarize"
+  exit 0
+fi
+
+[[ -f "$marker" ]] || {
+  echo "ERROR: no A2 capture window exists; run '$0 start' first" >&2
+  exit 1
+}
+IFS= read -r start_time <"$marker"
+[[ "$start_time" =~ ^[0-9]{2}-[0-9]{2}[[:space:]][0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}$ ]] || {
+  echo "ERROR: the A2 capture-window marker is invalid" >&2
+  exit 1
+}
+
+# Raw app logs stay in Android's volatile log buffer. Only the fixed-schema
+# sanitizer output reaches stdout; suppress ADB's own stderr because it may
+# contain the private transport serial and replace it with a generic failure.
+summary_tmp="$(mktemp)"
+trap 'rm -f "$summary_tmp"' EXIT
+set +e
+"$adb" -s "$serial" logcat -d -v raw -T "$start_time" --uid="$uid" \
+  2>/dev/null | "$summarizer" --require-signal-matrix >"$summary_tmp"
+pipeline_status=("${PIPESTATUS[@]}")
+set -e
+if (( pipeline_status[0] != 0 )); then
+  echo "ERROR: UID-scoped logcat capture failed; no device serial was printed" >&2
+  exit "${pipeline_status[0]}"
+fi
+cat "$summary_tmp"
+exit "${pipeline_status[1]}"

--- a/scripts/check-android-physical-device.sh
+++ b/scripts/check-android-physical-device.sh
@@ -18,7 +18,11 @@ fail() {
 [[ "$minimum_free_kib" =~ ^[0-9]+$ ]] || \
   fail "KARTPAD_ANDROID_A2_MIN_FREE_KIB must be an integer"
 
-devices="$($adb devices -l)"
+set +e
+devices="$("$adb" devices -l 2>&1)"
+devices_status=$?
+set -e
+(( devices_status == 0 )) || fail "unable to enumerate ADB targets; no device serial was printed"
 ready_count="$(printf '%s\n' "$devices" |
   awk 'NR > 1 && $2 == "device" { count++ } END { print count + 0 }')"
 unavailable_count="$(printf '%s\n' "$devices" |

--- a/scripts/check-android-physical-device.sh
+++ b/scripts/check-android-physical-device.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+# shellcheck source=android-toolchain-versions.sh
+source "$repo_root/scripts/android-toolchain-versions.sh"
+
+sdk_root="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/Library/Android/sdk}}"
+adb="${KARTPAD_ADB:-$sdk_root/platform-tools/adb}"
+minimum_free_kib="${KARTPAD_ANDROID_A2_MIN_FREE_KIB:-4194304}"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+[[ -x "$adb" ]] || fail "adb is unavailable at the configured path"
+[[ "$minimum_free_kib" =~ ^[0-9]+$ ]] || \
+  fail "KARTPAD_ANDROID_A2_MIN_FREE_KIB must be an integer"
+
+devices="$($adb devices -l)"
+ready_count="$(printf '%s\n' "$devices" |
+  awk 'NR > 1 && $2 == "device" { count++ } END { print count + 0 }')"
+unavailable_count="$(printf '%s\n' "$devices" |
+  awk 'NR > 1 && $2 != "device" && NF >= 2 { count++ } END { print count + 0 }')"
+
+if [[ "$ready_count" != 1 ]]; then
+  fail "expected exactly one ready ADB target (ready=$ready_count unavailable=$unavailable_count); no device serial was printed"
+fi
+
+# Keep the ADB serial private. It is used only to disambiguate shell commands and
+# is deliberately never included in output suitable for an evidence record.
+serial="$(printf '%s\n' "$devices" | awk 'NR > 1 && $2 == "device" { print $1; exit }')"
+adb_shell() {
+  local output
+  local command_status
+  set +e
+  output="$("$adb" -s "$serial" shell "$@" 2>&1)"
+  command_status=$?
+  set -e
+  if (( command_status != 0 )); then
+    output="${output//$serial/<redacted>}"
+    echo "ERROR: adb shell command failed ($*): $output" >&2
+    return "$command_status"
+  fi
+  printf '%s\n' "$output" | tr -d '\r'
+}
+
+qemu="$(adb_shell getprop ro.kernel.qemu)"
+[[ "$qemu" != 1 ]] || fail "the sole ready ADB target is an emulator, not physical hardware"
+
+api="$(adb_shell getprop ro.build.version.sdk)"
+abi="$(adb_shell getprop ro.product.cpu.abi)"
+page_size="$(adb_shell getconf PAGE_SIZE)"
+manufacturer="$(adb_shell getprop ro.product.manufacturer |
+  tr '[:space:]' '_' | tr -cd '[:alnum:]_.-')"
+model="$(adb_shell getprop ro.product.model |
+  tr '[:space:]' '_' | tr -cd '[:alnum:]_.-')"
+
+[[ "$api" =~ ^[0-9]+$ ]] || fail "device returned an invalid API level"
+(( api >= KARTPAD_ANDROID_MIN_SDK )) || \
+  fail "device API $api is below KartPad's minimum API $KARTPAD_ANDROID_MIN_SDK"
+[[ "$abi" == arm64-v8a ]] || fail "device primary ABI is $abi, expected arm64-v8a"
+case "$page_size" in
+  4096|16384) ;;
+  *) fail "device page size is $page_size, expected 4096 or 16384" ;;
+esac
+
+free_kib="$(adb_shell df -k /data | awk 'NR > 1 { print $4; exit }')"
+[[ "$free_kib" =~ ^[0-9]+$ ]] || fail "could not determine free space on /data"
+(( free_kib >= minimum_free_kib )) || \
+  fail "device has $free_kib KiB free on /data; A2 preflight requires $minimum_free_kib KiB"
+
+input_dump="$(adb_shell dumpsys input 2>/dev/null || true)"
+controller_count=0
+while IFS= read -r source_hex; do
+  [[ "$source_hex" =~ ^0[xX][0-9a-fA-F]+$ ]] || continue
+  source_value=$((source_hex))
+  # These are AINPUT_SOURCE_GAMEPAD and AINPUT_SOURCE_JOYSTICK from the
+  # pinned NDK's android/input.h. A device may advertise both in one mask.
+  if (( (source_value & 0x401) == 0x401 ||
+        (source_value & 0x01000010) == 0x01000010 )); then
+    controller_count=$((controller_count + 1))
+  fi
+done < <(printf '%s\n' "$input_dump" |
+  sed -nE 's/^[[:space:]]*Sources:[[:space:]]*(0[xX][0-9a-fA-F]+).*$/\1/p')
+
+if adb_shell pm path dev.kartpad.android 2>/dev/null | grep -Fq 'package:'; then
+  package_state=installed
+else
+  package_state=not-installed
+fi
+
+if adb_shell cmd gpu vkjson 2>/dev/null | grep -Eq 'deviceName|apiVersion|driverVersion'; then
+  vulkan_inventory=available
+else
+  vulkan_inventory=unavailable
+fi
+
+echo "Android A2 physical-device preflight passed: device=${manufacturer:-unknown}_${model:-unknown} api=$api abi=$abi page_size=$page_size free_kib=$free_kib package=$package_state input_controller_candidates=$controller_count vulkan_inventory=$vulkan_inventory adb_serial=redacted"
+if (( controller_count == 0 )); then
+  echo "NOTICE: no gamepad/joystick source is visible in dumpsys input; connect the intended controller before the hands-on A2 run" >&2
+fi
+echo "MANUAL: verify SDL controller connection, complete race/results/save/relaunch, pause/resume, surface recreation, audible audio, tactile rumble, and acceptable physical-device performance"

--- a/scripts/prepare-android-game-runtime.sh
+++ b/scripts/prepare-android-game-runtime.sh
@@ -40,6 +40,8 @@ patch --batch -p1 -d "$runtime_source/aurora-main" < \
   "$repo_root/patches/aurora-android-gamepad-rumble.patch"
 patch --batch -p1 -d "$runtime_source/aurora-main" < \
   "$repo_root/patches/aurora-android-gamepad-lifecycle.patch"
+patch --batch -p1 -d "$runtime_source/aurora-main" < \
+  "$repo_root/patches/aurora-android-gamepad-event-cache.patch"
 patch --batch -p1 -d "$runtime_source" < \
   "$repo_root/patches/wiicompiled-android-runtime.patch"
 patch --batch -p1 -d "$runtime_source" < \
@@ -52,6 +54,8 @@ patch --batch -p1 -d "$runtime_source" < \
   "$repo_root/patches/wiicompiled-android-sdl-controller.patch"
 patch --batch -p1 -d "$runtime_source" < \
   "$repo_root/patches/wiicompiled-android-sdl-rumble.patch"
+patch --batch -p1 -d "$runtime_source" < \
+  "$repo_root/patches/wiicompiled-android-sdl-fiber-poll.patch"
 
 generated_link="$(dirname "$runtime_source")/generated"
 if [[ -e "$generated_link" && ! -L "$generated_link" ]]; then

--- a/scripts/summarize-android-a2-session.py
+++ b/scripts/summarize-android-a2-session.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Emit an allowlisted, content-free summary of an Android A2 runtime log."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Sequence, TextIO
+
+
+AUDIO_ACTIVE = re.compile(
+    r"\[audio\] host playback active: (?P<rate>\d+) Hz, "
+    r"(?P<channels>\d+) channels, gain=(?P<gain>[-+0-9.eE]+)"
+)
+NON_SILENT = re.compile(
+    r"\[audio\] non-silent PCM reached host playback: "
+    r"peak=(?P<peak>\d+), queued=(?P<queued>-?\d+) bytes"
+)
+QUEUE = re.compile(
+    r"\[audio\] (?P<final>final )?queue telemetry: "
+    r"checks=(?P<checks>\d+), empty-before-push=(?P<empty>\d+), "
+    r"dropped-blocks=(?P<blocks>\d+), dropped-bytes=(?P<dropped>\d+), "
+    r"submitted-bytes=(?P<submitted>\d+), queued=(?P<queued>-?\d+), "
+    r"observed-range=\[(?P<minimum>-?\d+),(?P<maximum>-?\d+)\] bytes, "
+    r"limit=(?P<limit>\d+) bytes"
+)
+CONTROLLER = re.compile(
+    r"\[input\] Android SDL controller channel (?P<channel>\d+) "
+    r"(?P<state>connected|disconnected)"
+)
+
+LIFECYCLE_MARKERS = (
+    "surfaceCreated()",
+    "surfaceDestroyed()",
+    "nativePause()",
+    "nativeResume()",
+    "Standard gamepads suspended",
+    "Standard gamepads resumed",
+)
+FATAL_MARKERS = (
+    "FATAL EXCEPTION",
+    "Fatal signal",
+    "CheckJNI",
+    "SIGABRT",
+    "SIGSEGV",
+)
+
+
+@dataclass(frozen=True)
+class QueueSample:
+    checks: int
+    empty_before_push: int
+    dropped_blocks: int
+    dropped_bytes: int
+    submitted_bytes: int
+    queued_bytes: int
+    minimum_queued_bytes: int
+    maximum_queued_bytes: int
+    limit_bytes: int
+    final: bool
+
+
+def queue_sample(match: re.Match[str]) -> QueueSample:
+    values = match.groupdict()
+    sample = QueueSample(
+        checks=int(values["checks"]),
+        empty_before_push=int(values["empty"]),
+        dropped_blocks=int(values["blocks"]),
+        dropped_bytes=int(values["dropped"]),
+        submitted_bytes=int(values["submitted"]),
+        queued_bytes=int(values["queued"]),
+        minimum_queued_bytes=int(values["minimum"]),
+        maximum_queued_bytes=int(values["maximum"]),
+        limit_bytes=int(values["limit"]),
+        final=values["final"] is not None,
+    )
+    if (
+        sample.limit_bytes <= 0
+        or sample.minimum_queued_bytes < 0
+        or sample.minimum_queued_bytes > sample.maximum_queued_bytes
+        or sample.maximum_queued_bytes > sample.limit_bytes
+        or sample.queued_bytes < -1
+        or sample.queued_bytes > sample.limit_bytes
+    ):
+        raise ValueError("invalid Android audio queue telemetry")
+    return sample
+
+
+def summarize(streams: Iterable[TextIO]) -> dict:
+    audio_active_events = 0
+    audio_rates: set[int] = set()
+    audio_channels: set[int] = set()
+    non_silent_events = 0
+    maximum_peak = 0
+    queue_samples: list[QueueSample] = []
+    controller_connected = 0
+    controller_disconnected = 0
+    lifecycle = {marker: 0 for marker in LIFECYCLE_MARKERS}
+    fatal = {marker: 0 for marker in FATAL_MARKERS}
+
+    for stream in streams:
+        for raw_line in stream:
+            line = raw_line.rstrip("\r\n")
+            if match := AUDIO_ACTIVE.search(line):
+                audio_active_events += 1
+                audio_rates.add(int(match.group("rate")))
+                audio_channels.add(int(match.group("channels")))
+            if match := NON_SILENT.search(line):
+                non_silent_events += 1
+                maximum_peak = max(maximum_peak, int(match.group("peak")))
+            if "queue telemetry:" in line:
+                match = QUEUE.search(line)
+                if not match:
+                    raise ValueError("malformed Android audio queue telemetry")
+                queue_samples.append(queue_sample(match))
+            if match := CONTROLLER.search(line):
+                if int(match.group("channel")) == 0:
+                    if match.group("state") == "connected":
+                        controller_connected += 1
+                    else:
+                        controller_disconnected += 1
+            for marker in LIFECYCLE_MARKERS:
+                lifecycle[marker] += line.count(marker)
+            for marker in FATAL_MARKERS:
+                fatal[marker] += line.count(marker)
+
+    most_advanced = max(
+        queue_samples,
+        key=lambda sample: (sample.submitted_bytes, sample.checks),
+        default=None,
+    )
+    result = {
+        "schema_version": 1,
+        "audio": {
+            "host_playback_events": audio_active_events,
+            "sample_rates_hz": sorted(audio_rates),
+            "channel_counts": sorted(audio_channels),
+            "non_silent_events": non_silent_events,
+            "maximum_peak": maximum_peak,
+            "queue_sample_count": len(queue_samples),
+            "most_advanced_queue_sample": (
+                asdict(most_advanced) if most_advanced else None
+            ),
+        },
+        "controller": {
+            "channel_0_connected_events": controller_connected,
+            "channel_0_disconnected_events": controller_disconnected,
+        },
+        "lifecycle": {
+            "surface_created": lifecycle["surfaceCreated()"],
+            "surface_destroyed": lifecycle["surfaceDestroyed()"],
+            "native_pause": lifecycle["nativePause()"],
+            "native_resume": lifecycle["nativeResume()"],
+            "gamepads_suspended": lifecycle["Standard gamepads suspended"],
+            "gamepads_resumed": lifecycle["Standard gamepads resumed"],
+        },
+        "fatal_signature_counts": {
+            marker: count for marker, count in fatal.items() if count
+        },
+    }
+    result["automated_signal_matrix_passed"] = bool(
+        audio_active_events
+        and non_silent_events
+        and most_advanced
+        and most_advanced.submitted_bytes > 0
+        and controller_connected
+        and lifecycle["surfaceDestroyed()"]
+        and lifecycle["nativePause()"]
+        and lifecycle["surfaceCreated()"] >= 2
+        and lifecycle["nativeResume()"]
+        and lifecycle["Standard gamepads suspended"]
+        and lifecycle["Standard gamepads resumed"]
+        and not result["fatal_signature_counts"]
+    )
+    return result
+
+
+def self_test() -> None:
+    from io import StringIO
+
+    clean = StringIO(
+        "private text that must not be copied\n"
+        "[audio] host playback active: 32000 Hz, 2 channels, gain=1\n"
+        "[audio] non-silent PCM reached host playback: peak=3988, queued=2716 bytes\n"
+        "[audio] queue telemetry: checks=8192, empty-before-push=0, "
+        "dropped-blocks=1, dropped-bytes=384, submitted-bytes=3141120, "
+        "queued=8604, observed-range=[0,15260] bytes, limit=15360 bytes\n"
+        "[input] Android SDL controller channel 0 connected\n"
+        "surfaceCreated()\nsurfaceDestroyed()\nnativePause()\n"
+        "Standard gamepads suspended\nsurfaceCreated()\nnativeResume()\n"
+        "Standard gamepads resumed\n"
+    )
+    result = summarize([clean])
+    assert result["automated_signal_matrix_passed"]
+    assert result["audio"]["maximum_peak"] == 3988
+    assert "private text" not in json.dumps(result)
+
+    fatal = summarize([StringIO("Fatal signal 6\n")])
+    assert not fatal["automated_signal_matrix_passed"]
+    assert fatal["fatal_signature_counts"] == {"Fatal signal": 1}
+
+    malformed = StringIO("[audio] queue telemetry: private malformed data\n")
+    try:
+        summarize([malformed])
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("malformed queue telemetry was accepted")
+
+
+def open_inputs(paths: Sequence[str]) -> tuple[list[TextIO], list[TextIO]]:
+    if not paths or paths == ["-"]:
+        return [sys.stdin], []
+    if "-" in paths:
+        raise ValueError("stdin cannot be combined with log paths")
+    opened: list[TextIO] = []
+    try:
+        for path in paths:
+            opened.append(Path(path).open(encoding="utf-8", errors="replace"))
+    except OSError:
+        for stream in opened:
+            stream.close()
+        raise
+    return opened, opened
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("logs", nargs="*", help="private logs to summarize; default stdin")
+    parser.add_argument("--require-signal-matrix", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        self_test()
+        print("Android A2 session summarizer self-test passed")
+        return 0
+
+    if args.require_signal_matrix and len(args.logs) > 1:
+        parser.error("--require-signal-matrix accepts one capture or stdin only")
+
+    try:
+        streams, close_after = open_inputs(args.logs)
+        try:
+            result = summarize(streams)
+        finally:
+            for stream in close_after:
+                stream.close()
+    except OSError:
+        parser.error("could not read one or more log inputs")
+    except ValueError as error:
+        parser.error(str(error))
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if args.require_signal_matrix and not result["automated_signal_matrix_passed"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-android-physical-device-preflight.sh
+++ b/scripts/test-android-physical-device-preflight.sh
@@ -13,6 +13,10 @@ set -euo pipefail
 
 scenario="${FAKE_ADB_SCENARIO:-pass}"
 if [[ "${1:-}" == devices ]]; then
+  if [[ "$scenario" == devices-error ]]; then
+    echo "error while enumerating PRIVATE-SERIAL" >&2
+    exit 1
+  fi
   echo 'List of devices attached'
   case "$scenario" in
     absent) ;;
@@ -86,6 +90,7 @@ run_case minimal 0 'package=not-installed input_controller_candidates=1 vulkan_i
 run_case no-controller 0 'no gamepad/joystick source is visible'
 run_case absent 1 'ready=0 unavailable=0'
 run_case unauthorized 1 'ready=0 unavailable=1'
+run_case devices-error 1 'unable to enumerate ADB targets'
 run_case emulator 1 'is an emulator'
 run_case disconnect 1 'adb shell command failed'
 run_case old-api 1 'below KartPad'
@@ -93,4 +98,4 @@ run_case wrong-abi 1 'expected arm64-v8a'
 run_case wrong-page 1 'expected 4096 or 16384'
 run_case low-space 1 'A2 preflight requires'
 
-echo 'Android physical-device preflight contract passed (11 cases; ADB serial redacted).'
+echo 'Android physical-device preflight contract passed (12 cases; ADB serial redacted).'

--- a/scripts/test-android-physical-device-preflight.sh
+++ b/scripts/test-android-physical-device-preflight.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+probe="$repo_root/scripts/check-android-physical-device.sh"
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+fake_adb="$test_root/adb"
+
+cat >"$fake_adb" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+scenario="${FAKE_ADB_SCENARIO:-pass}"
+if [[ "${1:-}" == devices ]]; then
+  echo 'List of devices attached'
+  case "$scenario" in
+    absent) ;;
+    unauthorized) echo 'PRIVATE-SERIAL unauthorized usb:1-1' ;;
+    *) echo 'PRIVATE-SERIAL device usb:1-1 product:sample model:Sample_Device' ;;
+  esac
+  exit 0
+fi
+
+[[ "${1:-}" == -s && "${2:-}" == PRIVATE-SERIAL && "${3:-}" == shell ]]
+shift 3
+if [[ "$scenario" == disconnect ]]; then
+  echo "error: device 'PRIVATE-SERIAL' not found" >&2
+  exit 1
+fi
+case "$*" in
+  'getprop ro.kernel.qemu') [[ "$scenario" == emulator ]] && echo 1 || echo 0 ;;
+  'getprop ro.build.version.sdk') [[ "$scenario" == old-api ]] && echo 27 || echo 36 ;;
+  'getprop ro.product.cpu.abi') [[ "$scenario" == wrong-abi ]] && echo x86_64 || echo arm64-v8a ;;
+  'getconf PAGE_SIZE') [[ "$scenario" == wrong-page ]] && echo 8192 || echo 16384 ;;
+  'getprop ro.product.manufacturer') echo 'Example Corp' ;;
+  'getprop ro.product.model') echo 'Model 1' ;;
+  'df -k /data')
+    echo 'Filesystem 1K-blocks Used Available Use% Mounted on'
+    [[ "$scenario" == low-space ]] && echo '/dev 8000000 7000000 1000000 88% /data' || echo '/dev 16000000 8000000 8000000 50% /data'
+    ;;
+  'dumpsys input')
+    [[ "$scenario" == no-controller ]] || printf '  Sources: 0x01000511\n'
+    ;;
+  'pm path dev.kartpad.android')
+    [[ "$scenario" == minimal ]] && exit 1
+    echo 'package:/data/app/dev.kartpad.android/base.apk'
+    ;;
+  'cmd gpu vkjson')
+    [[ "$scenario" == minimal ]] && exit 1
+    echo '{"deviceName":"Example GPU","apiVersion":1}'
+    ;;
+  *) echo "unexpected fake adb command: $*" >&2; exit 64 ;;
+esac
+EOF
+chmod +x "$fake_adb"
+
+run_case() {
+  local scenario="$1"
+  local expected_status="$2"
+  local expected_text="$3"
+  local output
+  local status
+  set +e
+  output="$(FAKE_ADB_SCENARIO="$scenario" KARTPAD_ADB="$fake_adb" "$probe" 2>&1)"
+  status=$?
+  set -e
+  [[ "$status" == "$expected_status" ]] || {
+    echo "ERROR: scenario $scenario returned $status, expected $expected_status" >&2
+    echo "$output" >&2
+    exit 1
+  }
+  grep -Fq "$expected_text" <<<"$output" || {
+    echo "ERROR: scenario $scenario omitted expected text: $expected_text" >&2
+    echo "$output" >&2
+    exit 1
+  }
+  if grep -Fq 'PRIVATE-SERIAL' <<<"$output"; then
+    echo "ERROR: scenario $scenario exposed the ADB serial" >&2
+    exit 1
+  fi
+}
+
+run_case pass 0 'input_controller_candidates=1'
+run_case minimal 0 'package=not-installed input_controller_candidates=1 vulkan_inventory=unavailable'
+run_case no-controller 0 'no gamepad/joystick source is visible'
+run_case absent 1 'ready=0 unavailable=0'
+run_case unauthorized 1 'ready=0 unavailable=1'
+run_case emulator 1 'is an emulator'
+run_case disconnect 1 'adb shell command failed'
+run_case old-api 1 'below KartPad'
+run_case wrong-abi 1 'expected arm64-v8a'
+run_case wrong-page 1 'expected 4096 or 16384'
+run_case low-space 1 'A2 preflight requires'
+
+echo 'Android physical-device preflight contract passed (11 cases; ADB serial redacted).'

--- a/scripts/test-capture-android-a2-session.sh
+++ b/scripts/test-capture-android-a2-session.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+capture="$repo_root/scripts/capture-android-a2-session.sh"
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+fake_adb="$test_root/adb"
+marker="$test_root/capture-start.txt"
+
+cat >"$fake_adb" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+scenario="${FAKE_ADB_SCENARIO:-pass}"
+if [[ "${1:-}" == devices ]]; then
+  echo 'List of devices attached'
+  echo 'PRIVATE-SERIAL device usb:1-1 product:sample model:Sample_Device'
+  exit 0
+fi
+[[ "${1:-}" == -s && "${2:-}" == PRIVATE-SERIAL ]]
+shift 2
+if [[ "${1:-}" == logcat ]]; then
+  if [[ "$scenario" == logcat-error ]]; then
+    echo "error: device 'PRIVATE-SERIAL' disconnected" >&2
+    exit 1
+  fi
+  cat <<'LOG'
+PRIVATE_GAME_TEXT must never pass the sanitizer
+[audio] host playback active: 32000 Hz, 2 channels, gain=1
+[audio] non-silent PCM reached host playback: peak=4000, queued=3000 bytes
+[audio] queue telemetry: checks=8192, empty-before-push=0, dropped-blocks=0, dropped-bytes=0, submitted-bytes=3145728, queued=8000, observed-range=[0,15000] bytes, limit=15360 bytes
+[input] Android SDL controller channel 0 connected
+surfaceCreated()
+Standard gamepads suspended
+surfaceDestroyed()
+nativePause()
+surfaceCreated()
+nativeResume()
+Standard gamepads resumed
+LOG
+  exit 0
+fi
+[[ "${1:-}" == shell ]]
+shift
+case "$*" in
+  'getprop ro.kernel.qemu') echo 0 ;;
+  'getprop ro.build.version.sdk') echo 36 ;;
+  'getprop ro.product.cpu.abi') echo arm64-v8a ;;
+  'getconf PAGE_SIZE') echo 4096 ;;
+  'getprop ro.product.manufacturer') echo Example ;;
+  'getprop ro.product.model') echo Device ;;
+  'df -k /data')
+    printf 'Filesystem 1K-blocks Used Available Use%% Mounted on\n'
+    echo '/dev 16000000 8000000 8000000 50% /data'
+    ;;
+  'dumpsys input') echo '  Sources: 0x01000511' ;;
+  'pm path dev.kartpad.android') echo 'package:/data/app/dev.kartpad.android/base.apk' ;;
+  'cmd gpu vkjson') echo '{"deviceName":"Example GPU"}' ;;
+  'cmd package list packages -U dev.kartpad.android')
+    echo 'package:dev.kartpad.android uid:10123'
+    ;;
+  'date +%m-%d_%H:%M:%S.000') echo '09-04_12:34:56.000' ;;
+  *) echo "unexpected fake ADB command: $*" >&2; exit 64 ;;
+esac
+EOF
+chmod +x "$fake_adb"
+
+run_capture() {
+  FAKE_ADB_SCENARIO="${1:-pass}" \
+    KARTPAD_ADB="$fake_adb" \
+    KARTPAD_ANDROID_A2_CAPTURE_MARKER="$marker" \
+    "$capture" "$2" 2>&1
+}
+
+start_output="$(run_capture pass start)"
+[[ "$(<"$marker")" == '09-04 12:34:56.000' ]]
+[[ "$start_output" != *'PRIVATE-SERIAL'* ]]
+
+summary_output="$(run_capture pass summarize)"
+[[ "$summary_output" == *'"automated_signal_matrix_passed": true'* ]]
+[[ "$summary_output" != *'PRIVATE_GAME_TEXT'* ]]
+[[ "$summary_output" != *'PRIVATE-SERIAL'* ]]
+
+set +e
+failure_output="$(run_capture logcat-error summarize)"
+failure_status=$?
+set -e
+[[ "$failure_status" == 1 ]]
+[[ "$failure_output" == *'UID-scoped logcat capture failed'* ]]
+[[ "$failure_output" != *'automated_signal_matrix_passed'* ]]
+[[ "$failure_output" != *'PRIVATE-SERIAL'* ]]
+
+echo 'Android A2 UID-scoped capture contract passed (start, summarize, redaction).'


### PR DESCRIPTION
## Summary
- cache SDL controller button/axis state for guest KPAD reads and queue rumble for safe polling
- hand deferred Android SDL polling from Wii guest fibers to the original scheduler/JNI stack
- latch a batched button-down edge for one game snapshot so short cold-start taps are not collapsed by a same-poll release
- document virtual-controller hotplug, reconnect, lifecycle, full Time Trial setup/race entry, and controller-attached cold-launch evidence

## Verification
- API 36 ARM64 virtual controller: full setup into live N64 Mario Raceway
- controller attached before exact final process startup: consecutive 250 ms taps reached Select License and Main Menu; no CheckJNI abort
- fresh Android runtime preparation reproduced the inspected changed upstream files byte-for-byte
- full private ARM64 build/package; exact local APK SHA-256 `2c11450996f33a35ba3aa85dcf16c1c467bf6fd4a0943edef966557639d7a6e7`
- strict APK/privacy audit, host gamepad contract, repository safety, lintDebug, compileReleaseKotlin, SunPad snapshot, and git diff --check

A complete controller-driven race/results/save, physical controller/rumble, audible output, performance, and physical Android acceptance remain open. No APK/AAB or private game data is published.