### PR TITLE
Add Android Retro Rewind space preflight

### DIFF
--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindSpacePreflight.java
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindSpacePreflight.java
@@ -1,0 +1,106 @@
+package dev.kartpad.android;
+
+/** Pure free-space accounting for the Android Retro Rewind installer. */
+final class RetroRewindSpacePreflight {
+    static final long RESERVE_BYTES = 256L * 1024L * 1024L;
+
+    enum Error {
+        NONE,
+        INVALID_REQUIREMENT,
+        INSUFFICIENT_SHARED_STORE,
+        INSUFFICIENT_FILES_STORE,
+        INSUFFICIENT_CACHE_STORE,
+        PROBE_FAILED,
+    }
+
+    static final class Result {
+        final Error error;
+        final long requiredFilesBytes;
+        final long requiredCacheBytes;
+        final long availableFilesBytes;
+        final long availableCacheBytes;
+
+        Result(
+                Error error,
+                long requiredFilesBytes,
+                long requiredCacheBytes,
+                long availableFilesBytes,
+                long availableCacheBytes) {
+            this.error = error;
+            this.requiredFilesBytes = requiredFilesBytes;
+            this.requiredCacheBytes = requiredCacheBytes;
+            this.availableFilesBytes = availableFilesBytes;
+            this.availableCacheBytes = availableCacheBytes;
+        }
+
+        boolean isReady() {
+            return error == Error.NONE;
+        }
+    }
+
+    private RetroRewindSpacePreflight() {}
+
+    static Result evaluate(
+            long availableFilesBytes,
+            long availableCacheBytes,
+            boolean sameStore,
+            long archiveBytes,
+            long maximumExpandedBytes) {
+        if (availableFilesBytes < 0 || availableCacheBytes < 0 ||
+                archiveBytes < 0 || maximumExpandedBytes < 0) {
+            return result(Error.INVALID_REQUIREMENT, 0, 0,
+                    availableFilesBytes, availableCacheBytes);
+        }
+
+        if (sameStore) {
+            long required = checkedAdd(archiveBytes, maximumExpandedBytes);
+            required = checkedAdd(required, RESERVE_BYTES);
+            if (required < 0) {
+                return result(Error.INVALID_REQUIREMENT, 0, 0,
+                        availableFilesBytes, availableCacheBytes);
+            }
+            Error error = availableFilesBytes >= required
+                    ? Error.NONE : Error.INSUFFICIENT_SHARED_STORE;
+            return result(error, required, 0,
+                    availableFilesBytes, availableCacheBytes);
+        }
+
+        long requiredFiles = checkedAdd(maximumExpandedBytes, RESERVE_BYTES);
+        long requiredCache = checkedAdd(archiveBytes, RESERVE_BYTES);
+        if (requiredFiles < 0 || requiredCache < 0) {
+            return result(Error.INVALID_REQUIREMENT, 0, 0,
+                    availableFilesBytes, availableCacheBytes);
+        }
+        if (availableFilesBytes < requiredFiles) {
+            return result(Error.INSUFFICIENT_FILES_STORE, requiredFiles, requiredCache,
+                    availableFilesBytes, availableCacheBytes);
+        }
+        if (availableCacheBytes < requiredCache) {
+            return result(Error.INSUFFICIENT_CACHE_STORE, requiredFiles, requiredCache,
+                    availableFilesBytes, availableCacheBytes);
+        }
+        return result(Error.NONE, requiredFiles, requiredCache,
+                availableFilesBytes, availableCacheBytes);
+    }
+
+    static Result probeFailed() {
+        return result(Error.PROBE_FAILED, 0, 0, 0, 0);
+    }
+
+    private static long checkedAdd(long left, long right) {
+        if (left < 0 || right < 0 || left > Long.MAX_VALUE - right) {
+            return -1;
+        }
+        return left + right;
+    }
+
+    private static Result result(
+            Error error,
+            long requiredFilesBytes,
+            long requiredCacheBytes,
+            long availableFilesBytes,
+            long availableCacheBytes) {
+        return new Result(error, requiredFilesBytes, requiredCacheBytes,
+                availableFilesBytes, availableCacheBytes);
+    }
+}

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindSpaceProbe.kt
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindSpaceProbe.kt
@@ -1,0 +1,24 @@
+package dev.kartpad.android
+
+import android.system.ErrnoException
+import android.system.Os
+import java.io.File
+
+/** Reads Android filesystem identity/capacity and delegates policy to the pure evaluator. */
+internal object RetroRewindSpaceProbe {
+    fun check(filesDirectory: File, cacheDirectory: File): RetroRewindSpacePreflight.Result =
+        try {
+            val sameStore =
+                Os.stat(filesDirectory.absolutePath).st_dev ==
+                    Os.stat(cacheDirectory.absolutePath).st_dev
+            RetroRewindSpacePreflight.evaluate(
+                filesDirectory.usableSpace,
+                cacheDirectory.usableSpace,
+                sameStore,
+                RetroRewindRelease.ARCHIVE_BYTES,
+                RetroRewindRelease.MAXIMUM_EXPANDED_BYTES,
+            )
+        } catch (_: ErrnoException) {
+            RetroRewindSpacePreflight.probeFailed()
+        }
+}

