### PR TITLE
Add verified Android archive download

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <uses-feature android:glEsVersion="0x00030000" android:required="false" />
     <uses-feature android:name="android.hardware.vulkan.level" android:required="false" android:version="1" />
     <uses-feature android:name="android.hardware.vulkan.version" android:required="false" android:version="0x00401000" />

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindArchiveDownload.java
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindArchiveDownload.java
@@ -1,0 +1,292 @@
+package dev.kartpad.android;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/** Downloads and verifies the one profile-pinned Retro Rewind archive. */
+final class RetroRewindArchiveDownload {
+    private static final int BUFFER_BYTES = 1024 * 1024;
+    private static final int MAXIMUM_REDIRECTS = 5;
+    private static final int CONNECT_TIMEOUT_MILLIS = 30_000;
+    private static final int READ_TIMEOUT_MILLIS = 30_000;
+
+    interface Cancellation {
+        boolean isCancelled();
+    }
+
+    enum Error {
+        NONE,
+        CANCELLED,
+        INVALID_CACHE,
+        INSECURE_REDIRECT,
+        TOO_MANY_REDIRECTS,
+        HTTP_FAILURE,
+        NETWORK_FAILURE,
+        SIZE_MISMATCH,
+        HASH_MISMATCH,
+        STORAGE_FAILURE,
+    }
+
+    static final class Result {
+        final Error error;
+        final boolean reusedExisting;
+
+        Result(Error error, boolean reusedExisting) {
+            this.error = error;
+            this.reusedExisting = reusedExisting;
+        }
+
+        boolean isReady() {
+            return error == Error.NONE;
+        }
+    }
+
+    private RetroRewindArchiveDownload() {}
+
+    static Result downloadRelease(Path cacheDirectory, Cancellation cancellation) {
+        if (!isRealDirectory(cacheDirectory)) {
+            return result(Error.INVALID_CACHE, false);
+        }
+
+        Path archive = cacheDirectory.resolve(
+                "RetroRewind-" + RetroRewindRelease.VERSION + ".zip");
+        if (verifyFile(archive, RetroRewindRelease.ARCHIVE_BYTES,
+                RetroRewindRelease.ARCHIVE_SHA256) == Error.NONE) {
+            return result(Error.NONE, true);
+        }
+
+        Path partial;
+        try {
+            partial = Files.createTempFile(cacheDirectory,
+                    ".RetroRewind-" + RetroRewindRelease.VERSION + "-", ".part");
+        } catch (IOException exception) {
+            return result(Error.STORAGE_FAILURE, false);
+        }
+
+        try {
+            Result transfer = downloadPinned(partial, cancellation);
+            if (!transfer.isReady()) {
+                return transfer;
+            }
+            try {
+                Files.move(partial, archive, StandardCopyOption.ATOMIC_MOVE,
+                        StandardCopyOption.REPLACE_EXISTING);
+                return result(Error.NONE, false);
+            } catch (IOException exception) {
+                return result(Error.STORAGE_FAILURE, false);
+            }
+        } finally {
+            try {
+                Files.deleteIfExists(partial);
+            } catch (IOException ignored) {
+                // A private, unverified .part file is never treated as an archive.
+            }
+        }
+    }
+
+    private static Result downloadPinned(Path partial, Cancellation cancellation) {
+        URL current;
+        try {
+            current = new URL(RetroRewindRelease.ARCHIVE_URL);
+        } catch (IOException exception) {
+            return result(Error.NETWORK_FAILURE, false);
+        }
+
+        for (int redirects = 0; redirects <= MAXIMUM_REDIRECTS; redirects++) {
+            if (!"https".equalsIgnoreCase(current.getProtocol())) {
+                return result(Error.INSECURE_REDIRECT, false);
+            }
+
+            HttpURLConnection connection = null;
+            try {
+                connection = (HttpURLConnection) current.openConnection();
+                connection.setInstanceFollowRedirects(false);
+                connection.setConnectTimeout(CONNECT_TIMEOUT_MILLIS);
+                connection.setReadTimeout(READ_TIMEOUT_MILLIS);
+                connection.setRequestProperty("Accept-Encoding", "identity");
+                int response = connection.getResponseCode();
+                if (isRedirect(response)) {
+                    if (redirects == MAXIMUM_REDIRECTS) {
+                        return result(Error.TOO_MANY_REDIRECTS, false);
+                    }
+                    String location = connection.getHeaderField("Location");
+                    if (location == null || location.isEmpty()) {
+                        return result(Error.HTTP_FAILURE, false);
+                    }
+                    current = new URL(current, location);
+                    continue;
+                }
+                if (response != HttpURLConnection.HTTP_OK) {
+                    return result(Error.HTTP_FAILURE, false);
+                }
+                String encoding = connection.getContentEncoding();
+                if (encoding != null && !"identity".equalsIgnoreCase(encoding)) {
+                    return result(Error.HTTP_FAILURE, false);
+                }
+                long declaredBytes = connection.getContentLengthLong();
+                if (declaredBytes >= 0 && declaredBytes != RetroRewindRelease.ARCHIVE_BYTES) {
+                    return result(Error.SIZE_MISMATCH, false);
+                }
+                try (InputStream input = new BufferedInputStream(connection.getInputStream())) {
+                    Error error = transfer(input, partial, RetroRewindRelease.ARCHIVE_BYTES,
+                            RetroRewindRelease.ARCHIVE_SHA256, cancellation);
+                    return result(error, false);
+                }
+            } catch (IOException exception) {
+                return result(Error.NETWORK_FAILURE, false);
+            } finally {
+                if (connection != null) {
+                    connection.disconnect();
+                }
+            }
+        }
+        return result(Error.TOO_MANY_REDIRECTS, false);
+    }
+
+    static Error transfer(
+            InputStream input,
+            Path partial,
+            long expectedBytes,
+            String expectedSha256,
+            Cancellation cancellation) {
+        byte[] expectedDigest = decodeSha256(expectedSha256);
+        if (expectedBytes < 0 || expectedDigest == null || cancellation == null) {
+            return Error.STORAGE_FAILURE;
+        }
+
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException exception) {
+            return Error.STORAGE_FAILURE;
+        }
+
+        OutputStream openedOutput;
+        try {
+            openedOutput = Files.newOutputStream(partial,
+                    StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+        } catch (IOException exception) {
+            return Error.STORAGE_FAILURE;
+        }
+
+        long total = 0;
+        byte[] buffer = new byte[BUFFER_BYTES];
+        try (OutputStream output = openedOutput) {
+            while (true) {
+                if (cancellation.isCancelled()) {
+                    return Error.CANCELLED;
+                }
+                int count;
+                try {
+                    count = input.read(buffer);
+                } catch (IOException exception) {
+                    return Error.NETWORK_FAILURE;
+                }
+                if (count < 0) {
+                    break;
+                }
+                if (count == 0) {
+                    continue;
+                }
+                if (total > expectedBytes - count) {
+                    return Error.SIZE_MISMATCH;
+                }
+                try {
+                    output.write(buffer, 0, count);
+                } catch (IOException exception) {
+                    return Error.STORAGE_FAILURE;
+                }
+                digest.update(buffer, 0, count);
+                total += count;
+            }
+        } catch (IOException exception) {
+            return Error.STORAGE_FAILURE;
+        }
+
+        if (total != expectedBytes) {
+            return Error.SIZE_MISMATCH;
+        }
+        return MessageDigest.isEqual(digest.digest(), expectedDigest)
+                ? Error.NONE : Error.HASH_MISMATCH;
+    }
+
+    static Error verifyFile(Path path, long expectedBytes, String expectedSha256) {
+        byte[] expectedDigest = decodeSha256(expectedSha256);
+        if (!Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS) ||
+                expectedBytes < 0 || expectedDigest == null) {
+            return Error.STORAGE_FAILURE;
+        }
+        MessageDigest digest;
+        try (InputStream input = Files.newInputStream(path)) {
+            if (Files.size(path) != expectedBytes) {
+                return Error.SIZE_MISMATCH;
+            }
+            digest = MessageDigest.getInstance("SHA-256");
+            long total = 0;
+            byte[] buffer = new byte[BUFFER_BYTES];
+            while (true) {
+                int count = input.read(buffer);
+                if (count < 0) {
+                    break;
+                }
+                if (count == 0) {
+                    continue;
+                }
+                if (total > expectedBytes - count) {
+                    return Error.SIZE_MISMATCH;
+                }
+                digest.update(buffer, 0, count);
+                total += count;
+            }
+            if (total != expectedBytes) {
+                return Error.SIZE_MISMATCH;
+            }
+            return MessageDigest.isEqual(digest.digest(), expectedDigest)
+                    ? Error.NONE : Error.HASH_MISMATCH;
+        } catch (NoSuchAlgorithmException | IOException exception) {
+            return Error.STORAGE_FAILURE;
+        }
+    }
+
+    private static boolean isRealDirectory(Path path) {
+        return path != null && Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS);
+    }
+
+    private static boolean isRedirect(int response) {
+        return response == HttpURLConnection.HTTP_MOVED_PERM ||
+                response == HttpURLConnection.HTTP_MOVED_TEMP ||
+                response == HttpURLConnection.HTTP_SEE_OTHER ||
+                response == 307 || response == 308;
+    }
+
+    private static byte[] decodeSha256(String value) {
+        if (value == null || value.length() != 64) {
+            return null;
+        }
+        byte[] decoded = new byte[32];
+        for (int index = 0; index < decoded.length; index++) {
+            int high = Character.digit(value.charAt(index * 2), 16);
+            int low = Character.digit(value.charAt(index * 2 + 1), 16);
+            if (high < 0 || low < 0) {
+                return null;
+            }
+            decoded[index] = (byte) ((high << 4) | low);
+        }
+        return decoded;
+    }
+
+    private static Result result(Error error, boolean reusedExisting) {
+        return new Result(error, reusedExisting);
+    }
+}

