### PR TITLE
Extract shared Retro Rewind archive path validation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,6 +293,17 @@ if(MKW_BUILD_IOS_SIMULATOR OR MKW_BUILD_IOS_DEVICE)
 endif()
 
 if(BUILD_TESTING)
+  add_executable(kartpad_retro_rewind_archive_path_tests
+    runtime/tests/retro_rewind_archive_path_tests.cpp
+    runtime/src/retro_rewind/archive_path.cpp)
+  target_include_directories(kartpad_retro_rewind_archive_path_tests PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/runtime/include")
+  target_compile_features(kartpad_retro_rewind_archive_path_tests PRIVATE cxx_std_20)
+  target_compile_options(kartpad_retro_rewind_archive_path_tests PRIVATE
+    -Wall -Wextra -Wpedantic -Werror)
+  add_test(NAME kartpad.retro-rewind.archive-path
+    COMMAND kartpad_retro_rewind_archive_path_tests)
+
   add_executable(kartpad_mii_database_tests runtime/tests/mii_database_tests.cpp)
   target_include_directories(kartpad_mii_database_tests PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/runtime/include")

--- a/apple/ios/KartPadRetroRewindInstaller.mm
+++ b/apple/ios/KartPadRetroRewindInstaller.mm
@@ -3,6 +3,7 @@
 #import <CommonCrypto/CommonDigest.h>
 #import <TargetConditionals.h>
 
+#include "kartpad/retro_rewind/archive_path.h"
 #include "kartpad_retro_rewind_release.h"
 #include "mz.h"
 #include "mz_strm.h"
@@ -99,30 +100,37 @@ NSString *KartPadSHA256ForLargeFile(NSString *path,
   return KartPadHexDigest(digest, sizeof(digest));
 }
 
-NSArray<NSString *> *KartPadSafeArchiveComponents(NSString *name,
+NSArray<NSString *> *KartPadSafeArchiveComponents(const char *nameBytes,
+                                                   size_t nameLength,
+                                                   NSString **decodedName,
                                                    NSError **error) {
-  if (name.length == 0 || [name hasPrefix:@"/"] ||
-      [name containsString:@"\\"] || [name containsString:@"\0"]) {
+  const std::string_view bytes{nameBytes, nameLength};
+  const kartpad::retro_rewind::ArchiveMemberPath validated =
+      kartpad::retro_rewind::ValidateArchiveMemberPath(bytes);
+  NSString *name = [[NSString alloc] initWithBytes:nameBytes
+                                            length:nameLength
+                                          encoding:NSUTF8StringEncoding];
+  if (!validated || name == nil) {
     KartPadRetroRewindFail(error, 3,
         [NSString stringWithFormat:@"The archive contains an unsafe path: %@",
                                    name ?: @"(invalid)"]);
     return nil;
   }
+  if (decodedName != nullptr) *decodedName = name;
+
   NSMutableArray<NSString *> *parts =
-      [[name componentsSeparatedByString:@"/"] mutableCopy];
-  if (parts.lastObject.length == 0) [parts removeLastObject];
-  if (parts.count == 0) {
-    KartPadRetroRewindFail(error, 3, @"The archive contains an empty path.");
-    return nil;
-  }
-  for (NSString *part in parts) {
-    if (part.length == 0 || [part isEqualToString:@"."] ||
-        [part isEqualToString:@".."] || [part containsString:@":"]) {
+      [NSMutableArray arrayWithCapacity:validated.components.size()];
+  for (const std::string& component : validated.components) {
+    NSString *part = [[NSString alloc] initWithBytes:component.data()
+                                              length:component.size()
+                                            encoding:NSUTF8StringEncoding];
+    if (part == nil) {
       KartPadRetroRewindFail(error, 3,
           [NSString stringWithFormat:@"The archive contains an unsafe path: %@",
-                                     name]);
+                                     name ?: @"(invalid)"]);
       return nil;
     }
+    [parts addObject:part];
   }
   return parts;
 }
@@ -343,9 +351,9 @@ BOOL KartPadFileMatches(NSString *path, uint64_t expectedBytes,
                                           @"The ZIP directory is malformed.");
       break;
     }
-    NSString *name = [NSString stringWithUTF8String:info->filename];
-    NSArray<NSString *> *parts = name == nil ? nil :
-        KartPadSafeArchiveComponents(name, &workError);
+    NSString *name = nil;
+    NSArray<NSString *> *parts = KartPadSafeArchiveComponents(
+        info->filename, info->filename_size, &name, &workError);
     if (parts == nil) break;
     if (mz_zip_attrib_is_symlink(info->external_fa,
                                  info->version_madeby) == MZ_OK ||
@@ -389,8 +397,9 @@ BOOL KartPadFileMatches(NSString *path, uint64_t expectedBytes,
       workError = KartPadRetroRewindError(29, @"A ZIP entry could not be read.");
       break;
     }
-    NSString *name = [NSString stringWithUTF8String:info->filename];
-    NSArray<NSString *> *parts = KartPadSafeArchiveComponents(name, &workError);
+    NSString *name = nil;
+    NSArray<NSString *> *parts = KartPadSafeArchiveComponents(
+        info->filename, info->filename_size, &name, &workError);
     if (parts == nil) break;
     if ([parts.firstObject isEqualToString:
             [NSString stringWithUTF8String:KARTPAD_RR_ROOT]]) {

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -32,6 +32,16 @@ covers twelve supported and rejected device states and proves that the ADB
 serial is not emitted; the current host has no attached ADB target, so this
 does not satisfy a physical A2 row.
 
+While that external A2 prerequisite is unavailable, the first independent A3
+source slice extracts archive member-path validation into
+`runtime/src/retro_rewind/archive_path.cpp`. The existing iOS/tvOS installer
+now consumes that byte-oriented contract using minizip's explicit filename
+length, including embedded-NUL rejection. Host tests cover every prohibited
+path class, the pinned NDK compiles it for API-28 ARM64 with warnings as errors,
+and fresh Apple patch preparation succeeds. Android download,
+storage, extraction, activation, rollback, and gameplay remain unimplemented;
+this does not pass A3 or change A2's status.
+
 KartPad can be ported to Android without changing its defining architecture.
 The Android build should contain the same ahead-of-time translated Original
 Mario Kart Wii and Retro Rewind profiles as the Apple `KartPadDual` product,

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -150,7 +150,15 @@ not block offline Retro Rewind support.
    `docs/artifacts/2026-09-04/android/a2-physical-device-preflight.md`, plus
    `docs/artifacts/2026-09-04/android/a2-runtime-signal-sanitizer.md` and
    `docs/artifacts/2026-09-04/android/a2-uid-scoped-capture.md`.
-   A2 remains open.
+   A2 remains open. While no device is attached, an independent A3 source
+   slice moved ZIP member-path validation into portable C++ already consumed
+   by iOS/tvOS. Its host matrix, pinned NDK ARM64 compile, SDK-targeted
+   installer compile, and fresh Apple patch preparation pass; a full Apple
+   link stopped at an unrelated
+   fail-closed cached-Dawn hash mismatch. Continue the remaining shared
+   installer rules and thin Android owner only when they are immediately
+   consumed and tested. Evidence:
+   `docs/artifacts/2026-09-04/android/a3-shared-archive-path.md`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2153,3 +2153,31 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   hands-on rows. No APK/AAB, raw log, device identifier, package UID,
   controller name, save, or game data was published. Evidence:
   `docs/artifacts/2026-09-04/android/a2-uid-scoped-capture.md`.
+
+## 2026-09-04 — Android A3 shared archive-path validation
+
+- Kept A2 open because no physical Android target is attached, then selected
+  the independent source-only portion of A3 authorized by the goal loop.
+- Extracted the Apple Retro Rewind installer's ZIP member-path policy into a
+  byte-oriented portable C++ validator. It rejects empty and absolute names,
+  backslashes, embedded NULs, repeated/empty components, `.`/`..`, and colons
+  while allowing one trailing directory slash.
+- Wired the existing iOS/tvOS installer and every Apple product variant to the
+  shared implementation immediately. The wrapper now validates minizip's
+  explicit filename byte span before UTF-8 decoding, closing the prior
+  C-string truncation gap for embedded NULs.
+- The focused C++ contract passes. A targeted iOS Simulator SDK Objective-C++
+  compile, pinned NDK API-28 ARM64 warning-as-error compile, fresh dual-product
+  patch preparation, 29 builder/tvOS contracts, repository diff validation,
+  and source wiring checks pass; one private
+  payload test remains skipped because its optional input is not cached.
+- A full dual iOS Simulator link stopped before compilation because the cached
+  Dawn archive does not match the script's pinned SHA-256. The fail-closed
+  check was preserved and the cache was not trusted or modified.
+- Classification: **Pass for the portable path policy and immediate Apple
+  consumer; full Apple link inconclusive due to an unrelated dependency-cache
+  mismatch.** A2 remains the lowest incomplete goal, and A3 remains open for
+  the Android owner, remaining shared installer rules, failure recovery, and
+  complete emulator/physical offline acceptance. No APK/AAB or private input
+  was published. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-shared-archive-path.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -235,6 +235,20 @@ contract passes. No device is attached, so physical execution remains open.
 Evidence:
 [`docs/artifacts/2026-09-04/android/a2-uid-scoped-capture.md`](artifacts/2026-09-04/android/a2-uid-scoped-capture.md).
 
+Independent source-only A3 work has begun without relabeling the blocked A2
+physical row. The Retro Rewind archive member-path policy is now portable C++
+and is consumed by the existing iOS/tvOS installer using minizip's explicit
+filename byte length. Its contract rejects absolute paths, backslashes,
+embedded NULs, empty/repeated components, dot traversal, and colons/drive
+prefixes; a direct host test, pinned NDK ARM64 compile, Apple SDK syntax
+compile, fresh dual-product patch preparation, and 29 Apple/builder contracts
+pass. A full dual iOS link
+stopped fail-closed before compilation because the local cached Dawn archive
+does not match its pinned hash. This is one shared validation slice, not an
+Android installer or A3 acceptance result. A2 remains the lowest incomplete
+goal and A3 remains open. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-shared-archive-path.md`](artifacts/2026-09-04/android/a3-shared-archive-path.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-04/android/a3-shared-archive-path.md
+++ b/docs/artifacts/2026-09-04/android/a3-shared-archive-path.md
@@ -1,0 +1,70 @@
+# Android A3 shared archive-path contract
+
+Date: 2026-09-04
+
+Branch: `codex/android-a3-archive-path-core`
+
+Baseline: `ef791deb04c4653f282ac0f2d28e17332b95f4cf`
+
+## Falsifiable subgoal
+
+Move the existing Retro Rewind ZIP member-path policy out of the Apple-only
+installer into portable C++ that the Apple products consume immediately, and
+reject the same unsafe byte-level inputs in a host contract test. This is
+independent source-only A3 preparation while A2 remains blocked on physical
+Android hardware; it is not A3 installation or gameplay acceptance.
+
+## Result
+
+- Added `kartpad::retro_rewind::ValidateArchiveMemberPath`, which treats entry
+  names as opaque bytes and rejects empty names, absolute paths, backslashes,
+  embedded NULs, empty components, `.` and `..`, and colons/drive prefixes.
+- Exactly one trailing slash is retained as a directory marker. Repeated
+  separators, including a double trailing slash, remain invalid.
+- The iOS/tvOS installer now passes minizip's explicit `filename_size`, so an
+  embedded NUL cannot be hidden by C-string or `NSString` truncation.
+- Existing iOS, tvOS, Retro-only, and dual product targets compile the shared
+  `.cpp` through their current mobile source lists. Android can consume the
+  same API when its installer wrapper is added.
+
+Source SHA-256 values:
+
+- header: `a4555c677dd04ced3fd91466ffef24a7a463951658e51dba873d1ecb5ed421cf`
+- implementation: `fc2985fb2d56a92ef589472df07cbcae6352db1504d2e5f154f526c90a9e52aa`
+- test: `927fb46e929afe4304ca93af0ae7fab616e945c69b288c9f39875ec4bd35e52c`
+
+## Verification
+
+- `kartpad.retro-rewind.archive-path`: pass, including valid nested,
+  directory, and UTF-8 paths plus every prohibited path class.
+- Pinned NDK 29 API-28 ARM64 compile with the repository warning-as-error
+  policy: pass; output is an AArch64 ELF relocatable object.
+- iOS Simulator SDK-targeted Objective-C++ syntax compile of
+  `KartPadRetroRewindInstaller.mm` with warnings as errors: pass (with the
+  file's established Objective-C omitted-operand extension explicitly allowed).
+- Fresh integrated WiiCompiled source preparation for the dual Apple product:
+  pass; all patches apply and `PublicProducts.cmake` contains the shared
+  source.
+- `tests.test_kartpad_builder` and `tests.test_tvos_contract`: 29 pass, one
+  pre-existing private-payload test skipped because that payload is not
+  cached.
+- `git diff --check`: pass.
+
+A full dual iOS Simulator link was attempted but stopped before configuration:
+the local cached Dawn archive hashes to
+`c9272faca14a307e4545ea83cb66ab2f65e87fa33a0a687bf5c702666271bc03`,
+not the script's required
+`feb5c4e07da90c47d2f279bf83c43bc67db01dac1138cb9af8ea9b5b50c67fbf`.
+The integrity check was preserved; the mismatched cache was neither trusted nor
+modified. The direct SDK compile and fresh patch preparation cover this slice,
+but do not upgrade the full link to passing evidence.
+
+## Classification
+
+**Pass for the portable archive-member path contract and its immediate Apple
+consumer; inconclusive for a full Apple link due to the unrelated fail-closed
+Dawn cache mismatch.** A2 remains the lowest incomplete goal. A3 remains open
+for Android download/storage ownership, all remaining shared install rules,
+fault recovery, emulator and physical-device installation, mode switching,
+offline race/results/save/relaunch, and fallback rejection. No APK/AAB, Retro
+Rewind archive, game data, save, identifier, or private log was published.

--- a/patches/wiicompiled-ios-discio-import.patch
+++ b/patches/wiicompiled-ios-discio-import.patch
@@ -1,6 +1,6 @@
 --- a/cmake/PublicProducts.cmake
 +++ b/cmake/PublicProducts.cmake
-@@ -271,16 +271,55 @@
+@@ -271,16 +271,56 @@
  
  set(MKW_KARTPAD_REPO_ROOT "" CACHE PATH
      "KartPad repository root used to embed the exact mobile UIKit host")
@@ -53,10 +53,11 @@
 +        "${MKW_KARTPAD_IOS_DIR}/KartPadDiscExtractor.mm"
 +        "${MKW_KARTPAD_IOS_DIR}/KartPadDiscFormats.cpp"
 +        "${MKW_KARTPAD_IOS_DIR}/KartPadRetroRewindInstaller.mm"
++        "${MKW_KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_path.cpp"
          "${MKW_KARTPAD_MOBILE_DIR}/KartPadClassicInput.mm"
          "${MKW_KARTPAD_MOBILE_DIR}/KartPadPhysicalControllers.mm"
          "${MKW_KARTPAD_MOBILE_DIR}/KartPadMotionSteering.mm"
-@@ -306,20 +346,34 @@
+@@ -306,20 +347,34 @@
          "${MKW_KARTPAD_IOS_DIR}"
          "${MKW_KARTPAD_MOBILE_DIR}"
          "${MKW_KARTPAD_SHARED_DIR}"

--- a/patches/wiicompiled-tvos-runtime.patch
+++ b/patches/wiicompiled-tvos-runtime.patch
@@ -36,7 +36,7 @@
          _DISABLE_STRING_ANNOTATION _DISABLE_VECTOR_ANNOTATION TARGET_PC)
      target_compile_features(${target} PRIVATE cxx_std_20)
      mkw_apply_common_compile_options(${target})
-@@ -390,7 +390,104 @@
+@@ -390,7 +390,105 @@
          XCODE_ATTRIBUTE_SUPPORTS_MACCATALYST NO
          XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2")
  endif()
@@ -84,6 +84,7 @@
 +    set(MKW_KARTPAD_TVOS_SOURCES
 +        "${MKW_KARTPAD_TVOS_DIR}/KartPadTVRuntimeHost.mm"
 +        "${MKW_KARTPAD_IOS_DIR}/KartPadRetroRewindInstaller.mm"
++        "${MKW_KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_path.cpp"
 +        "${MKW_KARTPAD_MOBILE_DIR}/KartPadClassicInput.mm"
 +        "${MKW_KARTPAD_MOBILE_DIR}/KartPadPhysicalControllers.mm"
 +        "${MKW_KARTPAD_SUNPAD_DIR}/SunPadControllerMapping.mm"
@@ -141,7 +142,7 @@
  if(MKW_HAVE_RETRO_REWIND)
      add_executable(RetroRewind "${MKW_RETRO_REWIND_PRODUCT_SOURCE}" ${MKW_RETRO_REGISTRATION_SOURCES})
      mkw_configure_product(RetroRewind)
-@@ -455,6 +544,10 @@
+@@ -455,6 +545,10 @@
              XCODE_ATTRIBUTE_SUPPORTS_MACCATALYST NO
              XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2")
      endif()
@@ -152,7 +153,7 @@
      add_custom_target(mkw_release DEPENDS WiiCompiled RetroRewind)
  else()
      add_custom_target(mkw_release DEPENDS WiiCompiled)
-@@ -529,6 +622,10 @@
+@@ -529,6 +623,10 @@
              XCODE_ATTRIBUTE_SUPPORTS_MACCATALYST NO
              XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2")
      endif()

--- a/runtime/include/kartpad/retro_rewind/archive_path.h
+++ b/runtime/include/kartpad/retro_rewind/archive_path.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace kartpad::retro_rewind {
+
+enum class ArchivePathError {
+  None,
+  Empty,
+  Absolute,
+  Backslash,
+  Nul,
+  EmptyComponent,
+  DotComponent,
+  ParentComponent,
+  Colon,
+};
+
+struct ArchiveMemberPath {
+  ArchivePathError error = ArchivePathError::None;
+  std::vector<std::string> components;
+  bool directory = false;
+
+  explicit operator bool() const { return error == ArchivePathError::None; }
+};
+
+// Treats the archive name as opaque bytes. UTF-8 validation belongs to the
+// platform archive reader; this function enforces the cross-platform path
+// traversal contract without applying host filesystem normalization.
+ArchiveMemberPath ValidateArchiveMemberPath(std::string_view name);
+
+}  // namespace kartpad::retro_rewind

--- a/runtime/src/retro_rewind/archive_path.cpp
+++ b/runtime/src/retro_rewind/archive_path.cpp
@@ -1,0 +1,68 @@
+#include "kartpad/retro_rewind/archive_path.h"
+
+#include <algorithm>
+#include <cstddef>
+
+namespace kartpad::retro_rewind {
+namespace {
+
+ArchiveMemberPath InvalidPath(const ArchivePathError error) {
+  ArchiveMemberPath result;
+  result.error = error;
+  return result;
+}
+
+}  // namespace
+
+ArchiveMemberPath ValidateArchiveMemberPath(const std::string_view name) {
+  if (name.empty()) {
+    return InvalidPath(ArchivePathError::Empty);
+  }
+  if (name.front() == '/') {
+    return InvalidPath(ArchivePathError::Absolute);
+  }
+  if (name.find('\\') != std::string_view::npos) {
+    return InvalidPath(ArchivePathError::Backslash);
+  }
+  if (name.find('\0') != std::string_view::npos) {
+    return InvalidPath(ArchivePathError::Nul);
+  }
+
+  ArchiveMemberPath result;
+  result.directory = name.back() == '/';
+  const std::size_t content_size = name.size() - (result.directory ? 1 : 0);
+  if (content_size == 0) {
+    return InvalidPath(ArchivePathError::Empty);
+  }
+  if (name[content_size - 1] == '/') {
+    return InvalidPath(ArchivePathError::EmptyComponent);
+  }
+
+  std::size_t component_start = 0;
+  while (component_start < content_size) {
+    const std::size_t slash = name.find('/', component_start);
+    const std::size_t component_end =
+        std::min(slash == std::string_view::npos ? content_size : slash,
+                 content_size);
+    const std::string_view component =
+        name.substr(component_start, component_end - component_start);
+    if (component.empty()) {
+      return InvalidPath(ArchivePathError::EmptyComponent);
+    }
+    if (component == ".") {
+      return InvalidPath(ArchivePathError::DotComponent);
+    }
+    if (component == "..") {
+      return InvalidPath(ArchivePathError::ParentComponent);
+    }
+    if (component.find(':') != std::string_view::npos) {
+      return InvalidPath(ArchivePathError::Colon);
+    }
+    result.components.emplace_back(component);
+    component_start = component_end + 1;
+  }
+
+  return result;
+}
+
+}  // namespace kartpad::retro_rewind

--- a/runtime/tests/retro_rewind_archive_path_tests.cpp
+++ b/runtime/tests/retro_rewind_archive_path_tests.cpp
@@ -1,0 +1,69 @@
+#include "kartpad/retro_rewind/archive_path.h"
+
+#include <initializer_list>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+namespace {
+
+using kartpad::retro_rewind::ArchivePathError;
+using kartpad::retro_rewind::ValidateArchiveMemberPath;
+
+bool ExpectValid(const std::string_view input,
+                 const std::initializer_list<std::string_view> components,
+                 const bool directory = false) {
+  const auto result = ValidateArchiveMemberPath(input);
+  if (!result || result.directory != directory ||
+      result.components.size() != components.size()) {
+    std::cerr << "expected valid archive path\n";
+    return false;
+  }
+  std::size_t index = 0;
+  for (const std::string_view expected : components) {
+    if (result.components[index++] != expected) {
+      std::cerr << "archive component mismatch\n";
+      return false;
+    }
+  }
+  return true;
+}
+
+bool ExpectInvalid(const std::string_view input,
+                   const ArchivePathError expected) {
+  const auto result = ValidateArchiveMemberPath(input);
+  if (result || result.error != expected || !result.components.empty()) {
+    std::cerr << "unexpected archive path validation result\n";
+    return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+int main() {
+  bool ok = true;
+  ok &= ExpectValid("RetroRewind6.12.5/file.bin",
+                    {"RetroRewind6.12.5", "file.bin"});
+  ok &= ExpectValid("RetroRewind6.12.5/a/b/", {"RetroRewind6.12.5", "a", "b"},
+                    true);
+  ok &= ExpectValid("RetroRewind6.12.5/caf\xC3\xA9.bin",
+                    {"RetroRewind6.12.5", "caf\xC3\xA9.bin"});
+  ok &= ExpectValid("file", {"file"});
+
+  ok &= ExpectInvalid("", ArchivePathError::Empty);
+  ok &= ExpectInvalid("/absolute", ArchivePathError::Absolute);
+  ok &= ExpectInvalid("folder\\file", ArchivePathError::Backslash);
+  const std::string embedded_nul{"folder\0file", 11};
+  ok &= ExpectInvalid(embedded_nul, ArchivePathError::Nul);
+  ok &= ExpectInvalid("folder//file", ArchivePathError::EmptyComponent);
+  ok &= ExpectInvalid("folder//", ArchivePathError::EmptyComponent);
+  ok &= ExpectInvalid("./file", ArchivePathError::DotComponent);
+  ok &= ExpectInvalid("folder/./file", ArchivePathError::DotComponent);
+  ok &= ExpectInvalid("../file", ArchivePathError::ParentComponent);
+  ok &= ExpectInvalid("folder/../file", ArchivePathError::ParentComponent);
+  ok &= ExpectInvalid("C:/file", ArchivePathError::Colon);
+  ok &= ExpectInvalid("folder/name:stream", ArchivePathError::Colon);
+
+  return ok ? 0 : 1;
+}

--- a/tests/test_kartpad_builder.py
+++ b/tests/test_kartpad_builder.py
@@ -105,6 +105,16 @@ class ProfileTests(unittest.TestCase):
             source,
         )
 
+    def test_retro_rewind_archive_path_policy_is_shared(self) -> None:
+        installer = (REPO / "apple/ios/KartPadRetroRewindInstaller.mm").read_text()
+        ios_patch = (REPO / "patches/wiicompiled-ios-discio-import.patch").read_text()
+        tvos_patch = (REPO / "patches/wiicompiled-tvos-runtime.patch").read_text()
+        shared_source = "runtime/src/retro_rewind/archive_path.cpp"
+        self.assertIn('"kartpad/retro_rewind/archive_path.h"', installer)
+        self.assertIn("ValidateArchiveMemberPath", installer)
+        self.assertIn(shared_source, ios_patch)
+        self.assertIn(shared_source, tvos_patch)
+
     def test_dual_mode_chooser_keeps_a_width_on_wide_ipads(self) -> None:
         source = (REPO / "apple/ios/KartPadRuntimeOverlayHost.mm").read_text()
         self.assertIn("self.contentWidthConstraint.constant", source)

--- a/tests/test_tvos_contract.py
+++ b/tests/test_tvos_contract.py
@@ -26,6 +26,7 @@ class TvOSContractTests(unittest.TestCase):
             patch.count("TARGET_OS_IOS || TARGET_OS_TV"), 16
         )
         self.assertIn("MINIZIP::minizip", patch)
+        self.assertIn("runtime/src/retro_rewind/archive_path.cpp", patch)
         self.assertIn("KARTPAD_TVOS_BUNDLE_IDENTIFIER", patch)
 
     def test_tvos_host_keeps_rebuildable_and_durable_state_separate(self):


### PR DESCRIPTION
## Summary

- extract Retro Rewind ZIP member-path validation into portable C++
- validate minizip filename byte spans before Apple UTF-8 decoding
- compile the shared source into iOS/tvOS product variants and add direct contract coverage

## Verification

- `kartpad.retro-rewind.archive-path`
- pinned NDK 29 API-28 ARM64 warning-as-error compile
- iOS Simulator SDK Objective-C++ warning-as-error syntax compile
- fresh dual-product WiiCompiled patch preparation
- `PYTHONPATH=builder python3 -m unittest -v tests.test_kartpad_builder tests.test_tvos_contract` (29 pass, 1 optional private-input skip)
- `./scripts/check-repo-safety.sh`
- `./scripts/verify-sunpad-overlay-snapshot.sh`

## Scope

This is an independent source-only A3 slice stacked on the open A2 branch. A2 remains open for physical-device acceptance, and A3 remains open for the Android installer, remaining validation/activation rules, fault recovery, and offline gameplay. A full Apple link stopped fail-closed before compilation because the local Dawn cache does not match its pinned SHA; the cache was not trusted or modified. No APK/AAB or private data was published.