### PR TITLE
Share Retro Rewind archive scan limits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,18 @@ if(BUILD_TESTING)
   add_test(NAME kartpad.retro-rewind.archive-path
     COMMAND kartpad_retro_rewind_archive_path_tests)
 
+  add_executable(kartpad_retro_rewind_archive_scan_tests
+    runtime/tests/retro_rewind_archive_scan_tests.cpp
+    runtime/src/retro_rewind/archive_path.cpp
+    runtime/src/retro_rewind/archive_scan.cpp)
+  target_include_directories(kartpad_retro_rewind_archive_scan_tests PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/runtime/include")
+  target_compile_features(kartpad_retro_rewind_archive_scan_tests PRIVATE cxx_std_20)
+  target_compile_options(kartpad_retro_rewind_archive_scan_tests PRIVATE
+    -Wall -Wextra -Wpedantic -Werror)
+  add_test(NAME kartpad.retro-rewind.archive-scan
+    COMMAND kartpad_retro_rewind_archive_scan_tests)
+
   add_executable(kartpad_mii_database_tests runtime/tests/mii_database_tests.cpp)
   target_include_directories(kartpad_mii_database_tests PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/runtime/include")

--- a/apple/ios/KartPadRetroRewindInstaller.mm
+++ b/apple/ios/KartPadRetroRewindInstaller.mm
@@ -4,6 +4,7 @@
 #import <TargetConditionals.h>
 
 #include "kartpad/retro_rewind/archive_path.h"
+#include "kartpad/retro_rewind/archive_scan.h"
 #include "kartpad_retro_rewind_release.h"
 #include "mz.h"
 #include "mz_strm.h"
@@ -103,6 +104,8 @@ NSString *KartPadSHA256ForLargeFile(NSString *path,
 NSArray<NSString *> *KartPadSafeArchiveComponents(const char *nameBytes,
                                                    size_t nameLength,
                                                    NSString **decodedName,
+                                                   kartpad::retro_rewind::ArchiveMemberPath
+                                                       *portablePath,
                                                    NSError **error) {
   const std::string_view bytes{nameBytes, nameLength};
   const kartpad::retro_rewind::ArchiveMemberPath validated =
@@ -117,6 +120,7 @@ NSArray<NSString *> *KartPadSafeArchiveComponents(const char *nameBytes,
     return nil;
   }
   if (decodedName != nullptr) *decodedName = name;
+  if (portablePath != nullptr) *portablePath = validated;
 
   NSMutableArray<NSString *> *parts =
       [NSMutableArray arrayWithCapacity:validated.components.size()];
@@ -329,8 +333,8 @@ BOOL KartPadFileMatches(NSString *path, uint64_t expectedBytes,
   }
 
   void *reader = nullptr;
-  uint64_t selectedBytes = 0;
-  NSUInteger selectedEntries = 0;
+  kartpad::retro_rewind::ArchiveScan archiveScan{
+      KARTPAD_RR_ROOT, 10000, KARTPAD_RR_MAXIMUM_EXPANDED_BYTES};
   if (workError == nil) {
     reader = mz_zip_reader_create();
     if (reader == nullptr ||
@@ -352,28 +356,27 @@ BOOL KartPadFileMatches(NSString *path, uint64_t expectedBytes,
       break;
     }
     NSString *name = nil;
+    kartpad::retro_rewind::ArchiveMemberPath portablePath;
     NSArray<NSString *> *parts = KartPadSafeArchiveComponents(
-        info->filename, info->filename_size, &name, &workError);
+        info->filename, info->filename_size, &name, &portablePath, &workError);
     if (parts == nil) break;
-    if (mz_zip_attrib_is_symlink(info->external_fa,
-                                 info->version_madeby) == MZ_OK ||
-        (info->flag & MZ_ZIP_FLAG_ENCRYPTED) != 0 ||
-        info->uncompressed_size < 0) {
+    const auto observation = archiveScan.Observe(
+        portablePath, info->uncompressed_size,
+        mz_zip_attrib_is_symlink(info->external_fa,
+                                 info->version_madeby) == MZ_OK,
+        (info->flag & MZ_ZIP_FLAG_ENCRYPTED) != 0);
+    if (!observation &&
+        observation.error ==
+            kartpad::retro_rewind::ArchiveScanError::UnsupportedEntry) {
       workError = KartPadRetroRewindError(25,
           [NSString stringWithFormat:@"The ZIP contains an unsupported entry: %@",
                                      name]);
       break;
     }
-    if ([parts.firstObject isEqualToString:
-            [NSString stringWithUTF8String:KARTPAD_RR_ROOT]]) {
-      selectedEntries += 1;
-      selectedBytes += (uint64_t)info->uncompressed_size;
-      if (selectedEntries > 10000 ||
-          selectedBytes > KARTPAD_RR_MAXIMUM_EXPANDED_BYTES) {
-        workError = KartPadRetroRewindError(26,
-            @"The ZIP expands beyond this build's safety limits.");
-        break;
-      }
+    if (!observation) {
+      workError = KartPadRetroRewindError(26,
+          @"The ZIP expands beyond this build's safety limits.");
+      break;
     }
     status = mz_zip_reader_goto_next_entry(reader);
   }
@@ -381,7 +384,7 @@ BOOL KartPadFileMatches(NSString *path, uint64_t expectedBytes,
     workError = KartPadRetroRewindError(27,
                                         @"The ZIP directory could not be read.");
   }
-  if (workError == nil && selectedEntries == 0) {
+  if (workError == nil && archiveScan.selected_entries() == 0) {
     workError = KartPadRetroRewindError(28,
         [NSString stringWithFormat:@"The ZIP does not contain %@.",
             [NSString stringWithUTF8String:KARTPAD_RR_ROOT]]);
@@ -399,7 +402,7 @@ BOOL KartPadFileMatches(NSString *path, uint64_t expectedBytes,
     }
     NSString *name = nil;
     NSArray<NSString *> *parts = KartPadSafeArchiveComponents(
-        info->filename, info->filename_size, &name, &workError);
+        info->filename, info->filename_size, &name, nullptr, &workError);
     if (parts == nil) break;
     if ([parts.firstObject isEqualToString:
             [NSString stringWithUTF8String:KARTPAD_RR_ROOT]]) {
@@ -441,9 +444,10 @@ BOOL KartPadFileMatches(NSString *path, uint64_t expectedBytes,
         }
       }
       extractedBytes += (uint64_t)info->uncompressed_size;
-      if (progress != nil && selectedBytes > 0) {
+      if (progress != nil && archiveScan.selected_bytes() > 0) {
         const double fraction =
-            0.18 + 0.77 * ((double)extractedBytes / (double)selectedBytes);
+            0.18 + 0.77 * ((double)extractedBytes /
+                           (double)archiveScan.selected_bytes());
         const int percent = (int)(fraction * 100.0);
         if (percent != lastExtractionPercent) {
           lastExtractionPercent = percent;

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -42,6 +42,14 @@ and fresh Apple patch preparation succeeds. Android download,
 storage, extraction, activation, rollback, and gameplay remain unimplemented;
 this does not pass A3 or change A2's status.
 
+The next source-only slice adds `ArchiveScan` beside that validator and wires
+the Apple installer through it. The portable scan rejects invalid paths,
+symlinks, encryption, negative sizes, excess selected entries, excess expanded
+bytes, and unsigned-total overflow while selecting only the exact pinned root.
+Its host and NDK contracts pass. Duplicate detection, content hashes, atomic
+installation/recovery, and the Android platform owner remain subsequent A3
+work.
+
 KartPad can be ported to Android without changing its defining architecture.
 The Android build should contain the same ahead-of-time translated Original
 Mario Kart Wii and Retro Rewind profiles as the Apple `KartPadDual` product,

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -159,6 +159,12 @@ not block offline Retro Rewind support.
    installer rules and thin Android owner only when they are immediately
    consumed and tested. Evidence:
    `docs/artifacts/2026-09-04/android/a3-shared-archive-path.md`.
+   A second stacked slice adds a portable stateful archive scan now consumed by
+   Apple for symlink/encryption/negative-size rejection, exact-root selection,
+   entry and expansion caps, overflow-safe totals, and progress accounting.
+   Host, pinned NDK ARM64, Apple SDK, fresh patch preparation, and source
+   contracts pass. Evidence:
+   `docs/artifacts/2026-09-04/android/a3-shared-archive-scan.md`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2181,3 +2181,27 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   complete emulator/physical offline acceptance. No APK/AAB or private input
   was published. Evidence:
   `docs/artifacts/2026-09-04/android/a3-shared-archive-path.md`.
+
+## 2026-09-04 — Android A3 shared archive scan
+
+- Selected the next independent source-only A3 rule set while A2 remains open
+  for unavailable physical Android hardware.
+- Added a portable stateful archive scan for globally unsupported entry types,
+  exact-root selection, maximum selected entries, and maximum expanded bytes.
+  Checked-before-add accounting closes the Apple loop's theoretical unsigned
+  total wrap; the first error latches so callers cannot resume a failed scan.
+- Wired the Apple installer's preflight and extraction progress totals through
+  the shared scan without changing the pinned root or public limits. iOS/tvOS
+  and Original/Retro/dual product graphs all include the new implementation.
+- Both direct archive contracts pass. Pinned NDK API-28 ARM64 and Apple SDK
+  warning-as-error compiles, a fresh dual-product patch preparation, 29
+  builder/tvOS contracts, repository safety, the SunPad snapshot, and diff
+  checks pass. One optional private-payload test remains skipped because the
+  input is not cached.
+- The full Apple link remains unavailable at the previously recorded
+  fail-closed local Dawn cache hash mismatch; no pin or cache was weakened.
+- Classification: **Pass for the shared archive scan and immediate Apple
+  consumer.** A2 remains open, and A3 remains incomplete for duplicate entries,
+  content verification, Android ownership, fault recovery, and offline runtime
+  acceptance. No APK/AAB or private input was published. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-shared-archive-scan.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -249,6 +249,17 @@ Android installer or A3 acceptance result. A2 remains the lowest incomplete
 goal and A3 remains open. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-shared-archive-path.md`](artifacts/2026-09-04/android/a3-shared-archive-path.md).
 
+The next shared A3 slice moves ZIP entry policy into a portable stateful scan.
+The Apple installer now uses it to reject symlinks, encryption, negative sizes,
+invalid paths, excess entries, excess expansion, and 64-bit total overflow;
+safe foreign-root entries remain ignored and selected totals drive extraction
+progress. Direct host tests, pinned NDK ARM64 warning-as-error compiles, Apple
+SDK syntax compilation, fresh dual-product patch preparation, repository
+safety, and Apple contracts pass. This still is not an Android installer or A3
+runtime proof, and the full Apple link remains blocked before configuration by
+the already recorded local Dawn cache hash mismatch. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-shared-archive-scan.md`](artifacts/2026-09-04/android/a3-shared-archive-scan.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-04/android/a3-shared-archive-scan.md
+++ b/docs/artifacts/2026-09-04/android/a3-shared-archive-scan.md
@@ -1,0 +1,67 @@
+# Android A3 shared archive-scan contract
+
+Date: 2026-09-04
+
+Branch: `codex/android-a3-archive-entry-core`
+
+Baseline: `a768ea26522be9b365a3b90e5510f0b521416106`
+
+## Falsifiable subgoal
+
+Move the existing Retro Rewind ZIP entry-selection and expansion-limit policy
+into portable C++ consumed by the Apple installer, without changing the
+official root, entry cap, expanded-byte cap, or unsupported-entry behavior.
+
+## Result
+
+- Added a stateful `kartpad::retro_rewind::ArchiveScan` that rejects an invalid
+  path, symlink, encrypted entry, or negative uncompressed size before root
+  selection.
+- Safe entries outside the exact expected root are ignored without affecting
+  selected totals, matching the existing Apple behavior.
+- Selected entries are bounded by the caller's exact entry and expanded-byte
+  limits. Addition is checked before mutation, so a malicious directory cannot
+  wrap the 64-bit byte total.
+- The first error is latched, preventing a caller from continuing a scan after
+  a fail-closed result.
+- The iOS/tvOS installer now obtains its selected entry and byte totals from the
+  shared scan and uses the latter for extraction progress. Its existing error
+  categories and `RetroRewind6.12.5` profile authority remain unchanged.
+
+Source SHA-256 values:
+
+- header: `180c46133e94f8c70836619aec0d7320541bba20baa057f20b741ac00b244a3a`
+- implementation: `e6f69a8197bf9bcc9c194e9d29d0869fb5f3b5e6c4dc09523d37fa4337936792`
+- test: `324b37120382526274b335247fe4d6bef312c6ff5eecf076d9fbe1bb5c736460`
+
+## Verification
+
+- `kartpad.retro-rewind.archive-path` and
+  `kartpad.retro-rewind.archive-scan`: pass.
+- The scan test covers foreign-root ignore, exact-limit acceptance, entry-limit
+  rejection, expanded-size rejection, unsigned-addition overflow, symlink,
+  encryption, negative size, invalid path, counters, and error latching.
+- Pinned NDK 29 API-28 ARM64 warning-as-error compiles for both shared source
+  files: pass; each output is an AArch64 ELF relocatable object.
+- iOS Simulator SDK-targeted warning-as-error syntax compile of the updated
+  Objective-C++ installer: pass with its established omitted-operand extension
+  explicitly allowed.
+- Fresh integrated WiiCompiled source preparation for the dual Apple product:
+  pass; both shared sources appear in `PublicProducts.cmake`.
+- Builder/tvOS contracts: 29 pass and one optional private-payload test skips
+  because that input is not cached.
+- Repository safety, SunPad snapshot, and diff checks: pass.
+
+The full Apple link remains unavailable because the local Dawn cache mismatch
+recorded in `a3-shared-archive-path.md` occurs before configuration. The
+fail-closed dependency check remains unchanged.
+
+## Classification
+
+**Pass for shared unsupported-entry, exact-root selection, bounded-count, and
+overflow-safe expanded-byte policy with an immediate Apple consumer.** This is
+not an Android installer or A3 runtime result. A2 remains open for physical
+Android acceptance. A3 remains open for duplicate-entry handling, byte/hash and
+payload validation, Android download/storage/extraction/activation/recovery,
+and the complete emulator/physical offline gameplay matrix. No APK/AAB,
+archive, game data, save, device identifier, or private log was published.

--- a/patches/wiicompiled-ios-discio-import.patch
+++ b/patches/wiicompiled-ios-discio-import.patch
@@ -1,6 +1,6 @@
 --- a/cmake/PublicProducts.cmake
 +++ b/cmake/PublicProducts.cmake
-@@ -271,16 +271,56 @@
+@@ -271,16 +271,57 @@
  
  set(MKW_KARTPAD_REPO_ROOT "" CACHE PATH
      "KartPad repository root used to embed the exact mobile UIKit host")
@@ -54,10 +54,11 @@
 +        "${MKW_KARTPAD_IOS_DIR}/KartPadDiscFormats.cpp"
 +        "${MKW_KARTPAD_IOS_DIR}/KartPadRetroRewindInstaller.mm"
 +        "${MKW_KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_path.cpp"
++        "${MKW_KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_scan.cpp"
          "${MKW_KARTPAD_MOBILE_DIR}/KartPadClassicInput.mm"
          "${MKW_KARTPAD_MOBILE_DIR}/KartPadPhysicalControllers.mm"
          "${MKW_KARTPAD_MOBILE_DIR}/KartPadMotionSteering.mm"
-@@ -306,20 +347,34 @@
+@@ -306,20 +348,34 @@
          "${MKW_KARTPAD_IOS_DIR}"
          "${MKW_KARTPAD_MOBILE_DIR}"
          "${MKW_KARTPAD_SHARED_DIR}"

--- a/patches/wiicompiled-tvos-runtime.patch
+++ b/patches/wiicompiled-tvos-runtime.patch
@@ -36,7 +36,7 @@
          _DISABLE_STRING_ANNOTATION _DISABLE_VECTOR_ANNOTATION TARGET_PC)
      target_compile_features(${target} PRIVATE cxx_std_20)
      mkw_apply_common_compile_options(${target})
-@@ -390,7 +390,105 @@
+@@ -390,7 +390,106 @@
          XCODE_ATTRIBUTE_SUPPORTS_MACCATALYST NO
          XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2")
  endif()
@@ -85,6 +85,7 @@
 +        "${MKW_KARTPAD_TVOS_DIR}/KartPadTVRuntimeHost.mm"
 +        "${MKW_KARTPAD_IOS_DIR}/KartPadRetroRewindInstaller.mm"
 +        "${MKW_KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_path.cpp"
++        "${MKW_KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_scan.cpp"
 +        "${MKW_KARTPAD_MOBILE_DIR}/KartPadClassicInput.mm"
 +        "${MKW_KARTPAD_MOBILE_DIR}/KartPadPhysicalControllers.mm"
 +        "${MKW_KARTPAD_SUNPAD_DIR}/SunPadControllerMapping.mm"
@@ -142,7 +143,7 @@
  if(MKW_HAVE_RETRO_REWIND)
      add_executable(RetroRewind "${MKW_RETRO_REWIND_PRODUCT_SOURCE}" ${MKW_RETRO_REGISTRATION_SOURCES})
      mkw_configure_product(RetroRewind)
-@@ -455,6 +545,10 @@
+@@ -455,6 +546,10 @@
              XCODE_ATTRIBUTE_SUPPORTS_MACCATALYST NO
              XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2")
      endif()
@@ -153,7 +154,7 @@
      add_custom_target(mkw_release DEPENDS WiiCompiled RetroRewind)
  else()
      add_custom_target(mkw_release DEPENDS WiiCompiled)
-@@ -529,6 +623,10 @@
+@@ -529,6 +624,10 @@
              XCODE_ATTRIBUTE_SUPPORTS_MACCATALYST NO
              XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2")
      endif()

--- a/runtime/include/kartpad/retro_rewind/archive_scan.h
+++ b/runtime/include/kartpad/retro_rewind/archive_scan.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "kartpad/retro_rewind/archive_path.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace kartpad::retro_rewind {
+
+enum class ArchiveScanError {
+  None,
+  InvalidPath,
+  UnsupportedEntry,
+  EntryLimit,
+  ExpandedSizeLimit,
+};
+
+struct ArchiveScanObservation {
+  ArchiveScanError error = ArchiveScanError::None;
+  bool selected = false;
+
+  explicit operator bool() const { return error == ArchiveScanError::None; }
+};
+
+class ArchiveScan {
+ public:
+  ArchiveScan(std::string expected_root, std::size_t maximum_entries,
+              std::uint64_t maximum_expanded_bytes);
+
+  ArchiveScanObservation Observe(const ArchiveMemberPath& path,
+                                 std::int64_t uncompressed_size,
+                                 bool symlink, bool encrypted);
+
+  std::size_t selected_entries() const { return selected_entries_; }
+  std::uint64_t selected_bytes() const { return selected_bytes_; }
+  ArchiveScanError error() const { return error_; }
+
+ private:
+  ArchiveScanObservation Fail(ArchiveScanError error);
+
+  std::string expected_root_;
+  std::size_t maximum_entries_ = 0;
+  std::uint64_t maximum_expanded_bytes_ = 0;
+  std::size_t selected_entries_ = 0;
+  std::uint64_t selected_bytes_ = 0;
+  ArchiveScanError error_ = ArchiveScanError::None;
+};
+
+}  // namespace kartpad::retro_rewind

--- a/runtime/src/retro_rewind/archive_scan.cpp
+++ b/runtime/src/retro_rewind/archive_scan.cpp
@@ -1,0 +1,49 @@
+#include "kartpad/retro_rewind/archive_scan.h"
+
+#include <utility>
+
+namespace kartpad::retro_rewind {
+
+ArchiveScan::ArchiveScan(std::string expected_root,
+                         const std::size_t maximum_entries,
+                         const std::uint64_t maximum_expanded_bytes)
+    : expected_root_(std::move(expected_root)),
+      maximum_entries_(maximum_entries),
+      maximum_expanded_bytes_(maximum_expanded_bytes) {}
+
+ArchiveScanObservation ArchiveScan::Fail(const ArchiveScanError error) {
+  error_ = error;
+  return {.error = error, .selected = false};
+}
+
+ArchiveScanObservation ArchiveScan::Observe(
+    const ArchiveMemberPath& path, const std::int64_t uncompressed_size,
+    const bool symlink, const bool encrypted) {
+  if (error_ != ArchiveScanError::None) {
+    return {.error = error_, .selected = false};
+  }
+  if (!path || path.components.empty()) {
+    return Fail(ArchiveScanError::InvalidPath);
+  }
+  if (symlink || encrypted || uncompressed_size < 0) {
+    return Fail(ArchiveScanError::UnsupportedEntry);
+  }
+  if (path.components.front() != expected_root_) {
+    return {};
+  }
+  if (selected_entries_ >= maximum_entries_) {
+    return Fail(ArchiveScanError::EntryLimit);
+  }
+
+  const auto entry_bytes = static_cast<std::uint64_t>(uncompressed_size);
+  if (selected_bytes_ > maximum_expanded_bytes_ ||
+      entry_bytes > maximum_expanded_bytes_ - selected_bytes_) {
+    return Fail(ArchiveScanError::ExpandedSizeLimit);
+  }
+
+  ++selected_entries_;
+  selected_bytes_ += entry_bytes;
+  return {.error = ArchiveScanError::None, .selected = true};
+}
+
+}  // namespace kartpad::retro_rewind

--- a/runtime/tests/retro_rewind_archive_scan_tests.cpp
+++ b/runtime/tests/retro_rewind_archive_scan_tests.cpp
@@ -1,0 +1,101 @@
+#include "kartpad/retro_rewind/archive_scan.h"
+
+#include <cstdint>
+#include <iostream>
+#include <limits>
+
+namespace {
+
+using kartpad::retro_rewind::ArchiveScan;
+using kartpad::retro_rewind::ArchiveScanError;
+using kartpad::retro_rewind::ValidateArchiveMemberPath;
+
+bool Expect(const bool condition, const char* message) {
+  if (!condition) {
+    std::cerr << message << '\n';
+  }
+  return condition;
+}
+
+}  // namespace
+
+int main() {
+  bool ok = true;
+
+  ArchiveScan scan{"RetroRewind6.12.5", 3, 100};
+  const auto ignored =
+      scan.Observe(ValidateArchiveMemberPath("Other/file"), 90, false, false);
+  ok &= Expect(ignored && !ignored.selected, "safe foreign entry was not ignored");
+  ok &= Expect(scan.selected_entries() == 0 && scan.selected_bytes() == 0,
+               "ignored entry changed selected totals");
+
+  const auto root = scan.Observe(
+      ValidateArchiveMemberPath("RetroRewind6.12.5/"), 0, false, false);
+  const auto first = scan.Observe(
+      ValidateArchiveMemberPath("RetroRewind6.12.5/a"), 40, false, false);
+  const auto second = scan.Observe(
+      ValidateArchiveMemberPath("RetroRewind6.12.5/b"), 60, false, false);
+  ok &= Expect(root && root.selected && first && first.selected && second &&
+                   second.selected,
+               "selected entries were not accepted");
+  ok &= Expect(scan.selected_entries() == 3 && scan.selected_bytes() == 100,
+               "selected totals are incorrect");
+  const auto count_limit = scan.Observe(
+      ValidateArchiveMemberPath("RetroRewind6.12.5/c"), 0, false, false);
+  ok &= Expect(!count_limit && count_limit.error == ArchiveScanError::EntryLimit,
+               "entry limit did not fail closed");
+  const auto latched = scan.Observe(ValidateArchiveMemberPath("Other/safe"), 0,
+                                    false, false);
+  ok &= Expect(!latched && latched.error == ArchiveScanError::EntryLimit,
+               "scan error was not latched");
+
+  ArchiveScan size_scan{"RetroRewind6.12.5", 10, 99};
+  const auto size_limit = size_scan.Observe(
+      ValidateArchiveMemberPath("RetroRewind6.12.5/file"), 100, false, false);
+  ok &= Expect(!size_limit &&
+                   size_limit.error == ArchiveScanError::ExpandedSizeLimit,
+               "expanded-size limit did not fail closed");
+
+  ArchiveScan overflow_scan{"RetroRewind6.12.5", 10,
+                            std::numeric_limits<std::uint64_t>::max()};
+  const auto large = overflow_scan.Observe(
+      ValidateArchiveMemberPath("RetroRewind6.12.5/a"),
+      std::numeric_limits<std::int64_t>::max(), false, false);
+  const auto overflow = overflow_scan.Observe(
+      ValidateArchiveMemberPath("RetroRewind6.12.5/b"),
+      std::numeric_limits<std::int64_t>::max(), false, false);
+  ok &= Expect(large && overflow,
+               "valid signed archive sizes should not overflow uint64 totals");
+  const auto overflow_limit = overflow_scan.Observe(
+      ValidateArchiveMemberPath("RetroRewind6.12.5/c"), 2, false, false);
+  ok &= Expect(!overflow_limit &&
+                   overflow_limit.error == ArchiveScanError::ExpandedSizeLimit,
+               "uint64 expanded-size overflow was not rejected");
+
+  struct UnsupportedCase {
+    std::int64_t size;
+    bool symlink;
+    bool encrypted;
+  };
+  for (const UnsupportedCase test_case : {
+           UnsupportedCase{1, true, false},
+           UnsupportedCase{1, false, true},
+           UnsupportedCase{-1, false, false},
+       }) {
+    ArchiveScan unsupported{"RetroRewind6.12.5", 10, 100};
+    const auto result = unsupported.Observe(
+        ValidateArchiveMemberPath("Other/file"), test_case.size,
+        test_case.symlink, test_case.encrypted);
+    ok &= Expect(!result && result.error == ArchiveScanError::UnsupportedEntry,
+                 "unsupported entry was accepted");
+  }
+
+  ArchiveScan invalid{"RetroRewind6.12.5", 10, 100};
+  const auto invalid_result = invalid.Observe(
+      ValidateArchiveMemberPath("../file"), 1, false, false);
+  ok &= Expect(!invalid_result &&
+                   invalid_result.error == ArchiveScanError::InvalidPath,
+               "invalid path was accepted by scan");
+
+  return ok ? 0 : 1;
+}

--- a/tests/test_kartpad_builder.py
+++ b/tests/test_kartpad_builder.py
@@ -109,11 +109,17 @@ class ProfileTests(unittest.TestCase):
         installer = (REPO / "apple/ios/KartPadRetroRewindInstaller.mm").read_text()
         ios_patch = (REPO / "patches/wiicompiled-ios-discio-import.patch").read_text()
         tvos_patch = (REPO / "patches/wiicompiled-tvos-runtime.patch").read_text()
-        shared_source = "runtime/src/retro_rewind/archive_path.cpp"
+        shared_sources = (
+            "runtime/src/retro_rewind/archive_path.cpp",
+            "runtime/src/retro_rewind/archive_scan.cpp",
+        )
         self.assertIn('"kartpad/retro_rewind/archive_path.h"', installer)
+        self.assertIn('"kartpad/retro_rewind/archive_scan.h"', installer)
         self.assertIn("ValidateArchiveMemberPath", installer)
-        self.assertIn(shared_source, ios_patch)
-        self.assertIn(shared_source, tvos_patch)
+        self.assertIn("ArchiveScan", installer)
+        for shared_source in shared_sources:
+            self.assertIn(shared_source, ios_patch)
+            self.assertIn(shared_source, tvos_patch)
 
     def test_dual_mode_chooser_keeps_a_width_on_wide_ipads(self) -> None:
         source = (REPO / "apple/ios/KartPadRuntimeOverlayHost.mm").read_text()

--- a/tests/test_tvos_contract.py
+++ b/tests/test_tvos_contract.py
@@ -27,6 +27,7 @@ class TvOSContractTests(unittest.TestCase):
         )
         self.assertIn("MINIZIP::minizip", patch)
         self.assertIn("runtime/src/retro_rewind/archive_path.cpp", patch)
+        self.assertIn("runtime/src/retro_rewind/archive_scan.cpp", patch)
         self.assertIn("KARTPAD_TVOS_BUNDLE_IDENTIFIER", patch)
 
     def test_tvos_host_keeps_rebuildable_and_durable_state_separate(self):


### PR DESCRIPTION
## Summary

- add a portable stateful archive scan for unsupported entry types and exact-root selection
- enforce selected-entry and expanded-byte limits with overflow-safe accounting
- use shared scan totals in the existing Apple installer and compile it in every Apple product variant

## Verification

- `kartpad.retro-rewind.archive-path` and `kartpad.retro-rewind.archive-scan`
- pinned NDK 29 API-28 ARM64 warning-as-error compiles
- iOS Simulator SDK Objective-C++ warning-as-error syntax compile
- fresh dual-product WiiCompiled patch preparation with both shared sources
- 29 builder/tvOS contracts pass; one optional private-input test skips
- repository safety, SunPad snapshot, and diff checks pass

## Scope

This source-only A3 slice is stacked on #43. A2 remains open for physical-device acceptance; A3 remains open for duplicate handling, content validation, the Android installer/worker, recovery, and offline emulator/physical gameplay. The full Apple link remains unavailable at the already recorded fail-closed local Dawn cache hash mismatch. No pin was weakened and no APK/AAB or private data was published.