--- a/android/app/src/test/java/dev/kartpad/android/RetroRewindArchiveDownloadTestMain.java
+++ b/android/app/src/test/java/dev/kartpad/android/RetroRewindArchiveDownloadTestMain.java
@@ -1,0 +1,144 @@
+package dev.kartpad.android;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+public final class RetroRewindArchiveDownloadTestMain {
+    private RetroRewindArchiveDownloadTestMain() {}
+
+    public static void main(String[] args) throws Exception {
+        Path directory = Files.createTempDirectory("kartpad-archive-download-");
+        try {
+            byte[] content = "verified archive fixture".getBytes(StandardCharsets.UTF_8);
+            String hash = sha256(content);
+            Path partial = directory.resolve("fixture.part");
+            Files.write(partial, new byte[0]);
+
+            expectError(transfer(content, partial, content.length, hash, () -> false),
+                    RetroRewindArchiveDownload.Error.NONE);
+            expect(java.util.Arrays.equals(content, Files.readAllBytes(partial)),
+                    "successful transfer bytes changed");
+            expectError(RetroRewindArchiveDownload.verifyFile(
+                    partial, content.length, hash), RetroRewindArchiveDownload.Error.NONE);
+
+            expectError(transfer(content, partial, content.length + 1, hash, () -> false),
+                    RetroRewindArchiveDownload.Error.SIZE_MISMATCH);
+            expectError(transfer(content, partial, content.length - 1, hash, () -> false),
+                    RetroRewindArchiveDownload.Error.SIZE_MISMATCH);
+            expectError(transfer(content, partial, content.length, "0".repeat(64), () -> false),
+                    RetroRewindArchiveDownload.Error.HASH_MISMATCH);
+
+            var cancellation = new RetroRewindArchiveDownload.Cancellation() {
+                private int probes;
+
+                @Override
+                public boolean isCancelled() {
+                    probes++;
+                    return probes > 1;
+                }
+            };
+            expectError(RetroRewindArchiveDownload.transfer(
+                    new ChunkedInputStream(content), partial,
+                    content.length, hash, cancellation),
+                    RetroRewindArchiveDownload.Error.CANCELLED);
+
+            expectError(RetroRewindArchiveDownload.transfer(
+                    new FailingInputStream(), partial, content.length, hash, () -> false),
+                    RetroRewindArchiveDownload.Error.NETWORK_FAILURE);
+
+            Path symlink = directory.resolve("archive-link");
+            try {
+                Files.createSymbolicLink(symlink, partial.getFileName());
+                expectError(RetroRewindArchiveDownload.verifyFile(
+                        symlink, content.length, hash),
+                        RetroRewindArchiveDownload.Error.STORAGE_FAILURE);
+            } catch (UnsupportedOperationException | IOException exception) {
+                // Symlink creation is not guaranteed on every host running this harness.
+            }
+        } finally {
+            try (var paths = Files.list(directory)) {
+                paths.forEach(path -> {
+                    try {
+                        Files.deleteIfExists(path);
+                    } catch (IOException exception) {
+                        throw new IllegalStateException(exception);
+                    }
+                });
+            }
+            Files.deleteIfExists(directory);
+        }
+        System.out.println("Android Retro Rewind archive download passed.");
+    }
+
+    private static RetroRewindArchiveDownload.Error transfer(
+            byte[] content,
+            Path partial,
+            long expectedBytes,
+            String expectedHash,
+            RetroRewindArchiveDownload.Cancellation cancellation) {
+        return RetroRewindArchiveDownload.transfer(
+                new ByteArrayInputStream(content), partial,
+                expectedBytes, expectedHash, cancellation);
+    }
+
+    private static String sha256(byte[] content) throws NoSuchAlgorithmException {
+        return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(content));
+    }
+
+    private static void expectError(
+            RetroRewindArchiveDownload.Error actual,
+            RetroRewindArchiveDownload.Error expected) {
+        expect(actual == expected, "expected " + expected + ", got " + actual);
+    }
+
+    private static void expect(boolean condition, String message) {
+        if (!condition) {
+            throw new AssertionError(message);
+        }
+    }
+
+    private static final class ChunkedInputStream extends InputStream {
+        private final byte[] content;
+        private int offset;
+
+        ChunkedInputStream(byte[] content) {
+            this.content = content;
+        }
+
+        @Override
+        public int read() {
+            if (offset >= content.length) {
+                return -1;
+            }
+            return content[offset++] & 0xff;
+        }
+
+        @Override
+        public int read(byte[] output, int outputOffset, int length) {
+            if (offset >= content.length) {
+                return -1;
+            }
+            output[outputOffset] = content[offset++];
+            return 1;
+        }
+    }
+
+    private static final class FailingInputStream extends InputStream {
+        @Override
+        public int read() throws IOException {
+            throw new IOException("injected network loss");
+        }
+
+        @Override
+        public int read(byte[] output, int offset, int length) throws IOException {
+            throw new IOException("injected network loss");
+        }
+    }
+}

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -884,6 +884,11 @@ profile requires 4,327,477,355 bytes when cache and files share storage. The
 download/extraction worker is still absent, so these are tested contracts rather
 than an installed Retro Rewind runtime. Evidence is under
 [`docs/artifacts/2026-09-04/android/`](artifacts/2026-09-04/android/).
