### PR TITLE
Reject duplicate Retro Rewind archive entries

### DIFF
--- a/apple/ios/KartPadRetroRewindInstaller.mm
+++ b/apple/ios/KartPadRetroRewindInstaller.mm
@@ -365,17 +365,20 @@ BOOL KartPadFileMatches(NSString *path, uint64_t expectedBytes,
         mz_zip_attrib_is_symlink(info->external_fa,
                                  info->version_madeby) == MZ_OK,
         (info->flag & MZ_ZIP_FLAG_ENCRYPTED) != 0);
-    if (!observation &&
-        observation.error ==
-            kartpad::retro_rewind::ArchiveScanError::UnsupportedEntry) {
-      workError = KartPadRetroRewindError(25,
-          [NSString stringWithFormat:@"The ZIP contains an unsupported entry: %@",
-                                     name]);
-      break;
-    }
     if (!observation) {
-      workError = KartPadRetroRewindError(26,
-          @"The ZIP expands beyond this build's safety limits.");
+      if (observation.error ==
+          kartpad::retro_rewind::ArchiveScanError::UnsupportedEntry) {
+        workError = KartPadRetroRewindError(25,
+            [NSString stringWithFormat:
+                @"The ZIP contains an unsupported entry: %@", name]);
+      } else if (observation.error ==
+                 kartpad::retro_rewind::ArchiveScanError::DuplicateEntry) {
+        workError = KartPadRetroRewindError(31,
+                                            @"The ZIP contains duplicate files.");
+      } else {
+        workError = KartPadRetroRewindError(26,
+            @"The ZIP expands beyond this build's safety limits.");
+      }
       break;
     }
     status = mz_zip_reader_goto_next_entry(reader);

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -50,6 +50,12 @@ Its host and NDK contracts pass. Duplicate detection, content hashes, atomic
 installation/recovery, and the Android platform owner remain subsequent A3
 work.
 
+Duplicate selected entry paths are now rejected in that same portable scan
+before staging is mutated. The key is built from validated components, so a
+file/directory trailing-slash alias cannot target one output twice; ignored
+foreign-root duplicates remain outside the selected policy. The existing Apple
+filesystem check remains a second line of defense.
+
 KartPad can be ported to Android without changing its defining architecture.
 The Android build should contain the same ahead-of-time translated Original
 Mario Kart Wii and Retro Rewind profiles as the Apple `KartPadDual` product,

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -165,6 +165,11 @@ not block offline Retro Rewind support.
    Host, pinned NDK ARM64, Apple SDK, fresh patch preparation, and source
    contracts pass. Evidence:
    `docs/artifacts/2026-09-04/android/a3-shared-archive-scan.md`.
+   A third stacked slice rejects duplicate selected component paths during the
+   portable scan, before extraction, while retaining the Apple filesystem check
+   as defense in depth. Host, NDK, Apple SDK, safety, and contract tests pass.
+   Evidence:
+   `docs/artifacts/2026-09-04/android/a3-shared-archive-duplicates.md`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2205,3 +2205,19 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   content verification, Android ownership, fault recovery, and offline runtime
   acceptance. No APK/AAB or private input was published. Evidence:
   `docs/artifacts/2026-09-04/android/a3-shared-archive-scan.md`.