--- a/android/app/src/test/java/dev/kartpad/android/RetroRewindSpacePreflightTestMain.java
+++ b/android/app/src/test/java/dev/kartpad/android/RetroRewindSpacePreflightTestMain.java
@@ -1,0 +1,78 @@
+package dev.kartpad.android;
+
+public final class RetroRewindSpacePreflightTestMain {
+    private RetroRewindSpacePreflightTestMain() {}
+
+    public static void main(String[] args) {
+        long archive = 1_000;
+        long expanded = 2_000;
+        long reserve = RetroRewindSpacePreflight.RESERVE_BYTES;
+
+        var sharedReady = RetroRewindSpacePreflight.evaluate(
+                archive + expanded + reserve, 0, true, archive, expanded);
+        expect(sharedReady.isReady(), "exact shared-store capacity was rejected");
+        expect(sharedReady.requiredFilesBytes == archive + expanded + reserve,
+                "shared-store requirement is incorrect");
+        expect(sharedReady.requiredCacheBytes == 0,
+                "shared-store cache requirement should be folded into files");
+
+        expectError(
+                RetroRewindSpacePreflight.evaluate(
+                        archive + expanded + reserve - 1, Long.MAX_VALUE,
+                        true, archive, expanded),
+                RetroRewindSpacePreflight.Error.INSUFFICIENT_SHARED_STORE);
+
+        var separateReady = RetroRewindSpacePreflight.evaluate(
+                expanded + reserve, archive + reserve, false, archive, expanded);
+        expect(separateReady.isReady(), "exact separate-store capacity was rejected");
+        expect(separateReady.requiredFilesBytes == expanded + reserve,
+                "files-store requirement is incorrect");
+        expect(separateReady.requiredCacheBytes == archive + reserve,
+                "cache-store requirement is incorrect");
+
+        expectError(
+                RetroRewindSpacePreflight.evaluate(
+                        expanded + reserve - 1, Long.MAX_VALUE,
+                        false, archive, expanded),
+                RetroRewindSpacePreflight.Error.INSUFFICIENT_FILES_STORE);
+        expectError(
+                RetroRewindSpacePreflight.evaluate(
+                        Long.MAX_VALUE, archive + reserve - 1,
+                        false, archive, expanded),
+                RetroRewindSpacePreflight.Error.INSUFFICIENT_CACHE_STORE);
+
+        expectError(
+                RetroRewindSpacePreflight.evaluate(
+                        Long.MAX_VALUE, Long.MAX_VALUE, true,
+                        Long.MAX_VALUE, 1),
+                RetroRewindSpacePreflight.Error.INVALID_REQUIREMENT);
+        expectError(
+                RetroRewindSpacePreflight.evaluate(
+                        -1, 0, true, archive, expanded),
+                RetroRewindSpacePreflight.Error.INVALID_REQUIREMENT);
+        expectError(
+                RetroRewindSpacePreflight.probeFailed(),
+                RetroRewindSpacePreflight.Error.PROBE_FAILED);
+
+        var production = RetroRewindSpacePreflight.evaluate(
+                Long.MAX_VALUE, Long.MAX_VALUE, true,
+                RetroRewindRelease.ARCHIVE_BYTES,
+                RetroRewindRelease.MAXIMUM_EXPANDED_BYTES);
+        expect(production.isReady(), "production requirements overflowed");
+        expect(production.requiredFilesBytes == 4_327_477_355L,
+                "production shared-store requirement drifted");
+    }
+
+    private static void expectError(
+            RetroRewindSpacePreflight.Result result,
+            RetroRewindSpacePreflight.Error expected) {
+        expect(!result.isReady() && result.error == expected,
+                "expected " + expected + ", got " + result.error);
+    }
+
+    private static void expect(boolean condition, String message) {
+        if (!condition) {
+            throw new AssertionError(message);
+        }
+    }
+}

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -877,6 +877,13 @@ The A0 commands and sanitized result are recorded in
 [`a0-source-only-fixture.md`](artifacts/2026-09-03/android/a0-source-only-fixture.md).
 A1 evidence is under
 [`docs/artifacts/2026-09-03/android/`](artifacts/2026-09-03/android/).