+Pinned archive acquisition is also implemented as a source-only contract: it
+uses HTTPS-only bounded redirects/timeouts, exact streamed length/SHA-256,
+cancellation, verified-cache reuse, and atomic publication. INTERNET is the
+only allowed manifest permission. A worker/UI and ZIP extraction still need to
+consume these layers before A3 can claim an install.
 Do not begin the touch-UI port until A2's controller-driven Original-mode proof
 passes. Physical Android hardware remains authoritative for vendor Vulkan and
 controller behavior; Retro Rewind installation and touch parity follow from

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -192,6 +192,14 @@ not block offline Retro Rewind support.
    matrices, and package audit pass. The future download worker does not yet
    invoke it. Evidence:
    `docs/artifacts/2026-09-04/android/a3-space-preflight.md`.
+   The next layer adds HTTPS-only bounded redirects/timeouts, exact streamed
+   byte/hash verification, cancellation, verified-cache reuse, and atomic
+   publication of only a verified archive. Android now requests INTERNET and
+   the package audit enforces it as the sole permission. Direct fault tests,
+   earlier A3 matrices, public/private compilation, API-28 lint, package audit,
+   and safety pass. No worker/UI calls this downloader and the production
+   archive was not fetched. Evidence:
+   `docs/artifacts/2026-09-04/android/a3-archive-download.md`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2291,3 +2291,27 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   probe.** No downloader/worker invokes it yet, and A2/A3 runtime acceptance
   remains open. No APK/AAB or private data was published. Evidence:
   `docs/artifacts/2026-09-04/android/a3-space-preflight.md`.