+
+## 2026-09-04 — Android A3 shared duplicate-entry rejection
+
+- Extended the portable archive scan to reject a repeated selected component
+  path before extraction. A file and directory spelling that differ only by a
+  trailing slash intentionally collide; foreign-root duplicates remain ignored.
+- Duplicate failure occurs before counters mutate and latches the scan. The
+  existing Apple filesystem existence check remains defense in depth against a
+  changed second pass or staging interference.
+- Both direct archive contracts, pinned NDK API-28 ARM64 and Apple SDK
+  warning-as-error compiles, builder/tvOS contracts, repository safety, the
+  SunPad snapshot, and diff checks pass.
+- Classification: **Pass for shared pre-extraction duplicate rejection and its
+  Apple consumer.** A2 and A3 remain open at their previously documented gates.
+  No APK/AAB or private input was published. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-shared-archive-duplicates.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -260,6 +260,15 @@ runtime proof, and the full Apple link remains blocked before configuration by
 the already recorded local Dawn cache hash mismatch. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-shared-archive-scan.md`](artifacts/2026-09-04/android/a3-shared-archive-scan.md).
 
+The shared scan now also rejects duplicate selected paths before extraction,
+including file/directory spellings that resolve to the same component sequence.
+Duplicate failure leaves selected totals unchanged and latches the scan;
+foreign-root duplicates remain ignored. Host contracts, the pinned NDK ARM64
+compile, Apple SDK syntax compilation, repository safety, and Apple contracts
+pass. The extraction-time filesystem check remains defense in depth. This
+closes only the shared duplicate-directory rule, not A3. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-shared-archive-duplicates.md`](artifacts/2026-09-04/android/a3-shared-archive-duplicates.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-04/android/a3-shared-archive-duplicates.md
+++ b/docs/artifacts/2026-09-04/android/a3-shared-archive-duplicates.md
@@ -1,0 +1,57 @@
+# Android A3 shared archive duplicate rejection
+
+Date: 2026-09-04
+
+Branch: `codex/android-a3-archive-duplicate-core`
+
+Baseline: `f45332fc8f9961a08cace8db8a9d4a62549c6937`
+
+## Falsifiable subgoal
+
+Reject duplicate entries under the selected Retro Rewind root during the
+portable directory scan, before extraction mutates staging storage, while
+retaining the existing rule that entries outside the selected root are ignored.
+
+## Result
+
+- `ArchiveScan` now keys selected entries by their validated path components.
+  A trailing directory marker is not part of the key, so `content` and
+  `content/` collide rather than aliasing one output path.
+- Duplicate rejection occurs before selected counters mutate and latches the
+  scan in a failed state.
+- Repeated safe entries outside the expected root remain ignored and do not
+  consume selected-entry or expanded-byte limits.
+- The Apple wrapper maps the portable duplicate result to its established
+  duplicate-file error and retains the extraction-time filesystem existence
+  check as defense in depth.
+
+Updated scan SHA-256 values:
+
+- header: `b140604c4ceaf60b4cf6262095957347b50316423c77bfdf4501b2dfad01da48`
+- implementation: `33fb4fd78adf7d1fd9f4190bb19bffa9f671fe97264f1086d6f212e144d9188a`
+- test: `8e7f7b130f9bfaf86a590df693502f094cb4e80aa99cf010dec6690d05c64c1d`
+
+## Verification
+
+- `kartpad.retro-rewind.archive-path` and
+  `kartpad.retro-rewind.archive-scan`: pass.
+- The scan matrix proves file/directory spelling aliases collide, duplicate
+  failure leaves totals unchanged, and foreign-root duplicates remain ignored.
+- Pinned NDK 29 API-28 ARM64 warning-as-error compile: pass.
+- iOS Simulator SDK-targeted warning-as-error installer syntax compile: pass
+  with the file's established omitted-operand extension explicitly allowed.
+- Builder/tvOS contracts, repository safety, SunPad snapshot, and diff checks:
+  pass.
+
+The full Apple link remains unavailable at the fail-closed local Dawn cache
+hash mismatch recorded by the first shared A3 slice; no dependency pin or
+integrity check was changed.
+
+## Classification
+
+**Pass for pre-extraction duplicate rejection in the shared scan and its Apple
+consumer.** This does not prove an Android installer or A3 gameplay. A2 remains
+open for physical Android acceptance. A3 remains open for byte/hash and payload
+validation, Android download/storage/extraction/activation/recovery, failure
+injection, and the complete emulator/physical offline gameplay matrix. No
+APK/AAB, archive, game data, save, identifier, or private log was published.

--- a/runtime/include/kartpad/retro_rewind/archive_scan.h
+++ b/runtime/include/kartpad/retro_rewind/archive_scan.h
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <string>
+#include <unordered_set>
 
 namespace kartpad::retro_rewind {
 
@@ -12,6 +13,7 @@ enum class ArchiveScanError {
   None,
   InvalidPath,
   UnsupportedEntry,
+  DuplicateEntry,
   EntryLimit,
   ExpandedSizeLimit,
 };
@@ -44,6 +46,7 @@ class ArchiveScan {
   std::uint64_t maximum_expanded_bytes_ = 0;
   std::size_t selected_entries_ = 0;
   std::uint64_t selected_bytes_ = 0;
+  std::unordered_set<std::string> selected_paths_;
   ArchiveScanError error_ = ArchiveScanError::None;
 };
 

--- a/runtime/src/retro_rewind/archive_scan.cpp
+++ b/runtime/src/retro_rewind/archive_scan.cpp
@@ -41,6 +41,17 @@ ArchiveScanObservation ArchiveScan::Observe(
     return Fail(ArchiveScanError::ExpandedSizeLimit);
   }
 
+  std::string path_key;
+  for (const std::string& component : path.components) {
+    if (!path_key.empty()) {
+      path_key.push_back('/');
+    }
+    path_key.append(component);
+  }
+  if (!selected_paths_.insert(std::move(path_key)).second) {
+    return Fail(ArchiveScanError::DuplicateEntry);
+  }
+
   ++selected_entries_;
   selected_bytes_ += entry_bytes;
   return {.error = ArchiveScanError::None, .selected = true};

--- a/runtime/tests/retro_rewind_archive_scan_tests.cpp
+++ b/runtime/tests/retro_rewind_archive_scan_tests.cpp
@@ -56,6 +56,30 @@ int main() {
                    size_limit.error == ArchiveScanError::ExpandedSizeLimit,
                "expanded-size limit did not fail closed");
 
+  ArchiveScan duplicate_scan{"RetroRewind6.12.5", 10, 100};
+  const auto directory = duplicate_scan.Observe(
+      ValidateArchiveMemberPath("RetroRewind6.12.5/content/"), 0, false,
+      false);
+  const auto duplicate = duplicate_scan.Observe(
+      ValidateArchiveMemberPath("RetroRewind6.12.5/content"), 1, false,
+      false);
+  ok &= Expect(directory && directory.selected && !duplicate &&
+                   duplicate.error == ArchiveScanError::DuplicateEntry,
+               "duplicate selected entry was accepted");
+  ok &= Expect(duplicate_scan.selected_entries() == 1 &&
+                   duplicate_scan.selected_bytes() == 0,
+               "duplicate entry changed selected totals");
+
+  ArchiveScan foreign_duplicate_scan{"RetroRewind6.12.5", 10, 100};
+  const auto foreign_path = ValidateArchiveMemberPath("Other/content");
+  const auto foreign_first =
+      foreign_duplicate_scan.Observe(foreign_path, 1, false, false);
+  const auto foreign_second =
+      foreign_duplicate_scan.Observe(foreign_path, 1, false, false);
+  ok &= Expect(foreign_first && !foreign_first.selected && foreign_second &&
+                   !foreign_second.selected,
+               "foreign-root duplicate should remain ignored");
+
   ArchiveScan overflow_scan{"RetroRewind6.12.5", 10,
                             std::numeric_limits<std::uint64_t>::max()};
   const auto large = overflow_scan.Observe(


### PR DESCRIPTION
## Summary

- reject duplicate selected component paths during the portable archive scan
- treat trailing-slash file/directory aliases as one output path
- preserve foreign-root ignore behavior and the Apple extraction-time filesystem check as defense in depth

## Verification

- shared archive path/scan CTest matrix
- pinned NDK 29 API-28 ARM64 warning-as-error compile
- iOS Simulator SDK Objective-C++ warning-as-error syntax compile
- 29 builder/tvOS contracts pass; one optional private-input test skips
- repository safety, SunPad snapshot, and diff checks pass

## Scope

This source-only A3 slice is stacked on #44. A2 remains open for physical-device acceptance, and A3 remains open for content verification, Android ownership, recovery, and offline emulator/physical gameplay. The full Apple link remains unavailable at the already recorded fail-closed local Dawn cache mismatch. No APK/AAB or private data was published.