### PR TITLE
Record tvOS v0.4.1 storage acceptance

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -16,6 +16,14 @@ plus shared aspect-state synchronization. Physical testing of the exact tvOS
 artifact remains open, so A12 compatibility and supported Apple TV operation
 are not claimed.
 
+The Issue #17 reporter accepted the exact public `v0.4.1` tvOS storage hotfix on
+an Apple TV 4K (3rd generation) running tvOS 26.5/26.6. Config writes no longer
+raise error 513, both profiles launch, NAND/save and settings changes survive a
+normal relaunch, and the cache-root backup script succeeds. This resolves the
+reported storage defect without establishing the still-open 0.4.2, A12,
+sleep/wake, restore, multi-controller, purge-recovery, or sustained-performance
+gates.
+
 The `codex/iphone-touch-layout-editor` candidate captures the maintainer's
 current physical-iPhone control positions as the default for untouched iPhone
 installs only. Existing custom layouts and every iPad layout remain unchanged.

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -52,13 +52,15 @@ tvOS IPA SHA-256:
 - [x] Build and audit exact merged-source tvOS app 0.4.1 build 4
 - [x] Package twice byte-identically and pass fresh extraction audits
 - [x] Publish tag, IPA, checksum, and verify a fresh hosted download
-- [ ] Receive reporter acceptance on the exact signed hotfix artifact
+- [x] Receive reporter acceptance on the exact signed hotfix artifact
 
 Published source: `d0e77d5c9bc48a7f1f6aaedf79fd00d5e616dc0c`.
 tvOS executable SHA-256:
 `a9e5c89ba20406897f8925c48b9683a1582bf902a9335a6922c22db1240f7ce3`.
 tvOS IPA SHA-256:
 `ca62f6e00e0b5260ddb6b836ae2cda969d3bc5655ba4bd3dac19aa9406249e49`.
+The Issue #17 reporter accepted config writes without error 513, both profile
+launches, normal-relaunch persistence, and cache-root backup on 2026-09-04.
 
 ## 0.4.0 stable candidate
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -25,12 +25,13 @@ platform, dependency, symbol, privacy, and private-data audit. An external Apple
 TV 4K (3rd generation) run on tvOS 26.5/26.6 accepted playable Original and
 Retro Rewind video, audio, menus, and Extended Gamepad input after moving the
 runtime from unwritable Application Support to Caches. The `v0.4.1` tvOS-only
-hotfix incorporates that path correction. The 0.4.2 release adds a generic
-compiler baseline, explicitly disables RCpc instructions, and rejects those
-instructions during final-binary audit; physical testing of the exact public
-artifact, save recovery, sleep/wake, multi-controller, and sustained
-performance remain open. Apple TV support is therefore still experimental. The
-release includes
+hotfix incorporates that path correction, and the reporter accepted its exact
+public IPA for config writes, both profile launches, normal-relaunch
+persistence, and cache-root backup. The 0.4.2 release adds a generic compiler
+baseline, explicitly disables RCpc instructions, and rejects those instructions
+during final-binary audit; physical testing of the exact 0.4.2 artifact, restore,
+sleep/wake, multi-controller, and sustained performance remain open. Apple TV
+support is therefore still experimental. The release includes
 an original three-layer tvOS icon and Top Shelf image compiled into its audited
 asset catalog. The
 authoritative scope, build procedure, storage boundary, and external-testing
@@ -69,8 +70,12 @@ Support fallback, and adds a non-atomic config write fallback for the physical
 error-513 path. The exact merged-source build and app audit passed, two packages
 were byte-identical, and a fresh anonymous hosted download matched and passed
 checksum, ZIP, app, privacy, signing-residue, private-data, and provenance
-audits. The iPhone/iPad 0.4.0 release is unchanged. Reporter acceptance on the
-exact signed hotfix artifact remains open.
+audits. The iPhone/iPad 0.4.0 release is unchanged. On 2026-09-04, the reporter
+accepted the exact signed hotfix artifact on an Apple TV 4K (3rd generation):
+`Config.toml` wrote without error 513, Original and Retro Rewind launched,
+NAND/save and settings changes survived normal termination and relaunch, and
+`backup-tvos-state.sh` succeeded. Issue #17 is resolved; broader tvOS and exact
+0.4.2 acceptance remain separate gates.
 
 **0.4.0 is published as KartPad's second stable community release.** The
 `v0.4.0` tag points to source commit

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -48,6 +48,13 @@ The mobile settings bridge now reports the selected aspect mode through the
 guest `SCGetAspectRatio` result. This removes a deterministic state mismatch
 without adding new tvOS settings UI or changing the accepted launch flow.
 