+
+## 2026-09-04 — Android A3 pinned archive download
+
+- Added a pinned HTTPS archive owner with at most five secure redirects,
+  bounded timeouts, identity encoding, declared/exact byte checks, streamed
+  SHA-256, cancellation, verified-cache reuse, and same-directory atomic
+  publication. Unverified partial bytes are never promoted.
+- Added INTERNET as Android's sole manifest permission and changed the package
+  audit to require that exact allowlist. Any additional permission fails.
+- The first lint run rejected the host-Java `HexFormat` API because it requires
+  Android API 34. The replacement uses API-28-safe digest decoding/comparison;
+  the complete compile/lint rerun passes.
+- Warning-as-error transfer tests cover exact content, existing revalidation,
+  short/long streams, wrong hash, cancellation, injected network loss, and a
+  symlink. Earlier A3 matrices, 30 builder/tvOS tests, public assemble/release
+  compilation, private source configuration, package audit, shell/diff checks,
+  and repository safety pass.
+- The source-only APK is 33,675,275 bytes with SHA-256
+  `88129b305de90f0588cbd93978ede89fc061010b2420f3beb344522607052b65`.
+- Classification: **Pass for pinned acquisition and verified atomic cache
+  publication contracts.** No worker/UI invokes it, the production archive was
+  not downloaded, and ZIP extraction/process-death/runtime acceptance remain
+  open. No APK/AAB or private data was published. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-archive-download.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -306,6 +306,16 @@ probe yet, so this is capacity-policy evidence rather than an install or runtime
 claim. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-space-preflight.md`](artifacts/2026-09-04/android/a3-space-preflight.md).
 
+The next A3 layer adds pinned HTTPS archive acquisition with bounded redirects,
+timeouts, identity encoding, exact length/SHA-256 verification, cancellation,
+existing-cache revalidation, and atomic publication of only verified bytes.
+The manifest requests only INTERNET, and the package audit now enforces that
+exact permission set. Transfer faults, all earlier A3 contracts, public/private
+source configurations, API-28 lint, builder/tvOS tests, package/privacy audit,
+and repository safety pass. The production archive was not downloaded, and no
+worker or UI calls the downloader yet. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-archive-download.md`](artifacts/2026-09-04/android/a3-archive-download.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-04/android/a3-archive-download.md
+++ b/docs/artifacts/2026-09-04/android/a3-archive-download.md
@@ -1,0 +1,60 @@
+# Android A3 pinned archive download
+
+Date: 2026-09-04
+
+## Scope
+
+This source-only A3 slice adds acquisition of the sole profile-pinned Retro
+Rewind archive. The Android owner accepts only HTTPS, follows at most five
+HTTPS redirects, requests identity transfer encoding, applies 30-second connect
+and read timeouts, and requires an HTTP 200 response. A declared content length,
+when present, must match the generated archive byte count.
+
+The response is streamed through a 1 MiB buffer into a uniquely created
+app-cache partial file. The stream cannot exceed the pinned byte count and must
+finish at that exact count with the pinned SHA-256. Cancellation is checked
+between reads. Only a verified result is atomically moved to the stable cache
+name; failures and cancellation never promote the partial file. An existing
+regular, non-symlink archive is reused only after the same exact size/hash
+verification.
+
+The manifest now declares only `android.permission.INTERNET`. The package audit
+was narrowed from “no permissions” to an exact one-permission allowlist, so any
+additional Android permission still fails closed.
+
+## Verification
+
+- The pinned-JDK warning-as-error transfer harness passes exact content,
+  persisted bytes, existing-file revalidation, short/long input, mismatched
+  hash, cancellation, injected read/network loss, and symlink rejection.
+- The earlier space, installed-content, and atomic storage/recovery matrices
+  pass unchanged.
+- Public debug assemble, release Kotlin/Java compilation, and lint pass at API
+  28 compatibility. The first lint run correctly rejected Java `HexFormat`
+  (Android API 34); the implementation now decodes the expected digest without
+  that API and the rerun passes.
+- Private game-runtime debug Kotlin/Java configuration compilation passes. No
+  private APK was rebuilt or installed.
+- All 30 builder/tvOS tests pass with one optional private-input skip, and the
+  repository safety audit passes.
+- The exact source-only APK is 33,675,275 bytes with SHA-256
+  `88129b305de90f0588cbd93978ede89fc061010b2420f3beb344522607052b65`.
+  ABI, alignment, native dependencies, assets, privacy, and the exact INTERNET-
+  only permission allowlist pass the package audit.
+
+Source SHA-256 values:
+
+- downloader: `f40e0e98cb9f5ee3184721051c35526f338c83ea323d11961bb280fff52f5c30`
+- transfer test: `40f83767851e4fbd993cbcaa2274439b9a7b76316c759c6543f51e6f3c931b95`
+- test runner: `1b245dd476b477aa01b4882f5f715eed92ab07a53da196bdec3a69dcd9960197`
+- manifest: `02b23d4dd38bede5180889b5e8f2137c47a3de56157894db4bd6072b924e4fc9`
+- package audit: `35b6cb7a90a56f311b41f28c77327a2cff649adbfdf22e11db494a6f5d4cbe37`
+
+## Classification
+
+Pass for pinned HTTPS acquisition, bounded transfer verification, cancellation,
+and atomic cache publication contracts. The 1.86 GB production archive was not
+downloaded in this source-only test. No worker/UI invokes the downloader yet;
+ZIP extraction, durable worker lifecycle/progress, process-death cleanup, and
+Retro Rewind runtime acceptance remain open. No APK/AAB or private data was
+published.

--- a/scripts/audit-android-package.sh
+++ b/scripts/audit-android-package.sh
@@ -22,8 +22,10 @@ badging="$("$aapt2" dump badging "$apk")"
 [[ "$badging" == *"targetSdkVersion:'36'"* ]]
 [[ "$badging" == *"native-code: 'arm64-v8a'"* ]]
 permissions="$("$aapt2" dump permissions "$apk")"
-if [[ "$permissions" == *"uses-permission:"* ]]; then
-  echo "ERROR: KartPad Android package unexpectedly requests a permission" >&2
+permission_names="$(printf '%s\n' "$permissions" |
+  sed -n "s/^uses-permission: name='\([^']*\)'.*$/\1/p" | sort)"
+if [[ "$permission_names" != "android.permission.INTERNET" ]]; then
+  echo "ERROR: KartPad Android permission set differs from the network-only allowlist" >&2
   exit 1
 fi
 