+Independent A3 source work now includes generated release pins, validated
+same-volume activation/recovery, installed-content validation, and an
+overflow-safe filesystem-aware free-space preflight. The current production
+profile requires 4,327,477,355 bytes when cache and files share storage. The
+download/extraction worker is still absent, so these are tested contracts rather
+than an installed Retro Rewind runtime. Evidence is under
+[`docs/artifacts/2026-09-04/android/`](artifacts/2026-09-04/android/).
 Do not begin the touch-UI port until A2's controller-driven Original-mode proof
 passes. Physical Android hardware remains authoritative for vendor Vulkan and
 controller behavior; Retro Rewind installation and touch parity follow from

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -184,6 +184,14 @@ not block offline Retro Rewind support.
    validated production payload pin. Public/private compile configurations,
    lint, content fault tests, and package audit pass. Evidence:
    `docs/artifacts/2026-09-04/android/a3-content-validation.md`.
+   A further stacked slice adds overflow-safe Android free-space accounting and
+   probes exact filesystem device IDs to distinguish shared from separate app
+   files/cache stores. It retains a 256 MiB reserve and locks the current
+   same-store production requirement to 4,327,477,355 bytes. Direct boundary
+   tests, public build/release compilation, lint, safety, existing A3 fault
+   matrices, and package audit pass. The future download worker does not yet
+   invoke it. Evidence:
+   `docs/artifacts/2026-09-04/android/a3-space-preflight.md`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2271,3 +2271,23 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   download/free-space/ZIP extraction/worker lifecycle and runtime acceptance.
   No APK/AAB or private data was published. Evidence:
   `docs/artifacts/2026-09-04/android/a3-content-validation.md`.