+The Issue #17 Apple TV 4K (3rd generation) report also found the fixed 1.0x
+render scale visibly soft on a large display and reported that 2.0x or 2.5x
+remained at 60 FPS while the device thermal state was nominal. Treat that as a
+single-device optimization lead, not a new default or sustained-performance
+claim. Any default change belongs with the deferred tvOS settings work and must
+be benchmarked across supported Apple TV hardware and thermal states first.
+
 Acceptance requires all of the following:
 
 - controller-required messaging and input gating remain intact;

--- a/docs/TVOS.md
+++ b/docs/TVOS.md
@@ -7,10 +7,13 @@ path. An external Apple TV 4K (3rd generation) tester reached playable Original
 Mario Kart Wii and Retro Rewind on tvOS 26.5/26.6 with an Extended Gamepad, but
 the public `v0.4.0` build could not write config, NAND, saves, or logs under
 Application Support. The `v0.4.1` hotfix moves all filesystem-backed tvOS state
-to Caches, matching the successful physical workaround. The 0.4.2 candidate
-also uses a generic compiler baseline, disables RCpc instructions, and rejects
-them during final-binary audit. Until the remaining physical acceptance matrix
-passes on an exact public artifact, the correct
+to Caches, matching the successful physical workaround. The reporter then
+accepted the exact public `v0.4.1` IPA on the same hardware: error 513 was gone,
+both modes launched, save/config changes survived a normal relaunch, and the
+backup script succeeded. The 0.4.2 candidate also uses a generic compiler
+baseline, disables RCpc instructions, and rejects them during final-binary
+audit. Until the remaining physical acceptance matrix passes on the exact
+0.4.2 artifact, the correct
 claim is **public experimental tvOS build**, not supported Apple TV
 functionality.
 
@@ -139,9 +142,11 @@ Record the Apple TV model, tvOS version, Xcode/SDK, controller models, source
 commit, binary SHA-256, and whether the run used Original or Retro Rewind.
 
 - [x] Clean unsigned `KartPadDual` build passes `audit-tvos-app.sh`.
-- [ ] Locally signed candidate installs and opens on a physical Apple TV.
+- [x] The exact public `v0.4.1` IPA installs in place after local re-signing and
+  opens on a physical Apple TV.
 - [ ] Missing data shows setup instructions rather than crashing or exiting.
-- [ ] Valid RMCP01 data stages from a Mac and survives ordinary relaunch.
+- [x] Valid RMCP01 data loads from Caches and survives ordinary relaunch on the
+  exact public `v0.4.1` IPA.
 - [ ] Original mode reaches a complete race with correct video and audio.
 - [ ] Retro Rewind downloads, verifies, installs, and reaches a complete race.
 - [ ] Original/Retro mode switching works across clean relaunches.
@@ -149,8 +154,11 @@ commit, binary SHA-256, and whether the run used Original or Retro Rewind.
   reconnect; Siri Remote input never leaks into racing controls.
 - [ ] Two-, three-, and four-controller slot assignment is stable.
 - [ ] A save survives normal exit, relaunch, sleep/wake, and forced termination.
+  The normal-exit/relaunch substep passes on `v0.4.1`; sleep/wake and forced
+  termination remain open.
 - [ ] `backup-tvos-state.sh` captures the save and a restore rehearsal recovers
-  it before any tester is asked to risk meaningful progress.
+  it before any tester is asked to risk meaningful progress. Capture passes on
+  `v0.4.1`; restore remains open.
 - [ ] Purging reconstructible content produces a recovery screen; restaging
   game data and redownloading Retro Rewind do not overwrite saves.
 - [ ] A full cup and at least a 30-minute soak record frame pacing, audio,