--- a/scripts/test-android-retro-rewind-download.sh
+++ b/scripts/test-android-retro-rewind-download.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+# shellcheck source=android-toolchain-versions.sh
+source "${repo_root}/scripts/android-toolchain-versions.sh"
+java_home="${repo_root}/.android-bootstrap/jdk-${KARTPAD_ANDROID_JDK_VERSION}/Contents/Home"
+classes="${repo_root}/build/android-retro-rewind-download-tests"
+
+if [[ ! -x "${java_home}/bin/javac" || ! -x "${java_home}/bin/java" ]]; then
+  echo "ERROR: pinned Android JDK is unavailable; run scripts/bootstrap-android-host.sh" >&2
+  exit 1
+fi
+
+mkdir -p "${classes}"
+find "${classes}" -type f -delete
+"${java_home}/bin/javac" -Werror -Xlint:all -d "${classes}" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindRelease.java" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindArchiveDownload.java" \
+  "${repo_root}/android/app/src/test/java/dev/kartpad/android/RetroRewindArchiveDownloadTestMain.java"
+"${java_home}/bin/java" -cp "${classes}" \
+  dev.kartpad.android.RetroRewindArchiveDownloadTestMain


### PR DESCRIPTION
## Summary
- add HTTPS-only pinned Retro Rewind archive acquisition with bounded redirects and timeouts
- stream into a unique partial file with exact byte/SHA-256 checks, cancellation, and atomic publication
- revalidate existing cached archives and reject symlinks
- allow exactly the INTERNET manifest permission and enforce it in the APK audit

## Verification
- warning-as-error transfer fault matrix
- all earlier Android A3 contract tests
- public debug assemble, release Kotlin/Java compile, and API-28 lint
- private game-runtime debug Kotlin/Java configuration compile
- 30 builder/tvOS tests (one optional private-input skip)
- source-only APK/privacy/permission audit and repository safety

The production archive was not downloaded. No worker/UI invokes this layer yet, and no APK/AAB or private data was published.