+
+## 2026-09-04 — Android A3 free-space preflight
+
+- Added an overflow-safe pure Java storage evaluator and a thin Android probe
+  that uses filesystem device IDs rather than path assumptions to distinguish
+  shared app files/cache storage from separate stores.
+- The policy retains a 256 MiB reserve. Shared storage must hold archive plus
+  maximum expansion plus one reserve; separate stores independently require
+  expansion plus reserve and archive plus reserve. The exact generated 6.12.5
+  shared-store requirement is 4,327,477,355 bytes.
+- Exact-boundary, one-byte-short, invalid, overflow, probe-failure, and
+  production-drift tests pass with Java warnings treated as errors. Existing
+  content/storage matrices, 30 builder/tvOS tests, public assemble and release
+  compilation, lint, repository safety, and the strict APK audit also pass.
+- The source-only APK is 33,675,275 bytes with SHA-256
+  `700b899ed7ee22ecb87837542100427dd99ed5829b8b8d0615a50c38a3df7994`.
+- Classification: **Pass for free-space accounting and the Android capacity
+  probe.** No downloader/worker invokes it yet, and A2/A3 runtime acceptance
+  remains open. No APK/AAB or private data was published. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-space-preflight.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -295,6 +295,17 @@ tests, 22 builder tests, public debug/release compilation, lint, private game-
 configuration compile, and the strict source-only APK audit pass. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-content-validation.md`](artifacts/2026-09-04/android/a3-content-validation.md).
 
+Android now also has a pure, overflow-safe Retro Rewind free-space evaluator
+and an Android probe that compares exact filesystem device IDs before applying
+shared- or separate-store accounting. The policy retains a 256 MiB reserve and
+requires exactly 4,327,477,355 bytes for the current same-store production
+profile. Boundary/failure tests, the existing content and recovery matrices,
+30 builder/tvOS tests, public build/release compilation, lint, repository
+safety, and the strict source-only APK audit pass. No download worker calls the
+probe yet, so this is capacity-policy evidence rather than an install or runtime
+claim. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-space-preflight.md`](artifacts/2026-09-04/android/a3-space-preflight.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-04/android/a3-space-preflight.md
+++ b/docs/artifacts/2026-09-04/android/a3-space-preflight.md
@@ -1,0 +1,48 @@
+# Android A3 free-space preflight
+
+Date: 2026-09-04
+
+## Scope
+
+This source-only A3 slice adds deterministic storage-capacity accounting for a
+future Android Retro Rewind download worker. `RetroRewindSpaceProbe` obtains
+filesystem identity from `stat(2)` device IDs and capacity from Android's
+app-private files and cache directories, then delegates policy to the pure Java
+`RetroRewindSpacePreflight` evaluator.
+
+The evaluator retains a 256 MiB reserve. When files and cache share a
+filesystem, it requires the pinned archive size plus the maximum expanded size
+plus one reserve. On separate filesystems, the files store must independently
+hold the maximum expansion plus a reserve, and the cache store must hold the
+archive plus a reserve. Checked addition fails closed on overflow.
+
+For the generated 6.12.5 release contract, the same-filesystem requirement is
+exactly 4,327,477,355 bytes:
+
+- archive: 1,859,041,899 bytes
+- maximum expanded content: 2,200,000,000 bytes
+- reserve: 268,435,456 bytes
+
+## Verification
+
+- `./scripts/test-android-retro-rewind-space.sh` passes under the pinned JDK
+  with Java warnings treated as errors. It covers exact capacity boundaries,
+  one-byte shortages for shared/files/cache stores, invalid inputs, arithmetic
+  overflow, probe failure, and the exact production requirement.
+- `./scripts/test-android-retro-rewind-content.sh` passes.
+- `./scripts/test-android-retro-rewind-storage.sh` passes.
+- `PYTHONPATH=builder python3 -m unittest -q tests.test_kartpad_builder tests.test_tvos_contract`
+  passes 30 tests with one optional private-input skip.
+- Public debug assemble, release Kotlin/Java compilation, and debug lint pass
+  against the prepared pinned Dawn distribution.
+- `./scripts/audit-android-package.sh` passes for the source-only debug APK.
+  It is 33,675,275 bytes with SHA-256
+  `700b899ed7ee22ecb87837542100427dd99ed5829b8b8d0615a50c38a3df7994`.
+- Repository safety, shell syntax, and `git diff --check` pass.
+
+## Classification
+
+Pass for the Android free-space policy and Android filesystem/capacity probe.
+This is not download, extraction, worker-lifecycle, installed Retro Rewind, or
+runtime acceptance evidence: no production caller invokes the probe yet. A2
+and A3 remain open. No APK/AAB or private data was published.

--- a/scripts/test-android-retro-rewind-space.sh
+++ b/scripts/test-android-retro-rewind-space.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+# shellcheck source=android-toolchain-versions.sh
+source "${repo_root}/scripts/android-toolchain-versions.sh"
+java_home="${repo_root}/.android-bootstrap/jdk-${KARTPAD_ANDROID_JDK_VERSION}/Contents/Home"
+classes="${repo_root}/build/android-retro-rewind-space-tests"
+
+if [[ ! -x "${java_home}/bin/javac" || ! -x "${java_home}/bin/java" ]]; then
+  echo "ERROR: pinned Android JDK is unavailable; run scripts/bootstrap-android-host.sh" >&2
+  exit 1
+fi
+
+mkdir -p "${classes}"
+find "${classes}" -type f -delete
+"${java_home}/bin/javac" -Werror -Xlint:all -d "${classes}" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindRelease.java" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindSpacePreflight.java" \
+  "${repo_root}/android/app/src/test/java/dev/kartpad/android/RetroRewindSpacePreflightTestMain.java"
+"${java_home}/bin/java" -cp "${classes}" \
+  dev.kartpad.android.RetroRewindSpacePreflightTestMain
+echo "Android Retro Rewind space preflight passed."


### PR DESCRIPTION
## Summary
- add overflow-safe free-space accounting for shared and separate Android app stores
- probe exact filesystem device identity and usable capacity
- lock the current production requirement and fault boundaries in a pinned-JDK harness
- record build, lint, package-audit, and classification evidence

## Verification
- `./scripts/test-android-retro-rewind-space.sh`
- `./scripts/test-android-retro-rewind-content.sh`
- `./scripts/test-android-retro-rewind-storage.sh`
- `PYTHONPATH=builder python3 -m unittest -q tests.test_kartpad_builder tests.test_tvos_contract`
- public debug assemble, release Kotlin/Java compile, and lint
- private game-runtime debug Kotlin/Java configuration compile
- `./scripts/audit-android-package.sh android/app/build/outputs/apk/debug/app-debug.apk`
- `./scripts/check-repo-safety.sh`

This remains source-only A3 work: no downloader invokes the probe yet, and no APK/AAB or private data was published.