### PR TITLE
Validate Android Retro Rewind content

### DIFF
--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallValidator.java
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallValidator.java
@@ -1,0 +1,301 @@
+package dev.kartpad.android;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/** Validates a staged or installed Retro Rewind tree without exposing its path. */
+final class RetroRewindInstallValidator {
+    private static final int MAXIMUM_VERSION_BYTES = 128;
+    private static final int HASH_BUFFER_BYTES = 1024 * 1024;
+
+    enum Error {
+        NONE,
+        MISSING_ROOT,
+        VERSION_MISMATCH,
+        INVALID_REQUIREMENT,
+        MISSING_ARTIFACT,
+        SIZE_MISMATCH,
+        HASH_MISMATCH,
+        IO_ERROR,
+    }
+
+    static final class Result {
+        final Error error;
+        final String artifact;
+
+        Result(Error error, String artifact) {
+            this.error = error;
+            this.artifact = artifact;
+        }
+
+        boolean isValid() {
+            return error == Error.NONE;
+        }
+    }
+
+    static final class ArtifactRequirement {
+        final String relativePath;
+        final long bytes;
+        final String sha256;
+
+        ArtifactRequirement(String relativePath, long bytes, String sha256) {
+            this.relativePath = relativePath;
+            this.bytes = bytes;
+            this.sha256 = sha256;
+        }
+    }
+
+    static final class Contract {
+        final String version;
+        final String root;
+        final List<ArtifactRequirement> artifacts;
+
+        Contract(String version, String root, List<ArtifactRequirement> artifacts) {
+            this.version = version;
+            this.root = root;
+            this.artifacts = Collections.unmodifiableList(new ArrayList<>(artifacts));
+        }
+    }
+
+    private RetroRewindInstallValidator() {}
+
+    static Contract productionContract() {
+        return new Contract(
+                RetroRewindRelease.VERSION,
+                RetroRewindRelease.ROOT,
+                Arrays.asList(
+                        new ArtifactRequirement(
+                                RetroRewindRelease.CODE_PUL_PATH,
+                                RetroRewindRelease.CODE_PUL_BYTES,
+                                RetroRewindRelease.CODE_PUL_SHA256),
+                        new ArtifactRequirement(
+                                RetroRewindRelease.XML_PATH,
+                                RetroRewindRelease.XML_BYTES,
+                                RetroRewindRelease.XML_SHA256)));
+    }
+
+    static Result validate(Path installedRoot, Contract contract) {
+        try {
+            Path root = installedRoot.toAbsolutePath().normalize();
+            if (!Files.isDirectory(root, LinkOption.NOFOLLOW_LINKS)) {
+                return failed(Error.MISSING_ROOT, null);
+            }
+            if (contract.version == null || contract.version.isEmpty() ||
+                    !isSafeComponent(contract.root)) {
+                return failed(Error.INVALID_REQUIREMENT, null);
+            }
+
+            String installedVersion = readVersion(root.resolve("version.txt"));
+            if (!contract.version.equals(installedVersion)) {
+                return failed(Error.VERSION_MISMATCH, "version.txt");
+            }
+
+            for (ArtifactRequirement requirement : contract.artifacts) {
+                Result result = validateArtifact(root, requirement);
+                if (!result.isValid()) {
+                    return result;
+                }
+            }
+            return new Result(Error.NONE, null);
+        } catch (IOException error) {
+            return failed(Error.IO_ERROR, null);
+        }
+    }
+
+    static Result validateAndActivate(
+            File filesDirectory, Path staging, String token, Contract contract) {
+        if (contract == null || !isSafeComponent(contract.root)) {
+            return failed(Error.INVALID_REQUIREMENT, null);
+        }
+        Result validation = validate(staging.resolve(contract.root), contract);
+        if (!validation.isValid()) {
+            return validation;
+        }
+        try {
+            RetroRewindInstallStorage.activateValidatedStaging(
+                    filesDirectory, staging, token);
+            return new Result(Error.NONE, null);
+        } catch (IOException error) {
+            return failed(Error.IO_ERROR, null);
+        }
+    }
+
+    private static Result validateArtifact(Path root, ArtifactRequirement requirement)
+            throws IOException {
+        if (requirement == null || requirement.bytes < 0 ||
+                !isLowercaseSha256(requirement.sha256) ||
+                !isSafeRelativePath(requirement.relativePath)) {
+            return failed(Error.INVALID_REQUIREMENT, null);
+        }
+
+        Path relative = Paths.get(requirement.relativePath);
+        Path current = root;
+        for (int index = 0; index < relative.getNameCount() - 1; ++index) {
+            current = current.resolve(relative.getName(index));
+            if (!Files.isDirectory(current, LinkOption.NOFOLLOW_LINKS)) {
+                return failed(Error.MISSING_ARTIFACT, requirement.relativePath);
+            }
+        }
+        Path file = root.resolve(relative).normalize();
+        if (!file.startsWith(root) || !Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)) {
+            return failed(Error.MISSING_ARTIFACT, requirement.relativePath);
+        }
+        if (Files.size(file) != requirement.bytes) {
+            return failed(Error.SIZE_MISMATCH, requirement.relativePath);
+        }
+
+        HashResult hash = sha256(file);
+        if (hash.bytes != requirement.bytes) {
+            return failed(Error.SIZE_MISMATCH, requirement.relativePath);
+        }
+        if (!hash.hex.equals(requirement.sha256)) {
+            return failed(Error.HASH_MISMATCH, requirement.relativePath);
+        }
+        return new Result(Error.NONE, null);
+    }
+
+    private static String readVersion(Path path) throws IOException {
+        if (!Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
+            return null;
+        }
+        byte[] bytes;
+        try (InputStream input = Files.newInputStream(path)) {
+            byte[] bounded = new byte[MAXIMUM_VERSION_BYTES + 1];
+            int total = 0;
+            while (total < bounded.length) {
+                int count = input.read(bounded, total, bounded.length - total);
+                if (count == -1) {
+                    break;
+                }
+                total += count;
+            }
+            bytes = Arrays.copyOf(bounded, total);
+        }
+        if (bytes.length > MAXIMUM_VERSION_BYTES) {
+            return null;
+        }
+        String decoded;
+        try {
+            decoded = StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(bytes)).toString();
+        } catch (CharacterCodingException error) {
+            return null;
+        }
+        return trimWhitespace(decoded);
+    }
+
+    private static String trimWhitespace(String value) {
+        int start = 0;
+        int end = value.length();
+        while (start < end && isWhitespace(value.charAt(start))) {
+            ++start;
+        }
+        while (end > start && isWhitespace(value.charAt(end - 1))) {
+            --end;
+        }
+        return value.substring(start, end);
+    }
+
+    private static boolean isWhitespace(char value) {
+        return Character.isWhitespace(value) || Character.isSpaceChar(value);
+    }
+
+    private static HashResult sha256(Path path) throws IOException {
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException error) {
+            throw new AssertionError("Android runtime has no SHA-256", error);
+        }
+        byte[] buffer = new byte[HASH_BUFFER_BYTES];
+        long bytes = 0;
+        try (InputStream input = Files.newInputStream(path)) {
+            int count;
+            while ((count = input.read(buffer)) != -1) {
+                digest.update(buffer, 0, count);
+                bytes += count;
+            }
+        }
+        return new HashResult(bytes, hex(digest.digest()));
+    }
+
+    private static boolean isSafeRelativePath(String value) {
+        if (value == null || value.isEmpty() || value.startsWith("/") ||
+                value.contains("\\") || value.indexOf('\0') >= 0 || value.contains(":")) {
+            return false;
+        }
+        String[] components = value.split("/", -1);
+        if (components.length == 0) {
+            return false;
+        }
+        for (String component : components) {
+            if (!isSafeComponent(component)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isSafeComponent(String value) {
+        return value != null && !value.isEmpty() && !value.equals(".") &&
+                !value.equals("..") && !value.contains("/") &&
+                !value.contains("\\") && !value.contains(":") &&
+                value.indexOf('\0') < 0;
+    }
+
+    private static boolean isLowercaseSha256(String value) {
+        if (value == null || value.length() != 64) {
+            return false;
+        }
+        for (int index = 0; index < value.length(); ++index) {
+            char character = value.charAt(index);
+            if (!((character >= '0' && character <= '9') ||
+                    (character >= 'a' && character <= 'f'))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static String hex(byte[] bytes) {
+        char[] digits = "0123456789abcdef".toCharArray();
+        char[] output = new char[bytes.length * 2];
+        for (int index = 0; index < bytes.length; ++index) {
+            int value = bytes[index] & 0xff;
+            output[index * 2] = digits[value >>> 4];
+            output[index * 2 + 1] = digits[value & 0x0f];
+        }
+        return new String(output);
+    }
+
+    private static Result failed(Error error, String artifact) {
+        return new Result(error, artifact);
+    }
+
+    private static final class HashResult {
+        final long bytes;
+        final String hex;
+
+        HashResult(long bytes, String hex) {
+            this.bytes = bytes;
+            this.hex = hex;
+        }
+    }
+}

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindRelease.java
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindRelease.java
@@ -1,0 +1,22 @@
+// Generated from builder/profiles/mkwii-rmcp01-rev0.json. Do not edit.
+package dev.kartpad.android;
+
+final class RetroRewindRelease {
+    private RetroRewindRelease() {}
+
+    static final String VERSION = "6.12.5";
+    static final String ROOT = "RetroRewind6";
+    static final String ARCHIVE_URL = "https://cdn.update.rwfc.net/RetroRewind/zip/6.12.5-full.zip";
+    static final String ARCHIVE_SHA256 = "d8f7c61636ef76f8a451f4071ec5bbdcfea9d5f2500cfc6c245431f04580f9d9";
+    static final String CODE_PUL_PATH = "Binaries/Code.pul";
+    static final String CODE_PUL_SHA256 = "622485319fd01746c705e5c1b08b2551e36368d8abd70138ee843dc8a0a0a293";
+    static final String XML_PATH = "xml/RetroRewind6.xml";
+    static final String XML_SHA256 = "faf88234f81e16a85403d2a86d25e2ef4b261aedb553a312b532e60a11b28200";
+    static final String PAYLOAD_URL = "http://nas.play.rwfc.net/payload?g=RMCPD00";
+    static final String PAYLOAD_SHA256 = "fd8f26d6af26f1a0cfaecd1e472fe744a25d75f5136910533b7c75e3eca2f1d2";
+    static final long ARCHIVE_BYTES = 1859041899L;
+    static final long MAXIMUM_EXPANDED_BYTES = 2200000000L;
+    static final long CODE_PUL_BYTES = 1723600L;
+    static final long XML_BYTES = 21047L;
+    static final long PAYLOAD_BYTES = 28968L;
+}

--- a/android/app/src/test/java/dev/kartpad/android/RetroRewindInstallValidatorTestMain.java
+++ b/android/app/src/test/java/dev/kartpad/android/RetroRewindInstallValidatorTestMain.java
@@ -1,0 +1,189 @@
+package dev.kartpad.android;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.List;
+import java.util.stream.Stream;
+
+public final class RetroRewindInstallValidatorTestMain {
+    private static final byte[] CODE = "code-data".getBytes();
+    private static final byte[] XML = "xml-data".getBytes();
+
+    private RetroRewindInstallValidatorTestMain() {}
+
+    public static void main(String[] args) throws Exception {
+        Path temporary = Files.createTempDirectory("kartpad-content-test-");
+        try {
+            testValidAndActivated(temporary.resolve("valid"));
+            testVersionFailures(temporary.resolve("version"));
+            testArtifactFailures(temporary.resolve("artifact"));
+            testRequirementAndSymlinkFailures(temporary.resolve("safety"));
+            testProductionContract();
+        } finally {
+            deleteTree(temporary);
+        }
+    }
+
+    private static void testValidAndActivated(Path base) throws Exception {
+        Path filesPath = Files.createDirectories(base.resolve("files"));
+        Path staging = RetroRewindInstallStorage.createStagingDirectory(
+                filesPath.toFile(), "valid");
+        Path root = staging.resolve("RetroRewind6");
+        writeValidTree(root);
+
+        expectValid(RetroRewindInstallValidator.validate(root, testContract()));
+        expectValid(RetroRewindInstallValidator.validateAndActivate(
+                filesPath.toFile(), staging, "valid", testContract()));
+        Path active = RetroRewindInstallStorage.supportRoot(filesPath.toFile())
+                .resolve("RetroRewind/RetroRewind6");
+        expectValid(RetroRewindInstallValidator.validate(active, testContract()));
+
+        Path invalidStaging = RetroRewindInstallStorage.createStagingDirectory(
+                filesPath.toFile(), "invalid");
+        Path invalidRoot = invalidStaging.resolve("RetroRewind6");
+        writeValidTree(invalidRoot);
+        Files.delete(invalidRoot.resolve("Binaries/Code.pul"));
+        expectError(
+                RetroRewindInstallValidator.validateAndActivate(
+                        filesPath.toFile(), invalidStaging, "invalid", testContract()),
+                RetroRewindInstallValidator.Error.MISSING_ARTIFACT);
+        expect(Files.exists(invalidStaging), "invalid staging was activated");
+        expectValid(RetroRewindInstallValidator.validate(active, testContract()));
+    }
+
+    private static void testVersionFailures(Path base) throws Exception {
+        Path root = base.resolve("wrong");
+        writeValidTree(root);
+        Files.writeString(root.resolve("version.txt"), "6.12.4\n");
+        expectError(
+                RetroRewindInstallValidator.validate(root, testContract()),
+                RetroRewindInstallValidator.Error.VERSION_MISMATCH);
+
+        root = base.resolve("invalid-utf8");
+        writeValidTree(root);
+        Files.write(root.resolve("version.txt"), new byte[] {(byte) 0xc3, (byte) 0x28});
+        expectError(
+                RetroRewindInstallValidator.validate(root, testContract()),
+                RetroRewindInstallValidator.Error.VERSION_MISMATCH);
+
+        root = base.resolve("oversize");
+        writeValidTree(root);
+        Files.write(root.resolve("version.txt"), new byte[129]);
+        expectError(
+                RetroRewindInstallValidator.validate(root, testContract()),
+                RetroRewindInstallValidator.Error.VERSION_MISMATCH);
+    }
+
+    private static void testArtifactFailures(Path base) throws Exception {
+        Path missing = base.resolve("missing");
+        writeValidTree(missing);
+        Files.delete(missing.resolve("xml/RetroRewind6.xml"));
+        expectError(
+                RetroRewindInstallValidator.validate(missing, testContract()),
+                RetroRewindInstallValidator.Error.MISSING_ARTIFACT);
+
+        Path size = base.resolve("size");
+        writeValidTree(size);
+        Files.writeString(size.resolve("Binaries/Code.pul"), "short");
+        expectError(
+                RetroRewindInstallValidator.validate(size, testContract()),
+                RetroRewindInstallValidator.Error.SIZE_MISMATCH);
+
+        Path hash = base.resolve("hash");
+        writeValidTree(hash);
+        Files.writeString(hash.resolve("Binaries/Code.pul"), "code-datA");
+        expectError(
+                RetroRewindInstallValidator.validate(hash, testContract()),
+                RetroRewindInstallValidator.Error.HASH_MISMATCH);
+    }
+
+    private static void testRequirementAndSymlinkFailures(Path base) throws Exception {
+        Path root = base.resolve("root");
+        writeValidTree(root);
+        var unsafe = new RetroRewindInstallValidator.Contract(
+                "6.12.5",
+                "RetroRewind6",
+                List.of(new RetroRewindInstallValidator.ArtifactRequirement(
+                        "../outside", 1, "0".repeat(64))));
+        expectError(
+                RetroRewindInstallValidator.validate(root, unsafe),
+                RetroRewindInstallValidator.Error.INVALID_REQUIREMENT);
+
+        Path outside = base.resolve("outside");
+        Files.writeString(outside, "code-data");
+        Files.delete(root.resolve("Binaries/Code.pul"));
+        Files.createSymbolicLink(root.resolve("Binaries/Code.pul"), outside);
+        expectError(
+                RetroRewindInstallValidator.validate(root, testContract()),
+                RetroRewindInstallValidator.Error.MISSING_ARTIFACT);
+    }
+
+    private static void testProductionContract() {
+        var contract = RetroRewindInstallValidator.productionContract();
+        expect(contract.version.equals("6.12.5"), "production version drifted");
+        expect(contract.root.equals("RetroRewind6"), "production root drifted");
+        expect(contract.artifacts.size() == 2, "production artifact count drifted");
+    }
+
+    private static RetroRewindInstallValidator.Contract testContract() throws Exception {
+        return new RetroRewindInstallValidator.Contract(
+                "6.12.5",
+                "RetroRewind6",
+                List.of(
+                        new RetroRewindInstallValidator.ArtifactRequirement(
+                                "Binaries/Code.pul", CODE.length, sha256(CODE)),
+                        new RetroRewindInstallValidator.ArtifactRequirement(
+                                "xml/RetroRewind6.xml", XML.length, sha256(XML))));
+    }
+
+    private static void writeValidTree(Path root) throws IOException {
+        Files.createDirectories(root.resolve("Binaries"));
+        Files.createDirectories(root.resolve("xml"));
+        Files.writeString(root.resolve("version.txt"), " 6.12.5\n");
+        Files.write(root.resolve("Binaries/Code.pul"), CODE);
+        Files.write(root.resolve("xml/RetroRewind6.xml"), XML);
+    }
+
+    private static String sha256(byte[] bytes) throws Exception {
+        byte[] digest = MessageDigest.getInstance("SHA-256").digest(bytes);
+        StringBuilder output = new StringBuilder(digest.length * 2);
+        for (byte value : digest) {
+            output.append(String.format("%02x", value & 0xff));
+        }
+        return output.toString();
+    }
+
+    private static void expectValid(RetroRewindInstallValidator.Result result) {
+        expect(result.isValid(), "expected valid content, got " + result.error);
+    }
+
+    private static void expectError(
+            RetroRewindInstallValidator.Result result,
+            RetroRewindInstallValidator.Error expected) {
+        expect(!result.isValid() && result.error == expected,
+                "expected " + expected + ", got " + result.error);
+    }
+
+    private static void expect(boolean condition, String message) {
+        if (!condition) {
+            throw new AssertionError(message);
+        }
+    }
+
+    private static void deleteTree(Path root) throws IOException {
+        if (!Files.exists(root)) {
+            return;
+        }
+        try (Stream<Path> paths = Files.walk(root)) {
+            paths.sorted((left, right) -> right.compareTo(left)).forEach(path -> {
+                try {
+                    Files.delete(path);
+                } catch (IOException error) {
+                    throw new RuntimeException(error);
+                }
+            });
+        }
+    }
+}

--- a/builder/kartpad_builder/android_release_contract.py
+++ b/builder/kartpad_builder/android_release_contract.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .profiles import validate_profile
+
+
+def _java_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=True)
+
+
+def render_android_release_contract(profile_data: dict) -> str:
+    validate_profile(profile_data, "release profile")
+    config = profile_data["retroRewind"]
+    archive = config["archive"]
+    code = config["codePul"]
+    xml = config["riivolutionXml"]
+    payload = config["payload"]
+    strings = {
+        "VERSION": config["version"],
+        "ROOT": config["root"],
+        "ARCHIVE_URL": archive["url"],
+        "ARCHIVE_SHA256": archive["sha256"],
+        "CODE_PUL_PATH": code["path"],
+        "CODE_PUL_SHA256": code["sha256"],
+        "XML_PATH": xml["path"],
+        "XML_SHA256": xml["sha256"],
+        "PAYLOAD_URL": payload["url"],
+        "PAYLOAD_SHA256": payload["sha256"],
+    }
+    numbers = {
+        "ARCHIVE_BYTES": archive["bytes"],
+        "MAXIMUM_EXPANDED_BYTES": archive["maximumExpandedBytes"],
+        "CODE_PUL_BYTES": code["bytes"],
+        "XML_BYTES": xml["bytes"],
+        "PAYLOAD_BYTES": payload["bytes"],
+    }
+    lines = [
+        "// Generated from builder/profiles/mkwii-rmcp01-rev0.json. Do not edit.",
+        "package dev.kartpad.android;",
+        "",
+        "final class RetroRewindRelease {",
+        "    private RetroRewindRelease() {}",
+        "",
+    ]
+    lines.extend(
+        f"    static final String {name} = {_java_string(value)};"
+        for name, value in strings.items()
+    )
+    lines.extend(f"    static final long {name} = {value}L;" for name, value in numbers.items())
+    lines.extend(["}", ""])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate Android's pinned Retro Rewind release contract"
+    )
+    parser.add_argument("profile", type=Path)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+    profile_data = json.loads(args.profile.read_text())
+    rendered = render_android_release_contract(profile_data)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -64,6 +64,14 @@ unambiguous rollback during game-runtime startup. It refuses symlinked roots
 and out-of-scope staging. Content validation must succeed before its activation
 entry point is called; download, inspection, and extraction still remain.
 
+Android's release constants are now generated from the same profile and checked
+byte-for-byte against it. A bounded validator gates activation on strict UTF-8
+exact version plus exact size and streamed SHA-256 for `Code.pul` and the
+Riivolution XML, while rejecting unsafe requirement paths and symlinked nodes.
+The generated contract also carries the production payload pin whose signature
+and hash remain enforced by the translated-build pipeline; the payload is not
+an installed pack file. Invalid staging cannot call the atomic activation path.
+
 KartPad can be ported to Android without changing its defining architecture.
 The Android build should contain the same ahead-of-time translated Original
 Mario Kart Wii and Retro Rewind profiles as the Apple `KartPadDual` product,

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -177,6 +177,13 @@ not block offline Retro Rewind support.
    the source-only APK audit pass. Only validated staging may use activation;
    archive download/extraction/content validation are still absent. Evidence:
    `docs/artifacts/2026-09-04/android/a3-install-storage-recovery.md`.
+   Android's exact release constants are now generated and regression-checked
+   against the sole profile. A bounded strict-UTF-8/version and streamed-size/
+   SHA-256 validator for `Code.pul` and XML gates atomic activation and rejects
+   unsafe or symlinked content; the generated contract also retains the build-
+   validated production payload pin. Public/private compile configurations,
+   lint, content fault tests, and package audit pass. Evidence:
+   `docs/artifacts/2026-09-04/android/a3-content-validation.md`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2245,3 +2245,29 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   lacks archive download/extraction/content validation and runtime acceptance.
   No APK/AAB or private data was published. Evidence:
   `docs/artifacts/2026-09-04/android/a3-install-storage-recovery.md`.
+
+## 2026-09-04 — Android A3 profile-derived content validation
+
+- Added a deterministic Java release-contract renderer and checked-in output
+  for every Android-visible Retro Rewind profile pin. A builder test requires
+  byte equality with the sole profile, preventing stale hand-copied constants.
+- Added bounded strict-UTF-8 version reading and streaming SHA-256/size checks
+  for the installed `Code.pul` and Riivolution XML. Unsafe relative requirements
+  and symlinked directory/file nodes fail closed without returning absolute
+  app-private paths.
+- Joined validation to atomic activation. The test activates and revalidates a
+  complete staged tree, then proves a missing-artifact tree remains staged and
+  leaves the valid active install unchanged. Wrong/invalid/oversize version,
+  missing, short, same-size tampered, unsafe, and symlinked cases also pass.
+- The generated payload pin documents the exact already validated translated-
+  build input; Android does not download that executable input at runtime.
+- Pinned-JDK warning-as-error tests, 22 builder tests, public debug/release
+  compilation, lint, private game-runtime configuration compilation, package/
+  privacy audit, repository safety, shell lint, and diff checks pass. The
+  source-only APK is 33,675,275 bytes at SHA-256
+  `2c6ad2c220444e61ce36826f7b90116fa29be369ba43831d44af9dc670b15e5f`.
+- Classification: **Pass for profile-derived release constants and installed-
+  content validation gating activation.** A2 remains open; A3 still lacks
+  download/free-space/ZIP extraction/worker lifecycle and runtime acceptance.
+  No APK/AAB or private data was published. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-content-validation.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -282,6 +282,19 @@ configuration compile pass. This is storage/recovery evidence, not download,
 extraction, install validation, or gameplay. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-install-storage-recovery.md`](artifacts/2026-09-04/android/a3-install-storage-recovery.md).
 
+Android's release constants are now deterministically rendered from the sole
+repository Retro Rewind profile and checked byte-for-byte in the builder suite.
+A bounded installed-tree validator enforces strict UTF-8/exact version, safe
+relative paths, no symlinked nodes, exact `Code.pul` and XML byte counts, and
+streamed SHA-256 before the storage coordinator may activate staging. The
+generated contract also carries the already builder-validated production
+payload pin; that translated-build input is not redownloaded as pack content.
+Valid staging activates and revalidates in the fault harness, while missing,
+short, tampered, unsafe, or symlinked content remains inactive. Pinned-JDK
+tests, 22 builder tests, public debug/release compilation, lint, private game-
+configuration compile, and the strict source-only APK audit pass. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-content-validation.md`](artifacts/2026-09-04/android/a3-content-validation.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-04/android/a3-content-validation.md
+++ b/docs/artifacts/2026-09-04/android/a3-content-validation.md
@@ -1,0 +1,74 @@
+# Android A3 pinned content validation
+
+Date: 2026-09-04
+
+Branch: `codex/android-a3-content-validation`
+
+Baseline: `ba998d46b14d870b378f85dc066d65b88ce9c905`
+
+## Falsifiable subgoal
+
+Generate Android's Retro Rewind release constants from the repository profile
+and prevent an incomplete, wrong-version, wrong-size, wrong-hash, unsafe, or
+symlinked staging tree from reaching atomic activation.
+
+## Result
+
+- Added a deterministic Android Java contract renderer and checked-in generated
+  contract. A builder regression compares the file byte-for-byte with
+  `builder/profiles/mkwii-rmcp01-rev0.json`, so a profile advance cannot leave
+  Android's visible version, root, URLs, byte counts, or hashes stale.
+- The generated contract includes the archive, `Code.pul`, Riivolution XML, and
+  production payload pins. The payload remains a translated-build input: the
+  existing builder validates its size, hash, header, declared size, and
+  signature before producing the native profile. It is not an installed pack
+  file and is not downloaded again by the Android app.
+- Added a bounded Android installed-tree validator. It reads at most 129 bytes
+  for `version.txt`, decodes strict UTF-8, compares the exact trimmed version,
+  and streams required files through the platform SHA-256 implementation with a
+  1 MiB heap buffer.
+- Required artifact paths must satisfy the same absolute/backslash/NUL/dot/
+  parent/colon rules and every parent/final node must be a real directory/file,
+  not a symlink. Size is checked before hashing and again against streamed bytes
+  to catch a changed file.
+- Validation results contain only fixed error categories and profile-relative
+  artifact names; absolute app-private paths are never returned.
+- `validateAndActivate` joins this validator to the prior storage coordinator.
+  Invalid staging remains in place and leaves the active install unchanged;
+  only a fully valid tree reaches the atomic swap.
+
+Source SHA-256 values:
+
+- renderer: `3a5a846e5001cbd3adff832b0cedb7bb4bfdceb1e0b81a0e88b88b279676fdef`
+- generated contract: `4c631fe8847657b7ab657ff720a5bd1ab588c0af1b74294a3b9b4d0e51f76040`
+- validator: `342eae827d6fb66e3ead629ac38f62db33c7b77ec57f0a3da146ef0ee00dca3d`
+- test: `4e81526ec160bcbf1f77ff2bc7cf523c6cbd0107bbc079821abc9f3e2cf19563`
+- runner: `8d0f18110580038e3c713f324da09f8fbd1f6fc0a51187d7256a1285a639632f`
+
+## Verification
+
+- Pinned-JDK warning-as-error content matrix: pass. It covers valid staging and
+  post-activation validation, invalid staging refusal, wrong/invalid/oversize
+  version files, missing/short/tampered artifacts, unsafe requirements, and a
+  symlinked required file.
+- Generated-contract/profile byte comparison: pass.
+- Complete builder suite: 21 pass plus one optional private-payload test skip.
+- Public fixture debug assemble, release Java compilation, and debug lint: pass.
+- Private game-runtime debug Kotlin/Java configuration compile: pass. No private
+  APK was rebuilt or installed.
+- The exact source-only debug APK is 33,675,275 bytes with SHA-256
+  `2c6ad2c220444e61ce36826f7b90116fa29be369ba43831d44af9dc670b15e5f`.
+  Its ABI, alignment, native dependencies, permissions, assets, and private-
+  data/path audit passes, and the validator is present in its DEX.
+- Shell syntax/lint, repository safety, and diff checks: pass.
+
+## Classification
+
+**Pass for profile-derived Android release constants and bounded exact installed
+content validation gating atomic activation.** This does not download, inspect,
+or extract the archive, nor prove process-death behavior or gameplay. A2 remains
+open for physical Android acceptance. A3 remains open for acquisition,
+free-space preflight, ZIP adapter/extraction, durable progress/cancellation,
+fault injection across those layers, and complete emulator/physical offline
+mode-switch/race/save/relaunch acceptance. No APK/AAB or private data was
+published.

--- a/scripts/test-android-retro-rewind-content.sh
+++ b/scripts/test-android-retro-rewind-content.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+# shellcheck source=android-toolchain-versions.sh
+source "${repo_root}/scripts/android-toolchain-versions.sh"
+java_home="${repo_root}/.android-bootstrap/jdk-${KARTPAD_ANDROID_JDK_VERSION}/Contents/Home"
+classes="${repo_root}/build/android-retro-rewind-content-tests"
+
+if [[ ! -x "${java_home}/bin/javac" || ! -x "${java_home}/bin/java" ]]; then
+  echo "ERROR: pinned Android JDK is unavailable; run scripts/bootstrap-android-host.sh" >&2
+  exit 1
+fi
+
+mkdir -p "${classes}"
+find "${classes}" -type f -delete
+"${java_home}/bin/javac" -Werror -Xlint:all -d "${classes}" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindRelease.java" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallStorage.java" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallValidator.java" \
+  "${repo_root}/android/app/src/test/java/dev/kartpad/android/RetroRewindInstallValidatorTestMain.java"
+"${java_home}/bin/java" -cp "${classes}" \
+  dev.kartpad.android.RetroRewindInstallValidatorTestMain
+echo "Android Retro Rewind content contract passed."

--- a/tests/test_kartpad_builder.py
+++ b/tests/test_kartpad_builder.py
@@ -10,6 +10,7 @@ import zipfile
 from pathlib import Path
 
 from kartpad_builder.packaging import PackageError, audit_app, package_unsigned_ipa
+from kartpad_builder.android_release_contract import render_android_release_contract
 from kartpad_builder.pipeline import cache_key, dependency_cache_key
 from kartpad_builder.profiles import Profile, ProfileError, load_profiles, select_profile, validate_profile
 from kartpad_builder.release_header import render_retro_rewind_header
@@ -96,6 +97,15 @@ class ProfileTests(unittest.TestCase):
             retro["archive"]["url"],
             "the visible version and immutable archive URL must advance together",
         )
+
+    def test_android_release_contract_matches_profile(self) -> None:
+        profile = load_profiles(PROFILES)[0]
+        expected = render_android_release_contract(profile.data)
+        generated = (
+            REPO
+            / "android/app/src/main/java/dev/kartpad/android/RetroRewindRelease.java"
+        ).read_text()
+        self.assertEqual(generated, expected)
 
     def test_device_archive_hashing_uses_heap_storage(self) -> None:
         source = (REPO / "apple/ios/KartPadRetroRewindInstaller.mm").read_text()


### PR DESCRIPTION
## Summary

- generate Android Retro Rewind release constants deterministically from the sole profile
- validate strict version plus exact `Code.pul` and XML sizes/SHA-256 without following symlinks
- gate the prior atomic storage activation on a fully valid staged tree
- retain the production payload pin as a translated-build contract, not a runtime download

## Verification

- pinned-JDK content and storage fault matrices
- generated Java/profile byte comparison
- 30 builder/tvOS contracts pass with one optional private-input skip
- public fixture debug assemble, release Java compile, and debug lint
- private game-runtime debug source-configuration compile
- strict source-only APK package/privacy audit (`2c6ad2c220444e61ce36826f7b90116fa29be369ba43831d44af9dc670b15e5f`)
- shell lint, repository safety, SunPad snapshot, and diff checks

## Scope

This A3 slice is stacked on #46. It does not yet download, inspect, or extract the official archive. A2 remains open for physical-device acceptance; A3 remains open for free-space preflight, archive adapter/extraction, durable worker progress/cancellation, fault coverage, and offline emulator/physical gameplay. No APK/AAB or private data was published.