### PR TITLE
Add Android Retro Rewind install recovery

### DIFF
--- a/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
@@ -14,6 +14,7 @@ class KartPadActivity : SDLActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         if (BuildConfig.GAME_RUNTIME) {
+            RetroRewindInstallStorage.recover(filesDir)
             KartPadRuntimeResources.install(this)
             Os.setenv("KARTPAD_ANDROID_FILES_DIR", filesDir.absolutePath, true)
             Os.setenv("KARTPAD_ANDROID_CACHE_DIR", cacheDir.absolutePath, true)

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallStorage.java
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallStorage.java
@@ -1,0 +1,167 @@
+package dev.kartpad.android;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/** Owns same-volume Retro Rewind staging, activation, rollback, and recovery. */
+final class RetroRewindInstallStorage {
+    private static final String SUPPORT_DIRECTORY = "KartPad";
+    private static final String INSTALLED_DIRECTORY = "RetroRewind";
+    private static final String STAGING_PREFIX = "RetroRewind.import-";
+    private static final String ROLLBACK_PREFIX = "RetroRewind.rollback-";
+
+    @FunctionalInterface
+    interface AtomicMover {
+        void move(Path source, Path destination) throws IOException;
+    }
+
+    private RetroRewindInstallStorage() {}
+
+    static void recover(File filesDirectory) throws IOException {
+        Path support = supportRoot(filesDirectory);
+        if (!exists(support)) {
+            return;
+        }
+        requireDirectory(support, "Retro Rewind support root is invalid");
+
+        List<Path> rollbacks = new ArrayList<>();
+        try (var entries = Files.newDirectoryStream(support)) {
+            for (Path entry : entries) {
+                String name = entry.getFileName().toString();
+                if (name.startsWith(STAGING_PREFIX)) {
+                    deleteTree(entry);
+                } else if (name.startsWith(ROLLBACK_PREFIX)) {
+                    requireDirectory(entry, "Retro Rewind rollback entry is invalid");
+                    rollbacks.add(entry);
+                }
+            }
+        }
+        rollbacks.sort(Comparator.comparing(path -> path.getFileName().toString()));
+
+        Path installed = support.resolve(INSTALLED_DIRECTORY);
+        if (exists(installed)) {
+            requireDirectory(installed, "Retro Rewind installed root is invalid");
+        } else if (rollbacks.size() == 1) {
+            atomicMove(rollbacks.get(0), installed);
+        }
+    }
+
+    static Path createStagingDirectory(File filesDirectory, String token)
+            throws IOException {
+        requireToken(token);
+        Path support = supportRoot(filesDirectory);
+        Files.createDirectories(support);
+        requireDirectory(support, "Retro Rewind support root is invalid");
+        Path staging = support.resolve(STAGING_PREFIX + token);
+        return Files.createDirectory(staging);
+    }
+
+    static void activateValidatedStaging(File filesDirectory, Path staging, String token)
+            throws IOException {
+        activateValidatedStaging(filesDirectory, staging, token,
+                RetroRewindInstallStorage::atomicMove);
+    }
+
+    static void activateValidatedStaging(
+            File filesDirectory, Path staging, String token, AtomicMover mover)
+            throws IOException {
+        requireToken(token);
+        Path support = supportRoot(filesDirectory).toAbsolutePath().normalize();
+        requireDirectory(support, "Retro Rewind support root is invalid");
+        Path expectedStaging = support.resolve(STAGING_PREFIX + token);
+        Path normalizedStaging = staging.toAbsolutePath().normalize();
+        if (!normalizedStaging.equals(expectedStaging)) {
+            throw new IOException("Retro Rewind staging directory is invalid");
+        }
+        requireDirectory(normalizedStaging, "Retro Rewind staging directory is invalid");
+
+        Path installed = support.resolve(INSTALLED_DIRECTORY);
+        Path rollback = support.resolve(ROLLBACK_PREFIX + token);
+        if (exists(rollback)) {
+            throw new IOException("Retro Rewind rollback destination already exists");
+        }
+
+        boolean movedExisting = false;
+        if (exists(installed)) {
+            requireDirectory(installed, "Retro Rewind installed root is invalid");
+            mover.move(installed, rollback);
+            movedExisting = true;
+        }
+        try {
+            mover.move(normalizedStaging, installed);
+        } catch (IOException activationError) {
+            if (movedExisting && !exists(installed) && exists(rollback)) {
+                try {
+                    mover.move(rollback, installed);
+                } catch (IOException restoreError) {
+                    activationError.addSuppressed(restoreError);
+                }
+            }
+            throw activationError;
+        }
+
+        if (movedExisting) {
+            deleteTree(rollback);
+        }
+    }
+
+    static Path supportRoot(File filesDirectory) {
+        return filesDirectory.toPath().resolve(SUPPORT_DIRECTORY)
+                .toAbsolutePath().normalize();
+    }
+
+    private static void requireToken(String token) {
+        if (token == null || token.isEmpty() || token.length() > 64 ||
+                !token.matches("[A-Za-z0-9-]+")) {
+            throw new IllegalArgumentException("Invalid Retro Rewind install token");
+        }
+    }
+
+    private static void requireDirectory(Path path, String message) throws IOException {
+        if (!Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException(message);
+        }
+    }
+
+    private static void atomicMove(Path source, Path destination) throws IOException {
+        Files.move(source, destination, StandardCopyOption.ATOMIC_MOVE);
+    }
+
+    private static boolean exists(Path path) {
+        return Files.exists(path, LinkOption.NOFOLLOW_LINKS);
+    }
+
+    private static void deleteTree(Path root) throws IOException {
+        if (!exists(root)) {
+            return;
+        }
+        Files.walkFileTree(root, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attributes)
+                    throws IOException {
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path directory, IOException error)
+                    throws IOException {
+                if (error != null) {
+                    throw error;
+                }
+                Files.delete(directory);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+}

--- a/android/app/src/test/java/dev/kartpad/android/RetroRewindInstallStorageTestMain.java
+++ b/android/app/src/test/java/dev/kartpad/android/RetroRewindInstallStorageTestMain.java
@@ -1,0 +1,187 @@
+package dev.kartpad.android;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+public final class RetroRewindInstallStorageTestMain {
+    private RetroRewindInstallStorageTestMain() {}
+
+    public static void main(String[] args) throws Exception {
+        Path temporary = Files.createTempDirectory("kartpad-storage-test-");
+        try {
+            testRecovery(temporary.resolve("recovery"));
+            testAmbiguousRecovery(temporary.resolve("ambiguous"));
+            testActivation(temporary.resolve("activation"));
+            testActivationRollback(temporary.resolve("rollback"));
+            testScopeChecks(temporary.resolve("scope"));
+            testSymlinkBoundary(temporary.resolve("symlink"));
+            testRollbackSymlinkBoundary(temporary.resolve("rollback-symlink"));
+        } finally {
+            deleteTree(temporary);
+        }
+    }
+
+    private static void testRecovery(Path root) throws Exception {
+        File files = Files.createDirectories(root).toFile();
+        Path support = RetroRewindInstallStorage.supportRoot(files);
+        Path stale = Files.createDirectories(support.resolve("RetroRewind.import-stale"));
+        write(stale.resolve("partial"), "partial");
+        Path rollback = Files.createDirectories(support.resolve("RetroRewind.rollback-one"));
+        write(rollback.resolve("old"), "old");
+
+        RetroRewindInstallStorage.recover(files);
+
+        expect(!Files.exists(stale), "stale import was not removed");
+        expect(Files.readString(support.resolve("RetroRewind/old")).equals("old"),
+                "single rollback was not restored");
+        expect(!Files.exists(rollback), "restored rollback remains present");
+    }
+
+    private static void testAmbiguousRecovery(Path root) throws Exception {
+        File files = Files.createDirectories(root).toFile();
+        Path support = RetroRewindInstallStorage.supportRoot(files);
+        Files.createDirectories(support.resolve("RetroRewind.rollback-a"));
+        Files.createDirectories(support.resolve("RetroRewind.rollback-b"));
+
+        RetroRewindInstallStorage.recover(files);
+
+        expect(!Files.exists(support.resolve("RetroRewind")),
+                "ambiguous rollback was restored");
+    }
+
+    private static void testActivation(Path root) throws Exception {
+        File files = Files.createDirectories(root).toFile();
+        Path support = RetroRewindInstallStorage.supportRoot(files);
+        Path installed = Files.createDirectories(support.resolve("RetroRewind"));
+        write(installed.resolve("old"), "old");
+        Path staging = RetroRewindInstallStorage.createStagingDirectory(files, "success");
+        write(staging.resolve("new"), "new");
+
+        RetroRewindInstallStorage.activateValidatedStaging(files, staging, "success");
+
+        expect(Files.readString(support.resolve("RetroRewind/new")).equals("new"),
+                "validated staging was not activated");
+        expect(!Files.exists(support.resolve("RetroRewind/old")),
+                "old install remains active");
+        expect(!Files.exists(support.resolve("RetroRewind.rollback-success")),
+                "successful rollback was not removed");
+    }
+
+    private static void testActivationRollback(Path root) throws Exception {
+        File files = Files.createDirectories(root).toFile();
+        Path support = RetroRewindInstallStorage.supportRoot(files);
+        Path installed = Files.createDirectories(support.resolve("RetroRewind"));
+        write(installed.resolve("old"), "old");
+        Path staging = RetroRewindInstallStorage.createStagingDirectory(files, "failure");
+        write(staging.resolve("new"), "new");
+        AtomicInteger calls = new AtomicInteger();
+
+        try {
+            RetroRewindInstallStorage.activateValidatedStaging(
+                    files, staging, "failure", (source, destination) -> {
+                        if (calls.incrementAndGet() == 2) {
+                            throw new IOException("injected activation failure");
+                        }
+                        Files.move(source, destination);
+                    });
+            throw new AssertionError("injected activation failure was accepted");
+        } catch (IOException expected) {
+            expect(expected.getMessage().equals("injected activation failure"),
+                    "unexpected activation error");
+        }
+
+        expect(Files.readString(support.resolve("RetroRewind/old")).equals("old"),
+                "old install was not restored after activation failure");
+        expect(Files.exists(staging.resolve("new")),
+                "failed staging directory was unexpectedly removed");
+        expect(!Files.exists(support.resolve("RetroRewind.rollback-failure")),
+                "restored rollback remains present");
+    }
+
+    private static void testScopeChecks(Path root) throws Exception {
+        File files = Files.createDirectories(root).toFile();
+        Files.createDirectories(RetroRewindInstallStorage.supportRoot(files));
+        Path outside = Files.createDirectories(root.resolve("outside"));
+        try {
+            RetroRewindInstallStorage.activateValidatedStaging(files, outside, "safe");
+            throw new AssertionError("out-of-scope staging was accepted");
+        } catch (IOException expected) {
+            expect(expected.getMessage().contains("staging"),
+                    "unexpected out-of-scope error");
+        }
+        try {
+            RetroRewindInstallStorage.createStagingDirectory(files, "../escape");
+            throw new AssertionError("unsafe token was accepted");
+        } catch (IllegalArgumentException expected) {
+            expect(expected.getMessage().contains("token"), "unexpected token error");
+        }
+    }
+
+    private static void testSymlinkBoundary(Path root) throws Exception {
+        File files = Files.createDirectories(root.resolve("files")).toFile();
+        Path outside = Files.createDirectories(root.resolve("outside"));
+        write(outside.resolve("sentinel"), "outside");
+        Files.createSymbolicLink(RetroRewindInstallStorage.supportRoot(files), outside);
+
+        try {
+            RetroRewindInstallStorage.recover(files);
+            throw new AssertionError("symlinked support root was accepted");
+        } catch (IOException expected) {
+            expect(expected.getMessage().contains("support root"),
+                    "unexpected support-root error");
+        }
+        expect(Files.readString(outside.resolve("sentinel")).equals("outside"),
+                "support-root symlink target was modified");
+    }
+
+    private static void testRollbackSymlinkBoundary(Path root) throws Exception {
+        File files = Files.createDirectories(root.resolve("files")).toFile();
+        Path support = Files.createDirectories(
+                RetroRewindInstallStorage.supportRoot(files));
+        Path outside = Files.createDirectories(root.resolve("outside"));
+        write(outside.resolve("sentinel"), "outside");
+        Files.createSymbolicLink(support.resolve("RetroRewind.rollback-link"), outside);
+
+        try {
+            RetroRewindInstallStorage.recover(files);
+            throw new AssertionError("symlinked rollback was accepted");
+        } catch (IOException expected) {
+            expect(expected.getMessage().contains("rollback entry"),
+                    "unexpected rollback-entry error");
+        }
+        expect(Files.readString(outside.resolve("sentinel")).equals("outside"),
+                "rollback symlink target was modified");
+        expect(!Files.exists(support.resolve("RetroRewind")),
+                "rollback symlink was activated");
+    }
+
+    private static void write(Path path, String value) throws IOException {
+        Files.write(path, value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static void expect(boolean condition, String message) {
+        if (!condition) {
+            throw new AssertionError(message);
+        }
+    }
+
+    private static void deleteTree(Path root) throws IOException {
+        if (!Files.exists(root)) {
+            return;
+        }
+        try (Stream<Path> paths = Files.walk(root)) {
+            paths.sorted((left, right) -> right.compareTo(left)).forEach(path -> {
+                try {
+                    Files.delete(path);
+                } catch (IOException error) {
+                    throw new RuntimeException(error);
+                }
+            });
+        }
+    }
+}

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -56,6 +56,14 @@ file/directory trailing-slash alias cannot target one output twice; ignored
 foreign-root duplicates remain outside the selected policy. The existing Apple
 filesystem check remains a second line of defense.
 
+The Android owner now also has a same-volume app-private storage coordinator.
+It scopes staging and rollback names beneath `filesDir/KartPad`, uses atomic
+moves for old-install retention and activation, restores the prior install on
+an injected activation failure, clears stale imports, and restores only one
+unambiguous rollback during game-runtime startup. It refuses symlinked roots
+and out-of-scope staging. Content validation must succeed before its activation
+entry point is called; download, inspection, and extraction still remain.
+
 KartPad can be ported to Android without changing its defining architecture.
 The Android build should contain the same ahead-of-time translated Original
 Mario Kart Wii and Retro Rewind profiles as the Apple `KartPadDual` product,

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -170,6 +170,13 @@ not block offline Retro Rewind support.
    as defense in depth. Host, NDK, Apple SDK, safety, and contract tests pass.
    Evidence:
    `docs/artifacts/2026-09-04/android/a3-shared-archive-duplicates.md`.
+   Android now also has an app-private same-volume staging/atomic-activation/
+   rollback owner invoked during game-runtime startup. Its injected second-move
+   failure restores the prior install, cold recovery refuses ambiguous or
+   symlinked rollback state, and public/private build configurations, lint, and
+   the source-only APK audit pass. Only validated staging may use activation;
+   archive download/extraction/content validation are still absent. Evidence:
+   `docs/artifacts/2026-09-04/android/a3-install-storage-recovery.md`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2221,3 +2221,27 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   Apple consumer.** A2 and A3 remain open at their previously documented gates.
   No APK/AAB or private input was published. Evidence:
   `docs/artifacts/2026-09-04/android/a3-shared-archive-duplicates.md`.
+
+## 2026-09-04 — Android A3 install storage and recovery
+
+- Added an Android-owned storage coordinator beneath app-private
+  `filesDir/KartPad`. Production replacement uses same-volume atomic moves from
+  generated staging to active storage while retaining the old complete install
+  under a rollback name until activation succeeds.
+- Added cold recovery before game-runtime SDL startup: stale imports are
+  removed, exactly one rollback is restored when active storage is missing,
+  and ambiguous state is left untouched. Tokens and normalized paths are
+  bounded, and real-directory checks plus no-follow deletion reject symlink
+  escapes.
+- A pinned-JDK warning-as-error harness passes successful replacement and
+  injected second-move failure/restore, plus stale, ambiguous, scope, token, and
+  symlink cases. Public debug assemble, debug/release source compilation, lint,
+  private game-runtime configuration compilation, package/privacy audit,
+  repository safety, shell lint, and diff checks pass.
+- The source-only APK is 33,675,275 bytes with SHA-256
+  `ec5eefa73266e1dd15e76a9a76369093b3a4bb538022ffe5ea116d39c6bb5699`.
+- Classification: **Pass for Android same-volume staging, activation,
+  rollback, and startup recovery contracts.** A2 remains open, and A3 still
+  lacks archive download/extraction/content validation and runtime acceptance.
+  No APK/AAB or private data was published. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-install-storage-recovery.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -269,6 +269,19 @@ pass. The extraction-time filesystem check remains defense in depth. This
 closes only the shared duplicate-directory rule, not A3. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-shared-archive-duplicates.md`](artifacts/2026-09-04/android/a3-shared-archive-duplicates.md).
 
+Android now owns a tested app-private Retro Rewind storage coordinator. It
+creates same-volume staging under `filesDir/KartPad`, scopes activation to the
+exact generated token/path, atomically moves the prior install to rollback,
+atomically activates only caller-validated staging, restores the prior install
+after an injected second-move failure, removes stale imports, and restores only
+one unambiguous rollback on cold startup. Directory and cleanup operations
+refuse or avoid following symlinks. The game-runtime Activity invokes recovery
+before SDL startup. Its pinned-JDK fault matrix, fixture debug build, debug and
+release compilation, lint, strict 33,675,275-byte APK audit, and private game-
+configuration compile pass. This is storage/recovery evidence, not download,
+extraction, install validation, or gameplay. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-install-storage-recovery.md`](artifacts/2026-09-04/android/a3-install-storage-recovery.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-04/android/a3-install-storage-recovery.md
+++ b/docs/artifacts/2026-09-04/android/a3-install-storage-recovery.md
@@ -1,0 +1,69 @@
+# Android A3 install storage and recovery
+
+Date: 2026-09-04
+
+Branch: `codex/android-a3-install-storage`
+
+Baseline: `636e72e7316fadb9737d9719acc0569e99e342a8`
+
+## Falsifiable subgoal
+
+Give Android an app-private, same-volume Retro Rewind staging/activation/
+rollback contract that restores the prior complete installation after an
+injected activation failure and performs deterministic cold-start recovery.
+
+## Result
+
+- Added `RetroRewindInstallStorage` under the Android owner layer. All active,
+  staging, and rollback directories are direct children of
+  `filesDir/KartPad`, so production activation uses a same-filesystem
+  `ATOMIC_MOVE` rather than copying a partially extracted tree into place.
+- Install tokens are limited to 1--64 ASCII letters, digits, and hyphens; the
+  activation API also requires the exact normalized staging path created for
+  that token.
+- Startup removes stale `RetroRewind.import-*` trees. If the active install is
+  absent and exactly one real rollback directory exists, it atomically restores
+  that directory. Multiple rollbacks are left untouched for explicit recovery
+  rather than guessed.
+- Support, installed, staging, and rollback roots must be real directories, not
+  symlinks. Recursive cleanup does not follow symlinks.
+- A validated staging activation first moves the old install to a unique
+  rollback, then moves staging into the active name. If the second move fails,
+  the old install is restored; a failed restoration is retained as a suppressed
+  error and remains recoverable on the next startup.
+- Game-runtime `KartPadActivity` invokes recovery before installing public
+  runtime resources or loading SDL. Public fixture mode packages the owner but
+  does not mutate a Retro Rewind directory.
+
+Source SHA-256 values:
+
+- owner: `4f70ae8a97a238c604e2fd1563cc735b7065249c01acf12fb1d251c68497b99f`
+- test: `2c8e7fd513ec9033ec350a9060f99d54b75bad200657017a9cac3e6e40a6a789`
+- runner: `77e7b2058cd7977cda8782a113219b02185d548ae5571d033927690e6b7ab646`
+
+## Verification
+
+- Pinned-JDK warning-as-error storage contract: pass. It covers stale staging
+  removal, single rollback restoration, ambiguous rollback refusal, successful
+  replacement, injected second-move failure with old-install restoration,
+  out-of-scope staging, unsafe tokens, and support/rollback symlink refusal.
+- Public fixture debug assemble: pass.
+- Public debug lint plus debug/release Kotlin and Java compilation: pass.
+- Private game-runtime debug Kotlin and Java configuration compilation: pass.
+  This is a compile only; the private runtime APK was not rebuilt or installed.
+- The exact source-only debug APK is 33,675,275 bytes with SHA-256
+  `ec5eefa73266e1dd15e76a9a76369093b3a4bb538022ffe5ea116d39c6bb5699`.
+  Its ABI, alignment, native dependency, permission, asset allowlist, and
+  private-data/path audit passes.
+- Bash syntax, shell lint, repository safety, and diff checks: pass.
+
+## Classification
+
+**Pass for Android app-private same-volume staging, atomic activation,
+rollback, and cold-start recovery contracts.** No archive is downloaded or
+extracted yet, and only a future content validator may call the activation API.
+A2 remains open for physical Android acceptance. A3 remains open for Android
+archive acquisition/inspection/extraction and content validation, lifecycle-
+durable progress/cancellation, fault tests beyond this storage layer, and the
+complete emulator/physical offline gameplay matrix. No APK/AAB or private data
+was published.

--- a/scripts/test-android-retro-rewind-storage.sh
+++ b/scripts/test-android-retro-rewind-storage.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+# shellcheck source=android-toolchain-versions.sh
+source "${repo_root}/scripts/android-toolchain-versions.sh"
+java_home="${repo_root}/.android-bootstrap/jdk-${KARTPAD_ANDROID_JDK_VERSION}/Contents/Home"
+classes="${repo_root}/build/android-retro-rewind-storage-tests"
+
+if [[ ! -x "${java_home}/bin/javac" || ! -x "${java_home}/bin/java" ]]; then
+  echo "ERROR: pinned Android JDK is unavailable; run scripts/bootstrap-android-host.sh" >&2
+  exit 1
+fi
+
+mkdir -p "${classes}"
+find "${classes}" -type f -delete
+"${java_home}/bin/javac" -Werror -Xlint:all -d "${classes}" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallStorage.java" \
+  "${repo_root}/android/app/src/test/java/dev/kartpad/android/RetroRewindInstallStorageTestMain.java"
+"${java_home}/bin/java" -cp "${classes}" \
+  dev.kartpad.android.RetroRewindInstallStorageTestMain
+echo "Android Retro Rewind storage contract passed."


### PR DESCRIPTION
## Summary

- add an Android app-private same-volume staging/activation/rollback coordinator
- recover stale imports and one unambiguous rollback before game-runtime SDL startup
- refuse out-of-scope paths, unsafe tokens, and symlinked support/install/staging/rollback roots
- add an injected failure harness for atomic activation and rollback behavior

## Verification

- pinned-JDK warning-as-error storage matrix
- public fixture debug assemble
- debug/release Kotlin and Java compilation plus lint
- private game-runtime source configuration compilation
- strict source-only APK package/privacy audit (`ec5eefa73266e1dd15e76a9a76369093b3a4bb538022ffe5ea116d39c6bb5699`)
- Bash/shell lint, repository safety, and diff checks

## Scope

This Android-owned A3 slice is stacked on #45. It does not download or extract an archive; activation is explicitly for caller-validated staging. A2 remains open for physical-device acceptance and A3 remains open for acquisition, content validation, worker lifecycle, fault coverage, and offline emulator/physical gameplay. No APK/AAB or private data was published.