@@ -168,9 +176,15 @@ outside cohort performs physical acceptance. The first report confirms both
 modes can reach smooth playable gameplay with audio, 3D rendering, menus, and
 wireless gamepad input. It also exposed error 513 on Application Support; the
 reporter's cache-root workaround succeeded and is the basis of `v0.4.1`.
-Save/relaunch, sleep/wake, multi-controller, purge recovery, and an exact public
-hotfix retest remain open. This is still a hardware bring-up build, not a
-supported release.
+The reporter subsequently re-signed and installed the exact public `v0.4.1`
+IPA in place. Config writes produced no error 513, Original and Retro Rewind
+both launched, NAND/save and settings changes survived normal termination and
+relaunch, and `backup-tvos-state.sh` captured the cache-root state. This closes
+the storage defect in Issue #17. Sleep/wake, forced termination, restore,
+multi-controller, purge recovery, sustained performance, and the exact 0.4.2
+artifact remain open. This is still a hardware bring-up build, not a supported
+release. The acceptance record is in
+[`docs/artifacts/2026-09-04/tvos-v0.4.1-storage-acceptance.md`](artifacts/2026-09-04/tvos-v0.4.1-storage-acceptance.md).
 
 Before sending it, package and audit one exact candidate. Testers must have a
 paired Apple TV, a Mac with Xcode, an Extended Gamepad, their own supported game

--- a/docs/artifacts/2026-09-04/tvos-v0.4.1-storage-acceptance.md
+++ b/docs/artifacts/2026-09-04/tvos-v0.4.1-storage-acceptance.md
@@ -1,0 +1,44 @@
+# tvOS v0.4.1 storage acceptance
+
+Date: 2026-09-04
+
+Source: [Issue #17 reporter retest](https://github.com/chrissotraidis/kartpad/issues/17#issuecomment-5534726409)
+
+## Exact candidate
+
+- Device: Apple TV 4K (3rd generation), `AppleTV14,1`
+- OS: tvOS 26.5/26.6, build `23L773`
+- App: KartPad 0.4.1 build 4
+- IPA: `KartPad-v0.4.1-tvos-unsigned.ipa`
+- IPA SHA-256: `ca62f6e00e0b5260ddb6b836ae2cda969d3bc5655ba4bd3dac19aa9406249e49`
+- Installation: re-signed in place with the reporter's personal team profile
+- Input: Bluetooth Extended Gamepad
+
+## Accepted result
+
+The reporter confirmed all four checks requested for the public storage
+hotfix:
+
+1. `Library/Caches/KartPad/Config.toml` was created and written, with no Cocoa
+   error 513 on launch or profile change.
+2. Original Mario Kart Wii and Retro Rewind both launched and loaded their
+   assets from Caches.
+3. NAND/save and settings changes survived normal app termination and relaunch.
+4. `scripts/backup-tvos-state.sh` copied the cache-root state over the
+   CoreDevice connection without error.
+
+This accepts the `v0.4.1` Application Support-to-Caches correction and closes
+Issue #17. It does not prove the exact `v0.4.2` binary or its A12 compiler
+baseline, restore from backup, sleep/wake, forced termination, cache-purge
+recovery, multi-controller behavior, long-soak performance, or live Retro WFC.
+tvOS remains an experimental hardware-bring-up platform.
+
+## Follow-up observation
+
+At nominal thermal state, the reporter observed approximately 60 FPS with
+16.6 ms average frame time. Under prolonged load at a Serious thermal state,
+heavy scenes fell to approximately 50 FPS. They also reported that 2.0x or 2.5x
+render scale looked substantially sharper than the current 1.0x default while
+remaining at 60 FPS under nominal thermals. These are one-device observations,
+not accepted defaults or broad performance claims; the render-scale suggestion
+is tracked in `docs/TECH-DEBT.md`.


### PR DESCRIPTION
## Summary

- record the Issue #17 physical retest of the exact public v0.4.1 tvOS IPA
- mark the storage-hotfix reporter gate accepted without broadening the v0.4.2 or full tvOS claims
- preserve the resolution-scale observation as a benchmarked follow-up in tvOS technical debt

## Verification

- `./scripts/check-repo-safety.sh`
- `env PYTHONPATH=builder python3 -m unittest tests.test_tvos_contract`
- `git diff --check`

Closes #17