### PR TITLE
Add bounded Android archive extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ DerivedData/
 
 # Android machine-local state and build products
 /android/.gradle/
+/android/.kotlin/
 /android/local.properties
 /android/**/build/
 /android/**/.cxx/

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 val dawnAndroidRoot = providers.environmentVariable("DAWN_ANDROID_ROOT")
+val minizipAndroidRoot = providers.environmentVariable("MINIZIP_ANDROID_ROOT")
 val gameRuntimeSource = providers.gradleProperty("kartpadGameRuntimeSource").orNull
 val translatedShardManifest = providers.gradleProperty("kartpadTranslatedShardManifest").orNull
 
@@ -31,6 +32,7 @@ android {
                 arguments += listOf(
                     "-DANDROID_STL=c++_shared",
                     "-DDAWN_ANDROID_ROOT=${dawnAndroidRoot.get()}",
+                    "-DMINIZIP_ANDROID_ROOT=${minizipAndroidRoot.get()}",
                 )
                 if (gameRuntimeSource != null || translatedShardManifest != null) {
                     require(gameRuntimeSource != null && translatedShardManifest != null) {

--- a/android/app/src/main/assets/ThirdPartyLicenses/Minizip-NG.txt
+++ b/android/app/src/main/assets/ThirdPartyLicenses/Minizip-NG.txt
@@ -1,0 +1,17 @@
+Condition of use and distribution are the same as zlib:
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgement in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.

--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -7,6 +7,10 @@ endif()
 if(NOT DEFINED DAWN_ANDROID_ROOT OR DAWN_ANDROID_ROOT STREQUAL "")
   message(FATAL_ERROR "DAWN_ANDROID_ROOT must name the prepared pinned Dawn package")
 endif()
+if(NOT DEFINED MINIZIP_ANDROID_ROOT OR MINIZIP_ANDROID_ROOT STREQUAL "" OR
+   NOT EXISTS "${MINIZIP_ANDROID_ROOT}/CMakeLists.txt")
+  message(FATAL_ERROR "MINIZIP_ANDROID_ROOT must name the prepared pinned minizip-ng source")
+endif()
 
 find_package(Threads REQUIRED)
 find_package(SDL3 REQUIRED CONFIG)
@@ -20,6 +24,24 @@ endif()
 
 get_filename_component(KARTPAD_REPO_ROOT
   "${CMAKE_CURRENT_LIST_DIR}/../../../../.." ABSOLUTE)
+
+set(MZ_COMPAT OFF CACHE BOOL "" FORCE)
+set(MZ_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(MZ_BUILD_UNIT_TESTS OFF CACHE BOOL "" FORCE)
+set(MZ_BUILD_FUZZ_TESTS OFF CACHE BOOL "" FORCE)
+set(MZ_CODE_COVERAGE OFF CACHE BOOL "" FORCE)
+set(MZ_FETCH_LIBS OFF CACHE BOOL "" FORCE)
+set(MZ_BZIP2 OFF CACHE BOOL "" FORCE)
+set(MZ_LZMA OFF CACHE BOOL "" FORCE)
+set(MZ_ZSTD OFF CACHE BOOL "" FORCE)
+set(MZ_PKCRYPT OFF CACHE BOOL "" FORCE)
+set(MZ_WZAES OFF CACHE BOOL "" FORCE)
+set(MZ_OPENSSL OFF CACHE BOOL "" FORCE)
+set(MZ_LIBBSD OFF CACHE BOOL "" FORCE)
+set(MZ_ICONV OFF CACHE BOOL "" FORCE)
+set(MZ_DECOMPRESS_ONLY ON CACHE BOOL "" FORCE)
+set(SKIP_INSTALL_ALL ON CACHE BOOL "" FORCE)
+add_subdirectory("${MINIZIP_ANDROID_ROOT}" minizip-ng EXCLUDE_FROM_ALL)
 
 set(KARTPAD_GAME_RUNTIME_SOURCE "" CACHE PATH
   "Prepared private WiiCompiled source; empty builds the source-only fixture")
@@ -47,18 +69,31 @@ if(KARTPAD_GAME_RUNTIME_SOURCE)
   set(MKW_KARTPAD_REPO_ROOT "${KARTPAD_REPO_ROOT}" CACHE PATH "" FORCE)
   set(MKW_TRANSLATED_COMPILE_JOBS 2 CACHE STRING "" FORCE)
   add_subdirectory("${KARTPAD_GAME_RUNTIME_SOURCE}" game-runtime)
+  target_sources(WiiCompiled PRIVATE
+    retro_rewind_archive_jni.cpp
+    "${KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_extract.cpp"
+    "${KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_path.cpp"
+    "${KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_scan.cpp")
+  target_include_directories(WiiCompiled PRIVATE
+    "${KARTPAD_REPO_ROOT}/runtime/include")
+  target_link_libraries(WiiCompiled PRIVATE MINIZIP::minizip)
 else()
   add_library(main SHARED
     fixture_main.cpp
     guest_memory_fixture.cpp
     scheduler_fixture.cpp
     fiber_switch_android.S
-    "${KARTPAD_REPO_ROOT}/runtime/src/scheduler/guest_scheduler.cpp")
+    retro_rewind_archive_jni.cpp
+    "${KARTPAD_REPO_ROOT}/runtime/src/scheduler/guest_scheduler.cpp"
+    "${KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_extract.cpp"
+    "${KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_path.cpp"
+    "${KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_scan.cpp")
   target_compile_features(main PRIVATE cxx_std_20)
   target_compile_options(main PRIVATE -Wall -Wextra -Werror -fvisibility=hidden)
   target_include_directories(main PRIVATE
     "${KARTPAD_REPO_ROOT}/runtime/include")
-  target_link_libraries(main PRIVATE SDL3::SDL3 dawn::webgpu_dawn android log dl)
+  target_link_libraries(main PRIVATE SDL3::SDL3 dawn::webgpu_dawn
+    MINIZIP::minizip android log dl)
 
   set_target_properties(main PROPERTIES
     CXX_VISIBILITY_PRESET hidden

--- a/android/app/src/main/cpp/retro_rewind_archive_jni.cpp
+++ b/android/app/src/main/cpp/retro_rewind_archive_jni.cpp
@@ -1,0 +1,116 @@
+#include "kartpad/retro_rewind/archive_extract.h"
+
+#include <jni.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace {
+
+class UtfChars {
+ public:
+  UtfChars(JNIEnv* environment, jstring value)
+      : environment_(environment), value_(value) {
+    if (value_ != nullptr) chars_ = environment_->GetStringUTFChars(value_, nullptr);
+  }
+  ~UtfChars() {
+    if (chars_ != nullptr) environment_->ReleaseStringUTFChars(value_, chars_);
+  }
+  UtfChars(const UtfChars&) = delete;
+  UtfChars& operator=(const UtfChars&) = delete;
+  const char* get() const { return chars_; }
+
+ private:
+  JNIEnv* environment_;
+  jstring value_;
+  const char* chars_ = nullptr;
+};
+
+struct JavaCallbacks {
+  JNIEnv* environment = nullptr;
+  jobject cancellation = nullptr;
+  jobject progress = nullptr;
+  jmethodID is_cancelled = nullptr;
+  jmethodID on_progress = nullptr;
+};
+
+bool IsCancelled(void* opaque) {
+  auto* callbacks = static_cast<JavaCallbacks*>(opaque);
+  if (callbacks->environment->ExceptionCheck()) return true;
+  const jboolean cancelled = callbacks->environment->CallBooleanMethod(
+      callbacks->cancellation, callbacks->is_cancelled);
+  return callbacks->environment->ExceptionCheck() || cancelled == JNI_TRUE;
+}
+
+void ReportProgress(void* opaque, const std::uint64_t extracted,
+                    const std::uint64_t total) {
+  auto* callbacks = static_cast<JavaCallbacks*>(opaque);
+  if (callbacks->environment->ExceptionCheck()) return;
+  callbacks->environment->CallVoidMethod(
+      callbacks->progress, callbacks->on_progress,
+      static_cast<jlong>(extracted), static_cast<jlong>(total));
+}
+
+}  // namespace
+
+extern "C" JNIEXPORT jint JNICALL
+Java_dev_kartpad_android_RetroRewindArchiveExtractor_nativeExtract(
+    JNIEnv* environment, jclass, jstring archive_path, jstring staging_directory,
+    jstring expected_root, jint maximum_entries, jlong maximum_expanded_bytes,
+    jobject cancellation, jobject progress, jlongArray counts) {
+  if (archive_path == nullptr || staging_directory == nullptr ||
+      expected_root == nullptr || maximum_entries <= 0 ||
+      maximum_expanded_bytes <= 0 || cancellation == nullptr || progress == nullptr ||
+      counts == nullptr || environment->GetArrayLength(counts) != 3) {
+    return static_cast<jint>(
+        kartpad::retro_rewind::ArchiveExtractError::InvalidArgument);
+  }
+
+  jclass cancellation_class = environment->GetObjectClass(cancellation);
+  jclass progress_class = environment->GetObjectClass(progress);
+  if (cancellation_class == nullptr || progress_class == nullptr) {
+    if (cancellation_class != nullptr) environment->DeleteLocalRef(cancellation_class);
+    if (progress_class != nullptr) environment->DeleteLocalRef(progress_class);
+    return static_cast<jint>(
+        kartpad::retro_rewind::ArchiveExtractError::InvalidArgument);
+  }
+  JavaCallbacks callbacks{
+      .environment = environment,
+      .cancellation = cancellation,
+      .progress = progress,
+      .is_cancelled = environment->GetMethodID(cancellation_class, "isCancelled", "()Z"),
+      .on_progress = environment->GetMethodID(progress_class, "onProgress", "(JJ)V"),
+  };
+  environment->DeleteLocalRef(cancellation_class);
+  environment->DeleteLocalRef(progress_class);
+  if (environment->ExceptionCheck() || callbacks.is_cancelled == nullptr ||
+      callbacks.on_progress == nullptr) {
+    return static_cast<jint>(
+        kartpad::retro_rewind::ArchiveExtractError::InvalidArgument);
+  }
+
+  UtfChars archive{environment, archive_path};
+  UtfChars staging{environment, staging_directory};
+  UtfChars root{environment, expected_root};
+  if (archive.get() == nullptr || staging.get() == nullptr || root.get() == nullptr) {
+    return static_cast<jint>(
+        kartpad::retro_rewind::ArchiveExtractError::InvalidArgument);
+  }
+
+  const auto result = kartpad::retro_rewind::ExtractArchive(
+      archive.get(), staging.get(), root.get(),
+      static_cast<std::size_t>(maximum_entries),
+      static_cast<std::uint64_t>(maximum_expanded_bytes),
+      {.context = &callbacks,
+       .cancelled = IsCancelled,
+       .progress = ReportProgress});
+  if (!environment->ExceptionCheck()) {
+    const jlong values[] = {
+        static_cast<jlong>(result.selected_entries),
+        static_cast<jlong>(result.selected_bytes),
+        static_cast<jlong>(result.extracted_bytes),
+    };
+    environment->SetLongArrayRegion(counts, 0, 3, values);
+  }
+  return static_cast<jint>(result.error);
+}

--- a/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
@@ -6,6 +6,9 @@ import android.system.Os
 import android.util.Log
 import android.view.ViewGroup
 import java.io.File
+import java.io.FileOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 import org.libsdl.app.SDLActivity
 import org.libsdl.app.SDLSurface
 
@@ -22,6 +25,7 @@ class KartPadActivity : SDLActivity() {
             configureDebugStateTrace()
         }
         super.onCreate(savedInstanceState)
+        runDebugRetroRewindExtractionFixture()
         val overlay = KartPadOverlayView(this)
         mLayout.addView(
             overlay,
@@ -85,6 +89,44 @@ class KartPadActivity : SDLActivity() {
         }
     }
 
+    private fun runDebugRetroRewindExtractionFixture() {
+        if (!BuildConfig.DEBUG || BuildConfig.GAME_RUNTIME ||
+            !intent.getBooleanExtra(DEBUG_EXTRA_RETRO_REWIND_EXTRACTION, false)
+        ) {
+            return
+        }
+        val temporary = File(cacheDir, "RetroRewindExtractionFixture-${System.nanoTime()}")
+        try {
+            val staging = File(temporary, "stage")
+            check(staging.mkdirs())
+            val archive = File(temporary, "fixture.zip")
+            ZipOutputStream(FileOutputStream(archive)).use { zip ->
+                zip.putNextEntry(ZipEntry("${RetroRewindRelease.ROOT}/"))
+                zip.closeEntry()
+                zip.putNextEntry(ZipEntry("${RetroRewindRelease.ROOT}/version.txt"))
+                zip.write("${RetroRewindRelease.VERSION}\n".toByteArray(Charsets.UTF_8))
+                zip.closeEntry()
+            }
+            val result = RetroRewindArchiveExtractor.extract(
+                archive.toPath(),
+                staging.toPath(),
+                { false },
+                { _, _ -> },
+            )
+            val extracted = File(staging, "${RetroRewindRelease.ROOT}/version.txt")
+                .readText(Charsets.UTF_8)
+            check(result.isComplete() && result.selectedEntries == 2L &&
+                result.selectedBytes == extracted.toByteArray(Charsets.UTF_8).size.toLong() &&
+                result.extractedBytes == result.selectedBytes &&
+                extracted == "${RetroRewindRelease.VERSION}\n")
+            Log.i(TAG, "A3 JNI archive extraction passed entries=2 bytes=${result.extractedBytes}")
+        } catch (error: Exception) {
+            Log.e(TAG, "A3 JNI archive extraction failed", error)
+        } finally {
+            temporary.deleteRecursively()
+        }
+    }
+
     companion object {
         private const val TAG = "KartPadFixture"
         private const val DEBUG_RKG_RELATIVE_PATH = "KartPad/Diagnostics/TestInput.rkg"
@@ -94,6 +136,8 @@ class KartPadActivity : SDLActivity() {
             "KartPad/Diagnostics/StateTrace.enable"
         private const val DEBUG_STATE_TRACE_RELATIVE_PATH =
             "KartPad/Diagnostics/StateTrace.csv"
+        private const val DEBUG_EXTRA_RETRO_REWIND_EXTRACTION =
+            "dev.kartpad.android.TEST_RETRO_REWIND_EXTRACTION"
         private const val MIN_RKG_BYTES = 0x90L
         private const val MAX_RKG_BYTES = 1024L * 1024L
         private val RKG_MAGIC = byteArrayOf('R'.code.toByte(), 'K'.code.toByte(), 'G'.code.toByte(), 'D'.code.toByte())

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindArchiveExtractor.java
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindArchiveExtractor.java
@@ -1,0 +1,93 @@
+package dev.kartpad.android;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+
+/** Android owner for bounded native Retro Rewind ZIP extraction. */
+final class RetroRewindArchiveExtractor {
+    private static final int MAXIMUM_ENTRIES = 10_000;
+
+    interface Cancellation {
+        boolean isCancelled();
+    }
+
+    interface Progress {
+        void onProgress(long extractedBytes, long totalBytes);
+    }
+
+    enum Error {
+        NONE,
+        CANCELLED,
+        INVALID_ARGUMENT,
+        OPEN_FAILED,
+        MALFORMED_ARCHIVE,
+        UNSUPPORTED_ENTRY,
+        DUPLICATE_ENTRY,
+        LIMIT_EXCEEDED,
+        MISSING_ROOT,
+        IO_FAILURE,
+    }
+
+    static final class Result {
+        final Error error;
+        final long selectedEntries;
+        final long selectedBytes;
+        final long extractedBytes;
+
+        Result(Error error, long[] counts) {
+            this.error = error;
+            selectedEntries = counts[0];
+            selectedBytes = counts[1];
+            extractedBytes = counts[2];
+        }
+
+        boolean isComplete() {
+            return error == Error.NONE;
+        }
+    }
+
+    private RetroRewindArchiveExtractor() {}
+
+    static Result extract(
+            Path archive,
+            Path stagingDirectory,
+            Cancellation cancellation,
+            Progress progress) throws IOException {
+        if (!Files.isRegularFile(archive, LinkOption.NOFOLLOW_LINKS) ||
+                !Files.isDirectory(stagingDirectory, LinkOption.NOFOLLOW_LINKS) ||
+                cancellation == null || progress == null) {
+            throw new IOException("Retro Rewind extraction input is invalid");
+        }
+        Path root = stagingDirectory.resolve(RetroRewindRelease.ROOT);
+        if (Files.exists(root, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Retro Rewind extraction destination is not empty");
+        }
+
+        long[] counts = new long[3];
+        int code = nativeExtract(
+                archive.toAbsolutePath().toString(),
+                stagingDirectory.toAbsolutePath().toString(),
+                RetroRewindRelease.ROOT,
+                MAXIMUM_ENTRIES,
+                RetroRewindRelease.MAXIMUM_EXPANDED_BYTES,
+                cancellation,
+                progress,
+                counts);
+        Error[] errors = Error.values();
+        Error error = code >= 0 && code < errors.length
+                ? errors[code] : Error.IO_FAILURE;
+        return new Result(error, counts);
+    }
+
+    private static native int nativeExtract(
+            String archivePath,
+            String stagingDirectory,
+            String expectedRoot,
+            int maximumEntries,
+            long maximumExpandedBytes,
+            Cancellation cancellation,
+            Progress progress,
+            long[] counts);
+}

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallPipeline.java
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallPipeline.java
@@ -1,0 +1,136 @@
+package dev.kartpad.android;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+/** Joins verified archive input, bounded extraction, validation, and activation. */
+final class RetroRewindInstallPipeline {
+    @FunctionalInterface
+    interface ArchiveVerifier {
+        RetroRewindArchiveDownload.Error verify(Path archive);
+    }
+
+    @FunctionalInterface
+    interface Extractor {
+        RetroRewindArchiveExtractor.Result extract(
+                Path archive,
+                Path staging,
+                RetroRewindArchiveExtractor.Cancellation cancellation,
+                RetroRewindArchiveExtractor.Progress progress) throws IOException;
+    }
+
+    enum Error {
+        NONE,
+        ARCHIVE_INVALID,
+        STAGING_FAILURE,
+        EXTRACTION_FAILURE,
+        CONTENT_INVALID,
+        ACTIVATION_FAILURE,
+    }
+
+    static final class Result {
+        final Error error;
+        final RetroRewindArchiveExtractor.Error extractionError;
+        final RetroRewindInstallValidator.Error validationError;
+
+        Result(
+                Error error,
+                RetroRewindArchiveExtractor.Error extractionError,
+                RetroRewindInstallValidator.Error validationError) {
+            this.error = error;
+            this.extractionError = extractionError;
+            this.validationError = validationError;
+        }
+
+        boolean isInstalled() {
+            return error == Error.NONE;
+        }
+    }
+
+    private RetroRewindInstallPipeline() {}
+
+    static Result install(
+            File filesDirectory,
+            Path archive,
+            String token,
+            RetroRewindArchiveExtractor.Cancellation cancellation,
+            RetroRewindArchiveExtractor.Progress progress) {
+        return install(
+                filesDirectory,
+                archive,
+                token,
+                cancellation,
+                progress,
+                path -> RetroRewindArchiveDownload.verifyFile(
+                        path,
+                        RetroRewindRelease.ARCHIVE_BYTES,
+                        RetroRewindRelease.ARCHIVE_SHA256),
+                RetroRewindArchiveExtractor::extract,
+                RetroRewindInstallValidator.productionContract());
+    }
+
+    static Result install(
+            File filesDirectory,
+            Path archive,
+            String token,
+            RetroRewindArchiveExtractor.Cancellation cancellation,
+            RetroRewindArchiveExtractor.Progress progress,
+            ArchiveVerifier verifier,
+            Extractor extractor,
+            RetroRewindInstallValidator.Contract contract) {
+        if (filesDirectory == null || archive == null || cancellation == null ||
+                progress == null || verifier == null || extractor == null || contract == null) {
+            return failed(Error.STAGING_FAILURE, null, null);
+        }
+        if (verifier.verify(archive) != RetroRewindArchiveDownload.Error.NONE) {
+            return failed(Error.ARCHIVE_INVALID, null, null);
+        }
+
+        Path staging = null;
+        boolean activated = false;
+        try {
+            staging = RetroRewindInstallStorage.createStagingDirectory(filesDirectory, token);
+        } catch (IOException | IllegalArgumentException exception) {
+            return failed(Error.STAGING_FAILURE, null, null);
+        }
+        try {
+            RetroRewindArchiveExtractor.Result extraction;
+            try {
+                extraction = extractor.extract(archive, staging, cancellation, progress);
+            } catch (IOException exception) {
+                return failed(Error.EXTRACTION_FAILURE,
+                        RetroRewindArchiveExtractor.Error.IO_FAILURE, null);
+            }
+            if (!extraction.isComplete()) {
+                return failed(Error.EXTRACTION_FAILURE, extraction.error, null);
+            }
+            RetroRewindInstallValidator.Result validation =
+                    RetroRewindInstallValidator.validateAndActivate(
+                            filesDirectory, staging, token, contract);
+            if (!validation.isValid()) {
+                Error error = validation.error == RetroRewindInstallValidator.Error.IO_ERROR
+                        ? Error.ACTIVATION_FAILURE : Error.CONTENT_INVALID;
+                return failed(error, extraction.error, validation.error);
+            }
+            activated = true;
+            return failed(Error.NONE, extraction.error, validation.error);
+        } finally {
+            if (!activated && staging != null) {
+                try {
+                    RetroRewindInstallStorage.discardStagingDirectory(
+                            filesDirectory, staging, token);
+                } catch (IOException | IllegalArgumentException ignored) {
+                    // Startup recovery retries cleanup without risking active data.
+                }
+            }
+        }
+    }
+
+    private static Result failed(
+            Error error,
+            RetroRewindArchiveExtractor.Error extractionError,
+            RetroRewindInstallValidator.Error validationError) {
+        return new Result(error, extractionError, validationError);
+    }
+}

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallStorage.java
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallStorage.java
@@ -72,6 +72,22 @@ final class RetroRewindInstallStorage {
                 RetroRewindInstallStorage::atomicMove);
     }
 
+    static void discardStagingDirectory(File filesDirectory, Path staging, String token)
+            throws IOException {
+        requireToken(token);
+        Path support = supportRoot(filesDirectory).toAbsolutePath().normalize();
+        requireDirectory(support, "Retro Rewind support root is invalid");
+        Path expectedStaging = support.resolve(STAGING_PREFIX + token);
+        Path normalizedStaging = staging.toAbsolutePath().normalize();
+        if (!normalizedStaging.equals(expectedStaging)) {
+            throw new IOException("Retro Rewind staging directory is invalid");
+        }
+        if (exists(normalizedStaging)) {
+            requireDirectory(normalizedStaging, "Retro Rewind staging directory is invalid");
+            deleteTree(normalizedStaging);
+        }
+    }
+
     static void activateValidatedStaging(
             File filesDirectory, Path staging, String token, AtomicMover mover)
             throws IOException {

--- a/android/app/src/test/java/dev/kartpad/android/RetroRewindInstallPipelineTestMain.java
+++ b/android/app/src/test/java/dev/kartpad/android/RetroRewindInstallPipelineTestMain.java
@@ -1,0 +1,129 @@
+package dev.kartpad.android;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+
+public final class RetroRewindInstallPipelineTestMain {
+    private RetroRewindInstallPipelineTestMain() {}
+
+    public static void main(String[] args) throws Exception {
+        Path temporary = Files.createTempDirectory("kartpad-install-pipeline-");
+        try {
+            Path files = Files.createDirectory(temporary.resolve("files"));
+            Path archive = Files.write(temporary.resolve("archive.zip"), new byte[] {1});
+            byte[] artifact = "verified".getBytes(StandardCharsets.UTF_8);
+            var contract = new RetroRewindInstallValidator.Contract(
+                    RetroRewindRelease.VERSION,
+                    RetroRewindRelease.ROOT,
+                    List.of(new RetroRewindInstallValidator.ArtifactRequirement(
+                            "Binaries/Code.pul", artifact.length, sha256(artifact))));
+
+            var success = RetroRewindInstallPipeline.install(
+                    files.toFile(), archive, "success", () -> false, (done, total) -> {},
+                    path -> RetroRewindArchiveDownload.Error.NONE,
+                    (path, staging, cancellation, progress) -> {
+                        writeTree(staging, artifact);
+                        progress.onProgress(artifact.length, artifact.length);
+                        return extraction(RetroRewindArchiveExtractor.Error.NONE,
+                                artifact.length);
+                    },
+                    contract);
+            expect(success.isInstalled(), "valid extracted tree was not installed");
+            Path installed = files.resolve("KartPad/RetroRewind/RetroRewind6");
+            expect(Files.readString(installed.resolve("Binaries/Code.pul"))
+                            .equals("verified"),
+                    "activated content changed");
+
+            var extractionFailure = RetroRewindInstallPipeline.install(
+                    files.toFile(), archive, "cancel", () -> true, (done, total) -> {},
+                    path -> RetroRewindArchiveDownload.Error.NONE,
+                    (path, staging, cancellation, progress) ->
+                            extraction(RetroRewindArchiveExtractor.Error.CANCELLED, 0),
+                    contract);
+            expect(extractionFailure.error ==
+                            RetroRewindInstallPipeline.Error.EXTRACTION_FAILURE &&
+                            extractionFailure.extractionError ==
+                                    RetroRewindArchiveExtractor.Error.CANCELLED,
+                    "cancellation was not preserved");
+            expect(!Files.exists(files.resolve("KartPad/RetroRewind.import-cancel")),
+                    "cancelled staging was not discarded");
+            expect(Files.exists(installed), "cancellation removed active content");
+
+            var invalidContent = RetroRewindInstallPipeline.install(
+                    files.toFile(), archive, "invalid", () -> false, (done, total) -> {},
+                    path -> RetroRewindArchiveDownload.Error.NONE,
+                    (path, staging, cancellation, progress) -> {
+                        writeTree(staging, "wrong".getBytes(StandardCharsets.UTF_8));
+                        return extraction(RetroRewindArchiveExtractor.Error.NONE, 5);
+                    },
+                    contract);
+            expect(invalidContent.error == RetroRewindInstallPipeline.Error.CONTENT_INVALID,
+                    "invalid extracted content was not rejected");
+            expect(!Files.exists(files.resolve("KartPad/RetroRewind.import-invalid")),
+                    "invalid staging was not discarded");
+            expect(Files.readString(installed.resolve("Binaries/Code.pul"))
+                            .equals("verified"),
+                    "invalid content replaced active installation");
+
+            final boolean[] extracted = {false};
+            var invalidArchive = RetroRewindInstallPipeline.install(
+                    files.toFile(), archive, "bad-archive", () -> false,
+                    (done, total) -> {},
+                    path -> RetroRewindArchiveDownload.Error.HASH_MISMATCH,
+                    (path, staging, cancellation, progress) -> {
+                        extracted[0] = true;
+                        return extraction(RetroRewindArchiveExtractor.Error.NONE, 0);
+                    },
+                    contract);
+            expect(invalidArchive.error == RetroRewindInstallPipeline.Error.ARCHIVE_INVALID,
+                    "invalid archive was accepted");
+            expect(!extracted[0], "invalid archive reached extraction");
+        } finally {
+            deleteTree(temporary);
+        }
+        System.out.println("Android Retro Rewind install pipeline passed.");
+    }
+
+    private static void writeTree(Path staging, byte[] artifact) throws IOException {
+        Path root = staging.resolve(RetroRewindRelease.ROOT);
+        Files.createDirectories(root.resolve("Binaries"));
+        Files.writeString(root.resolve("version.txt"), RetroRewindRelease.VERSION + "\n");
+        Files.write(root.resolve("Binaries/Code.pul"), artifact);
+    }
+
+    private static RetroRewindArchiveExtractor.Result extraction(
+            RetroRewindArchiveExtractor.Error error, long bytes) {
+        return new RetroRewindArchiveExtractor.Result(error, new long[] {2, bytes, bytes});
+    }
+
+    private static String sha256(byte[] bytes) throws NoSuchAlgorithmException {
+        byte[] digest = MessageDigest.getInstance("SHA-256").digest(bytes);
+        char[] digits = "0123456789abcdef".toCharArray();
+        char[] output = new char[digest.length * 2];
+        for (int index = 0; index < digest.length; index++) {
+            int value = digest[index] & 0xff;
+            output[index * 2] = digits[value >>> 4];
+            output[index * 2 + 1] = digits[value & 0x0f];
+        }
+        return new String(output);
+    }
+
+    private static void deleteTree(Path root) throws IOException {
+        try (var paths = Files.walk(root)) {
+            for (Path path : paths.sorted(java.util.Comparator.reverseOrder()).toList()) {
+                Files.deleteIfExists(path);
+            }
+        }
+    }
+
+    private static void expect(boolean condition, String message) {
+        if (!condition) {
+            throw new AssertionError(message);
+        }
+    }
+}

--- a/dependencies.lock.json
+++ b/dependencies.lock.json
@@ -119,6 +119,18 @@
       "role": "Pinned SDLActivity, controller/audio glue, and Prefab native library for the Android source-only shell"
     },
     {
+      "name": "minizip-ng Android",
+      "repository": "https://github.com/zlib-ng/minizip-ng",
+      "version": "4.0.8",
+      "commit": "55db144e03027b43263e5ebcb599bf0878ba58de",
+      "artifact": "55db144e03027b43263e5ebcb599bf0878ba58de.tar.gz",
+      "url": "https://github.com/zlib-ng/minizip-ng/archive/55db144e03027b43263e5ebcb599bf0878ba58de.tar.gz",
+      "bytes": 772757,
+      "sha256": "e0fa42896ad244261f100fd06fae7c64f6054ce02d143f4d0f55df5fced9f63d",
+      "license": "Zlib",
+      "role": "Pinned ZIP directory and decompression implementation for the bounded Android Retro Rewind installer"
+    },
+    {
       "name": "sse2neon",
       "repository": "https://github.com/DLTcollab/sse2neon.git",
       "commit": "13a42df35dc7fcc94f987568e7274a998bb6cc86",

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -889,6 +889,12 @@ uses HTTPS-only bounded redirects/timeouts, exact streamed length/SHA-256,
 cancellation, verified-cache reuse, and atomic publication. INTERNET is the
 only allowed manifest permission. A worker/UI and ZIP extraction still need to
 consume these layers before A3 can claim an install.
+Bounded ZIP extraction is now connected as well: the pinned minizip-ng core
+uses the shared scan, strict UTF-8, directory-relative no-follow/exclusive
+writes, CRC/byte checks, cancellation, and byte progress. A joined Java pipeline
+revalidates the archive and gates atomic activation on the installed-content
+contract. Fixture-sized JNI extraction passes on both supported AVD page sizes;
+production download/worker/process-death and Retro Rewind gameplay remain open.
 Do not begin the touch-UI port until A2's controller-driven Original-mode proof
 passes. Physical Android hardware remains authoritative for vendor Vulkan and
 controller behavior; Retro Rewind installation and touch parity follow from

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -200,6 +200,14 @@ not block offline Retro Rewind support.
    and safety pass. No worker/UI calls this downloader and the production
    archive was not fetched. Evidence:
    `docs/artifacts/2026-09-04/android/a3-archive-download.md`.
+   Android now also has a pinned minizip-ng, two-pass bounded extraction core,
+   no-follow directory-relative output, JNI cancellation/progress, exact
+   staging cleanup, and a joined validation/atomic-activation pipeline. Host
+   faults, full private native linkage, public build/lint/audit, and wiped 4 KiB
+   plus 16 KiB AVD JNI execution pass. Production-size install, a durable
+   worker, injected process death, and Retro Rewind gameplay remain open.
+   Evidence:
+   `docs/artifacts/2026-09-04/android/a3-archive-extraction.md`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2315,3 +2315,33 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   not downloaded, and ZIP extraction/process-death/runtime acceptance remain
   open. No APK/AAB or private data was published. Evidence:
   `docs/artifacts/2026-09-04/android/a3-archive-download.md`.
+
+## 2026-09-04 — Android A3 bounded extraction and activation pipeline
+
+- Locked the official 772,757-byte minizip-ng 4.0.8 commit archive at SHA-256
+  `e0fa42896ad244261f100fd06fae7c64f6054ce02d143f4d0f55df5fced9f63d`
+  and added fail-closed bootstrap/CMake integration for both Android products.
+- Added a two-pass shared-policy extractor with strict UTF-8, no-follow
+  directory-relative output, exclusive files, exact byte/CRC enforcement,
+  cancellation, and progress. The Java pipeline revalidates the archive, then
+  joins extraction to content validation and atomic activation; failed staging
+  is removed without touching active content and startup recovery covers death.
+- Host extraction and Java pipeline fault matrices pass. Coverage includes
+  traversal, duplicates/aliases, links, encryption, slash data, invalid UTF-8,
+  missing root, limits, cancellation, CRC corruption, foreign entries, invalid
+  content/archive, and a pre-existing destination symlink.
+- Public build/release compile/API-28 lint, full private native linkage, strict
+  package/privacy/dependency/license audit, existing A3 tests, scoped shared
+  archive CTests, SunPad snapshot, 30 builder/tvOS tests, safety, shell, and diff
+  checks pass. An initial unscoped CTest command only found the two deliberately
+  built archive binaries; its scoped rerun passed both.
+- Wiped API 36 4 KiB and API 35 16 KiB ARM64 AVDs both passed the new JNI
+  extraction marker plus the complete existing A1/A2 fixture suite, then shut
+  down cleanly. No ADB target remains.
+- The source-only APK is 33,834,881 bytes with SHA-256
+  `dd891d78ffcd16fed258631ce9e92db95e343e2775e838ae97d3fe8d112ca3e2`.
+- Classification: **Pass for bounded extraction and validation-gated atomic
+  activation contracts, including Android JNI execution.** Production-size
+  download, durable worker/process-death behavior, Retro Rewind runtime, and
+  physical acceptance remain open. No artifact or private data was published.
+  Evidence: `docs/artifacts/2026-09-04/android/a3-archive-extraction.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -316,6 +316,17 @@ and repository safety pass. The production archive was not downloaded, and no
 worker or UI calls the downloader yet. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-archive-download.md`](artifacts/2026-09-04/android/a3-archive-download.md).
 
+Android now consumes verified archives through the shared bounded scan and a
+pinned minizip-ng extraction core. Directory-relative no-follow/exclusive
+writes, strict UTF-8, cancellation/progress, CRC and byte-count checks, scoped
+staging cleanup, installed-content validation, and atomic activation are joined
+and fault-tested. The JNI path passes on wiped 4 KiB and 16 KiB ARM64 AVDs, and
+the actual private game-runtime native target rebuilds with the same graph.
+This remains fixture-sized source proof; the production archive, durable worker
+lifecycle, process-death injection, and Retro Rewind gameplay are still open.
+Evidence:
+[`docs/artifacts/2026-09-04/android/a3-archive-extraction.md`](artifacts/2026-09-04/android/a3-archive-extraction.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-04/android/a3-archive-extraction.md
+++ b/docs/artifacts/2026-09-04/android/a3-archive-extraction.md
@@ -1,0 +1,97 @@
+# Android A3 bounded archive extraction and activation pipeline
+
+Date: 2026-09-04
+
+Branch: `codex/android-a3-archive-extraction`
+
+Baseline: `27eb5638c32709eea8bc3879ec56082f06d9a591`
+
+## Falsifiable subgoal
+
+Consume a verified Retro Rewind ZIP through the shared archive policy, extract
+only the pinned root without following filesystem links, and join that result
+to exact content validation and atomic activation on Android. Prove the JNI
+path on both supported emulator page-size lanes without downloading or
+publishing the production archive.
+
+## Result
+
+- Added official minizip-ng 4.0.8 commit
+  `55db144e03027b43263e5ebcb599bf0878ba58de` to the Android dependency lock.
+  Bootstrap fetches the 772,757-byte official archive at SHA-256
+  `e0fa42896ad244261f100fd06fae7c64f6054ce02d143f4d0f55df5fced9f63d`,
+  validates the extracted CMake source, and reports its path to Gradle/CMake.
+- The native build disables unneeded archive formats, encryption, fetching,
+  tests, and writers; it statically links only decompression and Android zlib
+  into the existing `libmain.so`. No new packaged native library appears.
+- Added a two-pass extraction core. Pass one applies the shared strict member
+  path, exact-root, duplicate, symlink, encryption, entry-count, and expansion
+  limits. Android additionally rejects invalid UTF-8. Pass two streams through
+  a 1 MiB buffer and verifies each advertised uncompressed byte count and CRC.
+- Output traversal uses directory file descriptors plus `mkdirat`/`openat`
+  with `O_NOFOLLOW`, `O_EXCL`, and private permissions. A pre-existing output
+  symlink or collision fails without writing outside staging.
+- JNI provides cancellation checks between archive reads and bounded byte
+  progress. The Java owner requires a regular non-symlink archive, a real
+  staging directory, and an absent pinned root.
+- The install pipeline revalidates the cached archive, creates exact scoped
+  staging, extracts, validates version/`Code.pul`/XML, and atomically activates.
+  Any cancellation, extraction, or validation failure discards only that exact
+  staging directory and preserves the active install. Startup recovery remains
+  the process-death cleanup boundary.
+- The exact minizip-ng Zlib license is included in the APK. The package audit
+  now enforces the exact asset set, exact native dependency allowlist including
+  Android `libz.so`, and the exported extraction JNI symbol.
+
+## Verification
+
+- Host extraction matrix: pass. It covers valid content and progress, foreign-
+  root exclusion, traversal, exact duplicates, file/directory aliases,
+  symlinks, slash-named data, encryption, invalid UTF-8, missing root, entry and
+  expansion limits, cancellation, CRC corruption, and a pre-existing output
+  symlink with an untouched outside directory.
+- Java pipeline fault matrix: pass. It proves successful activation, cancelled
+  staging cleanup, invalid-content cleanup, invalid-archive refusal before
+  extraction, and preservation of the prior active install.
+- Both pre-existing shared archive-path/scan CTests and the pinned SunPad
+  snapshot pass. An initial unscoped CTest command attempted sixteen unrelated
+  targets not built in that selective directory; the correctly scoped archive
+  invocation passed both available tests.
+- Pinned Android host/bootstrap, public source-only assemble, release
+  Kotlin/Java compilation, API-28 lint, and the package/privacy audit pass.
+- The full private game-runtime native target rebuilt successfully with the
+  new core/JNI/minizip graph, then an incremental rerun passed after final
+  source changes. Its ignored 639,690,520-byte `libmain.so` has SHA-256
+  `775101a01b04ab58233f8d28df314268e163b8b6ce4eb5613f796a3007aee1fa`
+  and exports the extraction JNI symbol. No private APK was packaged or
+  installed.
+- Wiped API 36 4 KiB and API 35 16 KiB ARM64 AVD runs both observed
+  `A3 JNI archive extraction passed entries=2 bytes=7` in addition to all
+  existing memory, fiber, scheduler, controller, Vulkan, orientation, and
+  lifecycle markers. Both emulators were shut down; no ADB target remains.
+- All earlier Android A3 download, space, content, and storage tests pass. All
+  30 builder/tvOS tests pass with one optional private-input skip. Shell syntax,
+  shell lint, repository safety, and diff checks pass.
+- The exact source-only debug APK is 33,834,881 bytes with SHA-256
+  `dd891d78ffcd16fed258631ce9e92db95e343e2775e838ae97d3fe8d112ca3e2`.
+
+Key source SHA-256 values:
+
+- extraction header: `77a05e676b2f7e36d591346ef2ad6924ee893c0dc54eec47bdb0f9ca339d0f30`
+- extraction implementation: `460ff62395a8ff405e2c93a00806e450f7fde7880edd292047c43f528900f047`
+- JNI owner: `dc14d06658e278661b69b9bebc95b9d13fb8e734f33287df85ddd0d803a6d90b`
+- Java extraction owner: `142ba8f2072567273fac5ac88b0324fe1e86576f44167792d6568905991f9c7e`
+- install pipeline: `8d1867300b1d6f3027de0f125cdf4d7e116e0041c5020bc7a3e63f8de8981345`
+- native test: `3eb25521b7a79f69b2ba016527f1f0fb25672b96452f1059e304ec555abe07c8`
+- extraction runner: `06e00a50a051cf696bf21b0b4e4178ba7256349913486e4f784963d044879aab`
+- pipeline runner: `bd35c76c27e13e3e8cbd85d679dd7fba6eadf9176e1295e6255d6032a04b9351`
+- packaged license: `675181c03fc1302a1c8554c00f7be9bb420c5dbc9dcc2013433cec144413de03`
+
+## Classification
+
+**Pass for bounded Android ZIP extraction, JNI cancellation/progress, exact
+staging cleanup, content-validation gating, and atomic activation contracts.**
+This does not prove the 1.86 GB production archive, a durable download worker,
+real process death during active work, complete Retro Rewind gameplay, or
+physical hardware. A2 and A3 remain open. No APK/AAB, archive, private data,
+device identifier, or raw capture was published.

--- a/runtime/include/kartpad/retro_rewind/archive_extract.h
+++ b/runtime/include/kartpad/retro_rewind/archive_extract.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace kartpad::retro_rewind {
+
+enum class ArchiveExtractError {
+  None,
+  Cancelled,
+  InvalidArgument,
+  OpenFailed,
+  MalformedArchive,
+  UnsupportedEntry,
+  DuplicateEntry,
+  LimitExceeded,
+  MissingRoot,
+  IoFailure,
+};
+
+struct ArchiveExtractCallbacks {
+  void* context = nullptr;
+  bool (*cancelled)(void* context) = nullptr;
+  void (*progress)(void* context, std::uint64_t extracted_bytes,
+                   std::uint64_t total_bytes) = nullptr;
+};
+
+struct ArchiveExtractResult {
+  ArchiveExtractError error = ArchiveExtractError::None;
+  std::size_t selected_entries = 0;
+  std::uint64_t selected_bytes = 0;
+  std::uint64_t extracted_bytes = 0;
+
+  explicit operator bool() const { return error == ArchiveExtractError::None; }
+};
+
+ArchiveExtractResult ExtractArchive(
+    const char* archive_path, const char* staging_parent,
+    const char* expected_root, std::size_t maximum_entries,
+    std::uint64_t maximum_expanded_bytes,
+    ArchiveExtractCallbacks callbacks = {});
+
+}  // namespace kartpad::retro_rewind

--- a/runtime/src/retro_rewind/archive_extract.cpp
+++ b/runtime/src/retro_rewind/archive_extract.cpp
@@ -1,0 +1,315 @@
+#include "kartpad/retro_rewind/archive_extract.h"
+
+#include "kartpad/retro_rewind/archive_path.h"
+#include "kartpad/retro_rewind/archive_scan.h"
+
+#include "mz.h"
+#include "mz_strm.h"
+#include "mz_zip.h"
+#include "mz_zip_rw.h"
+
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <fcntl.h>
+#include <string>
+#include <string_view>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <utility>
+#include <vector>
+
+namespace kartpad::retro_rewind {
+namespace {
+
+constexpr std::size_t kCopyBufferBytes = 1024 * 1024;
+
+class FileDescriptor {
+ public:
+  explicit FileDescriptor(const int value = -1) : value_(value) {}
+  ~FileDescriptor() {
+    if (value_ >= 0) close(value_);
+  }
+  FileDescriptor(const FileDescriptor&) = delete;
+  FileDescriptor& operator=(const FileDescriptor&) = delete;
+  FileDescriptor(FileDescriptor&& other) noexcept
+      : value_(std::exchange(other.value_, -1)) {}
+  FileDescriptor& operator=(FileDescriptor&& other) noexcept {
+    if (this != &other) {
+      if (value_ >= 0) close(value_);
+      value_ = std::exchange(other.value_, -1);
+    }
+    return *this;
+  }
+  int get() const { return value_; }
+  explicit operator bool() const { return value_ >= 0; }
+
+ private:
+  int value_;
+};
+
+bool IsCancelled(const ArchiveExtractCallbacks& callbacks) {
+  return callbacks.cancelled != nullptr &&
+         callbacks.cancelled(callbacks.context);
+}
+
+bool IsStrictUtf8(const std::string_view value) {
+  std::size_t index = 0;
+  while (index < value.size()) {
+    const auto first = static_cast<unsigned char>(value[index++]);
+    if (first <= 0x7f) continue;
+    std::uint32_t scalar = 0;
+    std::size_t trailing = 0;
+    if (first >= 0xc2 && first <= 0xdf) {
+      scalar = first & 0x1f;
+      trailing = 1;
+    } else if (first >= 0xe0 && first <= 0xef) {
+      scalar = first & 0x0f;
+      trailing = 2;
+    } else if (first >= 0xf0 && first <= 0xf4) {
+      scalar = first & 0x07;
+      trailing = 3;
+    } else {
+      return false;
+    }
+    if (trailing > value.size() - index) return false;
+    for (std::size_t offset = 0; offset < trailing; ++offset) {
+      const auto next = static_cast<unsigned char>(value[index++]);
+      if ((next & 0xc0) != 0x80) return false;
+      scalar = (scalar << 6) | (next & 0x3f);
+    }
+    if ((trailing == 2 && scalar < 0x800) ||
+        (trailing == 3 && scalar < 0x10000) || scalar > 0x10ffff ||
+        (scalar >= 0xd800 && scalar <= 0xdfff)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+ArchiveExtractError MapScanError(const ArchiveScanError error) {
+  switch (error) {
+    case ArchiveScanError::None:
+      return ArchiveExtractError::None;
+    case ArchiveScanError::UnsupportedEntry:
+      return ArchiveExtractError::UnsupportedEntry;
+    case ArchiveScanError::DuplicateEntry:
+      return ArchiveExtractError::DuplicateEntry;
+    case ArchiveScanError::EntryLimit:
+    case ArchiveScanError::ExpandedSizeLimit:
+      return ArchiveExtractError::LimitExceeded;
+    case ArchiveScanError::InvalidPath:
+      return ArchiveExtractError::MalformedArchive;
+  }
+  return ArchiveExtractError::MalformedArchive;
+}
+
+bool EntryInfo(void* reader, mz_zip_file** info, ArchiveMemberPath* path,
+               bool* directory, ArchiveExtractError* error) {
+  if (mz_zip_reader_entry_get_info(reader, info) != MZ_OK || *info == nullptr ||
+      (*info)->filename == nullptr) {
+    *error = ArchiveExtractError::MalformedArchive;
+    return false;
+  }
+  const std::string_view name{(*info)->filename,
+                              static_cast<std::size_t>((*info)->filename_size)};
+  if (!IsStrictUtf8(name)) {
+    *error = ArchiveExtractError::MalformedArchive;
+    return false;
+  }
+  *path = ValidateArchiveMemberPath(name);
+  *directory = path->directory ||
+               mz_zip_attrib_is_dir((*info)->external_fa,
+                                    (*info)->version_madeby) == MZ_OK;
+  return true;
+}
+
+FileDescriptor OpenOrCreateDirectory(const int parent, const std::string& name) {
+  if (mkdirat(parent, name.c_str(), 0700) != 0 && errno != EEXIST) {
+    return FileDescriptor{-1};
+  }
+  return FileDescriptor{
+      openat(parent, name.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW)};
+}
+
+FileDescriptor OpenParent(const int staging, const ArchiveMemberPath& path,
+                          const std::size_t component_count) {
+  const int duplicate = dup(staging);
+  FileDescriptor current{duplicate};
+  if (!current) return FileDescriptor{-1};
+  for (std::size_t index = 0; index < component_count; ++index) {
+    FileDescriptor next = OpenOrCreateDirectory(current.get(), path.components[index]);
+    if (!next) return FileDescriptor{-1};
+    current = std::move(next);
+  }
+  return current;
+}
+
+bool WriteAll(const int descriptor, const std::uint8_t* bytes, std::size_t count) {
+  while (count > 0) {
+    const ssize_t written = write(descriptor, bytes, count);
+    if (written < 0) {
+      if (errno == EINTR) continue;
+      return false;
+    }
+    if (written == 0) return false;
+    bytes += written;
+    count -= static_cast<std::size_t>(written);
+  }
+  return true;
+}
+
+}  // namespace
+
+ArchiveExtractResult ExtractArchive(
+    const char* archive_path, const char* staging_parent,
+    const char* expected_root, const std::size_t maximum_entries,
+    const std::uint64_t maximum_expanded_bytes,
+    const ArchiveExtractCallbacks callbacks) {
+  ArchiveExtractResult result;
+  if (archive_path == nullptr || *archive_path == '\0' ||
+      staging_parent == nullptr || *staging_parent == '\0' ||
+      expected_root == nullptr || *expected_root == '\0' ||
+      maximum_entries == 0 || maximum_expanded_bytes == 0) {
+    result.error = ArchiveExtractError::InvalidArgument;
+    return result;
+  }
+
+  FileDescriptor staging{open(staging_parent,
+                              O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW)};
+  if (!staging) {
+    result.error = ArchiveExtractError::IoFailure;
+    return result;
+  }
+
+  void* reader = mz_zip_reader_create();
+  if (reader == nullptr || mz_zip_reader_open_file(reader, archive_path) != MZ_OK) {
+    if (reader != nullptr) mz_zip_reader_delete(&reader);
+    result.error = ArchiveExtractError::OpenFailed;
+    return result;
+  }
+
+  ArchiveScan scan{expected_root, maximum_entries, maximum_expanded_bytes};
+  int32_t status = mz_zip_reader_goto_first_entry(reader);
+  while (status == MZ_OK && result.error == ArchiveExtractError::None) {
+    if (IsCancelled(callbacks)) {
+      result.error = ArchiveExtractError::Cancelled;
+      break;
+    }
+    mz_zip_file* info = nullptr;
+    ArchiveMemberPath path;
+    bool directory = false;
+    if (!EntryInfo(reader, &info, &path, &directory, &result.error)) break;
+    const auto observation = scan.Observe(
+        path, info->uncompressed_size,
+        mz_zip_attrib_is_symlink(info->external_fa, info->version_madeby) == MZ_OK,
+        (info->flag & MZ_ZIP_FLAG_ENCRYPTED) != 0);
+    if (!observation) {
+      result.error = MapScanError(observation.error);
+      break;
+    }
+    if (observation.selected && directory && info->uncompressed_size != 0) {
+      result.error = ArchiveExtractError::UnsupportedEntry;
+      break;
+    }
+    status = mz_zip_reader_goto_next_entry(reader);
+  }
+  result.selected_entries = scan.selected_entries();
+  result.selected_bytes = scan.selected_bytes();
+  if (result.error == ArchiveExtractError::None && status != MZ_END_OF_LIST) {
+    result.error = ArchiveExtractError::MalformedArchive;
+  }
+  if (result.error == ArchiveExtractError::None && result.selected_entries == 0) {
+    result.error = ArchiveExtractError::MissingRoot;
+  }
+
+  std::vector<std::uint8_t> buffer(kCopyBufferBytes);
+  if (result.error == ArchiveExtractError::None) {
+    status = mz_zip_reader_goto_first_entry(reader);
+  }
+  while (status == MZ_OK && result.error == ArchiveExtractError::None) {
+    if (IsCancelled(callbacks)) {
+      result.error = ArchiveExtractError::Cancelled;
+      break;
+    }
+    mz_zip_file* info = nullptr;
+    ArchiveMemberPath path;
+    bool directory = false;
+    if (!EntryInfo(reader, &info, &path, &directory, &result.error)) break;
+    if (path.components.front() == expected_root) {
+      if (directory) {
+        if (!OpenParent(staging.get(), path, path.components.size())) {
+          result.error = ArchiveExtractError::IoFailure;
+          break;
+        }
+      } else {
+        FileDescriptor parent =
+            OpenParent(staging.get(), path, path.components.size() - 1);
+        if (!parent) {
+          result.error = ArchiveExtractError::IoFailure;
+          break;
+        }
+        FileDescriptor output{openat(parent.get(), path.components.back().c_str(),
+                                     O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC |
+                                         O_NOFOLLOW,
+                                     0600)};
+        if (!output || mz_zip_reader_entry_open(reader) != MZ_OK) {
+          result.error = ArchiveExtractError::IoFailure;
+          break;
+        }
+        std::uint64_t entry_bytes = 0;
+        while (result.error == ArchiveExtractError::None) {
+          if (IsCancelled(callbacks)) {
+            result.error = ArchiveExtractError::Cancelled;
+            break;
+          }
+          const int32_t count = mz_zip_reader_entry_read(
+              reader, buffer.data(), static_cast<int32_t>(buffer.size()));
+          if (count < 0) {
+            result.error = ArchiveExtractError::MalformedArchive;
+            break;
+          }
+          if (count == 0) break;
+          const auto unsigned_count = static_cast<std::uint64_t>(count);
+          if (entry_bytes > static_cast<std::uint64_t>(info->uncompressed_size) ||
+              unsigned_count >
+                  static_cast<std::uint64_t>(info->uncompressed_size) - entry_bytes) {
+            result.error = ArchiveExtractError::MalformedArchive;
+            break;
+          }
+          if (!WriteAll(output.get(), buffer.data(),
+                        static_cast<std::size_t>(count))) {
+            result.error = ArchiveExtractError::IoFailure;
+            break;
+          }
+          entry_bytes += unsigned_count;
+          result.extracted_bytes += unsigned_count;
+          if (callbacks.progress != nullptr) {
+            callbacks.progress(callbacks.context, result.extracted_bytes,
+                               result.selected_bytes);
+          }
+        }
+        if (mz_zip_reader_entry_close(reader) != MZ_OK &&
+            result.error == ArchiveExtractError::None) {
+          result.error = ArchiveExtractError::MalformedArchive;
+        }
+        if (result.error == ArchiveExtractError::None &&
+            entry_bytes != static_cast<std::uint64_t>(info->uncompressed_size)) {
+          result.error = ArchiveExtractError::MalformedArchive;
+        }
+      }
+    }
+    status = mz_zip_reader_goto_next_entry(reader);
+  }
+  if (result.error == ArchiveExtractError::None && status != MZ_END_OF_LIST) {
+    result.error = ArchiveExtractError::MalformedArchive;
+  }
+  if (mz_zip_reader_close(reader) != MZ_OK &&
+      result.error == ArchiveExtractError::None) {
+    result.error = ArchiveExtractError::MalformedArchive;
+  }
+  mz_zip_reader_delete(&reader);
+  return result;
+}
+
+}  // namespace kartpad::retro_rewind

--- a/runtime/tests/retro_rewind_archive_extract/CMakeLists.txt
+++ b/runtime/tests/retro_rewind_archive_extract/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.24)
+project(kartpad_archive_extract_test LANGUAGES C CXX)
+
+if(NOT DEFINED KARTPAD_REPO_ROOT OR NOT DEFINED MINIZIP_SOURCE_DIR)
+  message(FATAL_ERROR "KARTPAD_REPO_ROOT and MINIZIP_SOURCE_DIR are required")
+endif()
+
+set(MZ_COMPAT OFF CACHE BOOL "" FORCE)
+set(MZ_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(MZ_BUILD_UNIT_TESTS OFF CACHE BOOL "" FORCE)
+set(MZ_BUILD_FUZZ_TESTS OFF CACHE BOOL "" FORCE)
+set(MZ_CODE_COVERAGE OFF CACHE BOOL "" FORCE)
+set(MZ_FETCH_LIBS OFF CACHE BOOL "" FORCE)
+set(MZ_BZIP2 OFF CACHE BOOL "" FORCE)
+set(MZ_LZMA OFF CACHE BOOL "" FORCE)
+set(MZ_ZSTD OFF CACHE BOOL "" FORCE)
+set(MZ_PKCRYPT OFF CACHE BOOL "" FORCE)
+set(MZ_WZAES OFF CACHE BOOL "" FORCE)
+set(MZ_OPENSSL OFF CACHE BOOL "" FORCE)
+set(MZ_LIBBSD OFF CACHE BOOL "" FORCE)
+set(MZ_ICONV OFF CACHE BOOL "" FORCE)
+set(MZ_DECOMPRESS_ONLY ON CACHE BOOL "" FORCE)
+set(SKIP_INSTALL_ALL ON CACHE BOOL "" FORCE)
+add_subdirectory("${MINIZIP_SOURCE_DIR}" minizip-ng EXCLUDE_FROM_ALL)
+
+add_executable(kartpad_archive_extract_test
+  main.cpp
+  "${KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_extract.cpp"
+  "${KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_path.cpp"
+  "${KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_scan.cpp")
+target_compile_features(kartpad_archive_extract_test PRIVATE cxx_std_20)
+target_compile_options(kartpad_archive_extract_test PRIVATE
+  -Wall -Wextra -Werror -pedantic)
+target_include_directories(kartpad_archive_extract_test PRIVATE
+  "${KARTPAD_REPO_ROOT}/runtime/include")
+target_link_libraries(kartpad_archive_extract_test PRIVATE MINIZIP::minizip)

--- a/runtime/tests/retro_rewind_archive_extract/main.cpp
+++ b/runtime/tests/retro_rewind_archive_extract/main.cpp
@@ -1,0 +1,118 @@
+#include "kartpad/retro_rewind/archive_extract.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace fs = std::filesystem;
+using kartpad::retro_rewind::ArchiveExtractCallbacks;
+using kartpad::retro_rewind::ArchiveExtractError;
+using kartpad::retro_rewind::ExtractArchive;
+
+namespace {
+
+struct ProgressState {
+  std::uint64_t last = 0;
+  std::uint64_t total = 0;
+  int calls = 0;
+  bool cancel_after_progress = false;
+};
+
+bool Cancelled(void* opaque) {
+  const auto* state = static_cast<ProgressState*>(opaque);
+  return state->cancel_after_progress && state->calls > 0;
+}
+
+void Progress(void* opaque, const std::uint64_t extracted,
+              const std::uint64_t total) {
+  auto* state = static_cast<ProgressState*>(opaque);
+  if (extracted < state->last || total < extracted) {
+    std::cerr << "invalid progress sequence\n";
+    std::exit(2);
+  }
+  state->last = extracted;
+  state->total = total;
+  ++state->calls;
+}
+
+bool Expect(const bool condition, const std::string& message) {
+  if (!condition) std::cerr << message << '\n';
+  return condition;
+}
+
+std::string Read(const fs::path& path) {
+  std::ifstream stream{path, std::ios::binary};
+  return {std::istreambuf_iterator<char>{stream},
+          std::istreambuf_iterator<char>{}};
+}
+
+bool Run(const fs::path& fixtures, const fs::path& work,
+         const std::string& name, const ArchiveExtractError expected,
+         const std::uint64_t limit = 1000, const bool cancel = false) {
+  const fs::path stage = work / ("stage-" + name);
+  fs::create_directory(stage);
+  ProgressState progress{.cancel_after_progress = cancel};
+  const auto result = ExtractArchive(
+      (fixtures / (name + ".zip")).c_str(), stage.c_str(), "RetroRewind6", 10,
+      limit,
+      ArchiveExtractCallbacks{.context = &progress,
+                              .cancelled = Cancelled,
+                              .progress = Progress});
+  bool ok = Expect(result.error == expected,
+                   name + ": unexpected extraction result " +
+                       std::to_string(static_cast<int>(result.error)));
+  if (expected == ArchiveExtractError::None) {
+    ok &= Expect(result.selected_entries == 2, "valid: selected entry count");
+    ok &= Expect(result.selected_bytes == 7, "valid: selected byte count");
+    ok &= Expect(result.extracted_bytes == 7, "valid: extracted byte count");
+    ok &= Expect(progress.calls > 0 && progress.last == 7 && progress.total == 7,
+                 "valid: final progress");
+    ok &= Expect(Read(stage / "RetroRewind6/version.txt") == "6.12.5\n",
+                 "valid: extracted content");
+    ok &= Expect(!fs::exists(stage / "foreign.txt"),
+                 "valid: foreign-root content escaped selection");
+  }
+  return ok;
+}
+
+}  // namespace
+
+int main(const int argc, char** argv) {
+  if (argc != 3) {
+    std::cerr << "usage: test FIXTURES WORK\n";
+    return 64;
+  }
+  const fs::path fixtures = argv[1];
+  const fs::path work = argv[2];
+  fs::create_directories(work);
+
+  bool ok = true;
+  ok &= Run(fixtures, work, "valid", ArchiveExtractError::None);
+  ok &= Run(fixtures, work, "traversal", ArchiveExtractError::MalformedArchive);
+  ok &= Run(fixtures, work, "duplicate", ArchiveExtractError::DuplicateEntry);
+  ok &= Run(fixtures, work, "alias", ArchiveExtractError::DuplicateEntry);
+  ok &= Run(fixtures, work, "symlink", ArchiveExtractError::UnsupportedEntry);
+  ok &= Run(fixtures, work, "slash-data", ArchiveExtractError::UnsupportedEntry);
+  ok &= Run(fixtures, work, "encrypted", ArchiveExtractError::UnsupportedEntry);
+  ok &= Run(fixtures, work, "invalid-utf8", ArchiveExtractError::MalformedArchive);
+  ok &= Run(fixtures, work, "entry-limit", ArchiveExtractError::LimitExceeded);
+  ok &= Run(fixtures, work, "missing", ArchiveExtractError::MissingRoot);
+  ok &= Run(fixtures, work, "valid", ArchiveExtractError::LimitExceeded, 6);
+  ok &= Run(fixtures, work, "cancel", ArchiveExtractError::Cancelled, 1000, true);
+  ok &= Run(fixtures, work, "corrupt", ArchiveExtractError::MalformedArchive);
+
+  const fs::path outside = work / "outside";
+  const fs::path stage = work / "stage-preexisting-symlink";
+  fs::create_directory(outside);
+  fs::create_directory(stage);
+  fs::create_directory_symlink(outside, stage / "RetroRewind6");
+  const auto symlink_result = ExtractArchive(
+      (fixtures / "valid.zip").c_str(), stage.c_str(), "RetroRewind6", 10, 1000);
+  ok &= Expect(symlink_result.error == ArchiveExtractError::IoFailure,
+               "preexisting output symlink was not rejected");
+  ok &= Expect(fs::is_empty(outside), "preexisting output symlink was followed");
+
+  return ok ? 0 : 1;
+}

--- a/scripts/audit-android-package.sh
+++ b/scripts/audit-android-package.sh
@@ -59,6 +59,10 @@ expected_native_members="$(printf '%s\n' \
 asset_members="$(printf '%s\n' "$members" | grep '^assets/.' | sort || true)"
 if [[ -n "$asset_members" ]]; then
   expected_asset_members="$(printf '%s\n' \
+    assets/ThirdPartyLicenses/Minizip-NG.txt | sort)"
+  if printf '%s\n' "$asset_members" | grep -Fxq assets/dsp/dsp_coef.bin; then
+    expected_asset_members="$(printf '%s\n' \
+    assets/ThirdPartyLicenses/Minizip-NG.txt \
     assets/dsp/dsp_coef.bin \
     assets/pipeline/initial_pipeline_cache.db \
     assets/wii/README.md \
@@ -73,6 +77,7 @@ if [[ -n "$asset_members" ]]; then
     assets/wii/shared2/wc24/nwc24fls.bin \
     assets/wii/shared2/wc24/nwc24msg.cbk \
     assets/wii/shared2/wc24/nwc24msg.cfg | sort)"
+  fi
   [[ "$asset_members" == "$expected_asset_members" ]] || {
     echo "ERROR: APK asset set differs from the public runtime-resource allowlist" >&2
     exit 1
@@ -91,9 +96,15 @@ for library in libSDL3.so libc++_shared.so libmain.so; do
   fi
 done
 dynamic="$("$readelf" -d -l "$audit_root/libmain.so")"
-[[ "$dynamic" == *"Shared library: [libSDL3.so]"* ]]
-[[ "$dynamic" == *"Shared library: [libandroid.so]"* ]]
-[[ "$dynamic" == *"Shared library: [liblog.so]"* ]]
+needed="$(printf '%s\n' "$dynamic" |
+  sed -n 's/.*Shared library: \[\([^]]*\)\].*/\1/p' | sort)"
+expected_needed="$(printf '%s\n' \
+  libc++_shared.so libc.so libdl.so libm.so libSDL3.so \
+  libandroid.so liblog.so libz.so | sort)"
+[[ "$needed" == "$expected_needed" ]] || {
+  echo "ERROR: libmain.so dependency set differs from the allowlist" >&2
+  exit 1
+}
 [[ "$dynamic" == *"GNU_RELRO"* ]]
 if ! printf '%s\n' "$dynamic" | grep -Eq 'GNU_STACK .* RW  0x0$'; then
   echo "ERROR: libmain.so does not have a non-executable stack" >&2
@@ -107,7 +118,8 @@ sdl_symbols="$("$readelf" --wide --dyn-syms "$audit_root/libSDL3.so")"
 }
 for symbol in \
   Java_dev_kartpad_android_KartPadSurface_nativeBeginSurfaceMutation \
-  Java_dev_kartpad_android_KartPadSurface_nativeEndSurfaceMutation; do
+  Java_dev_kartpad_android_KartPadSurface_nativeEndSurfaceMutation \
+  Java_dev_kartpad_android_RetroRewindArchiveExtractor_nativeExtract; do
   [[ "$main_symbols" == *" $symbol"* ]] || {
     echo "ERROR: libmain.so does not export $symbol" >&2
     exit 1

--- a/scripts/build-android-fixture.sh
+++ b/scripts/build-android-fixture.sh
@@ -8,14 +8,16 @@ source "$repo_root/scripts/android-toolchain-versions.sh"
 prepare_output="$("$repo_root/scripts/prepare-android-dependencies.sh")"
 echo "$prepare_output"
 dawn_root="$(printf '%s\n' "$prepare_output" | sed -n 's/^DAWN_ANDROID_ROOT=//p')"
-if [[ -z "$dawn_root" ]]; then
-  echo "ERROR: dependency preparation did not report DAWN_ANDROID_ROOT" >&2
+minizip_root="$(printf '%s\n' "$prepare_output" | sed -n 's/^MINIZIP_ANDROID_ROOT=//p')"
+if [[ -z "$dawn_root" || -z "$minizip_root" ]]; then
+  echo "ERROR: dependency preparation did not report native dependency roots" >&2
   exit 1
 fi
 
 export JAVA_HOME="$repo_root/.android-bootstrap/jdk-$KARTPAD_ANDROID_JDK_VERSION/Contents/Home"
 export ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/Library/Android/sdk}}"
 export DAWN_ANDROID_ROOT="$dawn_root"
+export MINIZIP_ANDROID_ROOT="$minizip_root"
 
 "$repo_root/android/gradlew" --project-dir "$repo_root/android" \
   --no-daemon :app:assembleDebug

--- a/scripts/build-android-game-app.sh
+++ b/scripts/build-android-game-app.sh
@@ -20,8 +20,9 @@ runtime_build="$(absolute_from_repo "${3:-build/android-game-runtime-build}")"
 prepare_output="$("$repo_root/scripts/prepare-android-dependencies.sh")"
 echo "$prepare_output"
 dawn_root="$(printf '%s\n' "$prepare_output" | sed -n 's/^DAWN_ANDROID_ROOT=//p')"
-if [[ -z "$dawn_root" ]]; then
-  echo "ERROR: dependency preparation did not report DAWN_ANDROID_ROOT" >&2
+minizip_root="$(printf '%s\n' "$prepare_output" | sed -n 's/^MINIZIP_ANDROID_ROOT=//p')"
+if [[ -z "$dawn_root" || -z "$minizip_root" ]]; then
+  echo "ERROR: dependency preparation did not report native dependency roots" >&2
   exit 1
 fi
 if [[ ! -d "$runtime_source" ]]; then
@@ -36,6 +37,7 @@ fi
 export JAVA_HOME="$repo_root/.android-bootstrap/jdk-$KARTPAD_ANDROID_JDK_VERSION/Contents/Home"
 export ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/Library/Android/sdk}}"
 export DAWN_ANDROID_ROOT="$dawn_root"
+export MINIZIP_ANDROID_ROOT="$minizip_root"
 
 "$repo_root/android/gradlew" --project-dir "$repo_root/android" --no-daemon \
   -PkartpadGameRuntimeSource="$runtime_source" \

--- a/scripts/prepare-android-dependencies.sh
+++ b/scripts/prepare-android-dependencies.sh
@@ -64,7 +64,28 @@ if [[ "$sanitized_targets_sha256" != \
   exit 1
 fi
 
+minizip_commit="55db144e03027b43263e5ebcb599bf0878ba58de"
+minizip_archive="$cache_root/minizip-ng-$minizip_commit.tar.gz"
+fetch_locked \
+  "https://github.com/zlib-ng/minizip-ng/archive/$minizip_commit.tar.gz" \
+  "$minizip_archive" 772757 \
+  e0fa42896ad244261f100fd06fae7c64f6054ce02d143f4d0f55df5fced9f63d
+minizip_root="$cache_root/minizip-ng-$minizip_commit"
+if [[ ! -f "$minizip_root/CMakeLists.txt" ]]; then
+  temporary_minizip_root="$(mktemp -d "$cache_root/.minizip-ng-$minizip_commit.XXXXXX")"
+  tar -xzf "$minizip_archive" -C "$temporary_minizip_root" --strip-components=1
+  mv "$temporary_minizip_root" "$minizip_root"
+fi
+minizip_cmake_sha256="$(shasum -a 256 "$minizip_root/CMakeLists.txt" | awk '{print $1}')"
+if [[ "$minizip_cmake_sha256" != \
+      "7ed446837e293dbb61dd4e9a49566bde6408c7acd95c815e50680aeef4d60695" ]]; then
+  echo "ERROR: extracted minizip-ng source digest changed" >&2
+  exit 1
+fi
+
 echo "SDL3 Android AAR: $(shasum -a 256 "$repo_root/android/app/libs/SDL3-3.4.4.aar" | awk '{print $1}')"
 echo "Dawn archive: $(shasum -a 256 "$dawn_archive" | awk '{print $1}')"
 echo "Dawn sanitized targets: $sanitized_targets_sha256"
+echo "minizip-ng archive: $(shasum -a 256 "$minizip_archive" | awk '{print $1}')"
 echo "DAWN_ANDROID_ROOT=$dawn_root"
+echo "MINIZIP_ANDROID_ROOT=$minizip_root"

--- a/scripts/run-android-fixture.sh
+++ b/scripts/run-android-fixture.sh
@@ -65,7 +65,8 @@ apk="$repo_root/android/app/build/outputs/apk/debug/app-debug.apk"
 "$adb" install -r "$apk" >/dev/null
 "$adb" logcat -c
 "$adb" shell am force-stop dev.kartpad.android
-"$adb" shell am start -W -n dev.kartpad.android/.KartPadActivity >/dev/null
+"$adb" shell am start -W -n dev.kartpad.android/.KartPadActivity \
+  --ez dev.kartpad.android.TEST_RETRO_REWIND_EXTRACTION true >/dev/null
 wait_for_marker() {
   local marker="$1"
   for _ in {1..60}; do
@@ -85,6 +86,7 @@ wait_for_marker \
 wait_for_marker \
   "A1 ELF scheduler passed operations=2000000 hash=0x7287563387fb1677 fiber_switches=1000000"
 wait_for_marker "A2 SDL gamepad contract passed"
+wait_for_marker "A3 JNI archive extraction passed entries=2 bytes=7"
 wait_for_marker \
   "A1 Vulkan present passed abi=arm64-v8a page_size=$expected_page_size"
 

--- a/scripts/test-android-retro-rewind-extraction.sh
+++ b/scripts/test-android-retro-rewind-extraction.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+prepare_output="$("${repo_root}/scripts/prepare-android-dependencies.sh")"
+minizip_root="$(printf '%s\n' "${prepare_output}" |
+  sed -n 's/^MINIZIP_ANDROID_ROOT=//p')"
+if [[ -z "${minizip_root}" ]]; then
+  echo "ERROR: dependency preparation did not report MINIZIP_ANDROID_ROOT" >&2
+  exit 1
+fi
+
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/kartpad-archive-extract.XXXXXX")"
+cleanup() {
+  find "${test_root}" -depth -delete
+}
+trap cleanup EXIT
+fixtures="${test_root}/fixtures"
+work="${test_root}/work"
+build="${repo_root}/build/android-retro-rewind-extraction-tests"
+mkdir -p "${fixtures}" "${work}" "${build}"
+
+python3 - "${fixtures}" <<'PY'
+from pathlib import Path
+import stat
+import sys
+import warnings
+import zipfile
+
+root = Path(sys.argv[1])
+
+def create(name, entries):
+    with zipfile.ZipFile(root / f"{name}.zip", "w", zipfile.ZIP_DEFLATED) as archive:
+        for path, content, mode in entries:
+            info = zipfile.ZipInfo(path)
+            info.create_system = 3
+            info.external_attr = mode << 16
+            info.compress_type = zipfile.ZIP_DEFLATED
+            archive.writestr(info, content)
+
+valid = [
+    ("RetroRewind6/", b"", stat.S_IFDIR | 0o700),
+    ("RetroRewind6/version.txt", b"6.12.5\n", stat.S_IFREG | 0o600),
+    ("foreign.txt", b"ignored", stat.S_IFREG | 0o600),
+]
+create("valid", valid)
+create("traversal", [("RetroRewind6/../escape", b"x", stat.S_IFREG | 0o600)])
+warnings.filterwarnings("ignore", message="Duplicate name:.*")
+create("duplicate", [
+    ("RetroRewind6/version.txt", b"one", stat.S_IFREG | 0o600),
+    ("RetroRewind6/version.txt", b"two", stat.S_IFREG | 0o600),
+])
+create("alias", [
+    ("RetroRewind6/item/", b"", stat.S_IFDIR | 0o700),
+    ("RetroRewind6/item", b"file", stat.S_IFREG | 0o600),
+])
+create("symlink", [("RetroRewind6/link", b"target", stat.S_IFLNK | 0o777)])
+create("slash-data", [("RetroRewind6/not-a-directory/", b"x", stat.S_IFREG | 0o600)])
+create("missing", [("Other/file", b"x", stat.S_IFREG | 0o600)])
+create("entry-limit", [
+    (f"RetroRewind6/{index}", b"x", stat.S_IFREG | 0o600)
+    for index in range(11)
+])
+create("cancel", [
+    ("RetroRewind6/one", b"one", stat.S_IFREG | 0o600),
+    ("RetroRewind6/two", b"two", stat.S_IFREG | 0o600),
+])
+corrupt = root / "corrupt.zip"
+with zipfile.ZipFile(corrupt, "w", zipfile.ZIP_STORED) as archive:
+    info = zipfile.ZipInfo("RetroRewind6/data")
+    info.create_system = 3
+    info.external_attr = (stat.S_IFREG | 0o600) << 16
+    archive.writestr(info, b"known-content", compress_type=zipfile.ZIP_STORED)
+data = bytearray(corrupt.read_bytes())
+offset = data.index(b"known-content")
+data[offset] ^= 0x01
+corrupt.write_bytes(data)
+
+create("encrypted", [("RetroRewind6/data", b"data", stat.S_IFREG | 0o600)])
+encrypted = root / "encrypted.zip"
+data = bytearray(encrypted.read_bytes())
+local = data.index(b"PK\x03\x04")
+central = data.index(b"PK\x01\x02")
+data[local + 6] |= 0x01
+data[central + 8] |= 0x01
+encrypted.write_bytes(data)
+
+create("invalid-utf8", [("RetroRewind6/bad-name", b"data", stat.S_IFREG | 0o600)])
+invalid_utf8 = root / "invalid-utf8.zip"
+data = bytearray(invalid_utf8.read_bytes())
+needle = b"RetroRewind6/bad-name"
+first = data.index(needle)
+second = data.index(needle, first + 1)
+data[first + len(needle) - 1] = 0xff
+data[second + len(needle) - 1] = 0xff
+invalid_utf8.write_bytes(data)
+PY
+
+cmake -S "${repo_root}/runtime/tests/retro_rewind_archive_extract" -B "${build}" \
+  -DKARTPAD_REPO_ROOT="${repo_root}" \
+  -DMINIZIP_SOURCE_DIR="${minizip_root}" >/dev/null
+cmake --build "${build}" --target kartpad_archive_extract_test --parallel 2 >/dev/null
+"${build}/kartpad_archive_extract_test" "${fixtures}" "${work}"
+echo "Android Retro Rewind archive extraction passed."

--- a/scripts/test-android-retro-rewind-pipeline.sh
+++ b/scripts/test-android-retro-rewind-pipeline.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+# shellcheck source=android-toolchain-versions.sh
+source "${repo_root}/scripts/android-toolchain-versions.sh"
+java_home="${repo_root}/.android-bootstrap/jdk-${KARTPAD_ANDROID_JDK_VERSION}/Contents/Home"
+classes="${repo_root}/build/android-retro-rewind-pipeline-tests"
+
+if [[ ! -x "${java_home}/bin/javac" || ! -x "${java_home}/bin/java" ]]; then
+  echo "ERROR: pinned Android JDK is unavailable; run scripts/bootstrap-android-host.sh" >&2
+  exit 1
+fi
+
+mkdir -p "${classes}"
+find "${classes}" -type f -delete
+"${java_home}/bin/javac" -Werror -Xlint:all -d "${classes}" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindRelease.java" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindArchiveDownload.java" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindArchiveExtractor.java" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallStorage.java" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallValidator.java" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallPipeline.java" \
+  "${repo_root}/android/app/src/test/java/dev/kartpad/android/RetroRewindInstallPipelineTestMain.java"
+"${java_home}/bin/java" -cp "${classes}" \
+  dev.kartpad.android.RetroRewindInstallPipelineTestMain


### PR DESCRIPTION
## Summary
- lock and bootstrap the same pinned minizip-ng lineage used by the Apple installer
- add a two-pass shared-policy extractor with strict UTF-8, no-follow/exclusive writes, CRC/byte checks, cancellation, and progress
- expose extraction through JNI and join verified input to content validation and atomic activation
- include the minizip-ng license and tighten APK asset/dependency/JNI audits

## Verification
- adversarial host extraction matrix and Java pipeline fault matrix
- full private game-runtime native rebuild and exported JNI symbol check
- public debug assemble, release Kotlin/Java compile, API-28 lint, and strict APK audit
- wiped API 36 4 KiB and API 35 16 KiB AVD JNI runs plus the existing A1/A2 fixture suite
- earlier A3 contracts, scoped shared archive CTests, SunPad snapshot, builder/tvOS suite, shell/diff checks, and repository safety

This is fixture-sized extraction proof. Production archive/worker/process-death/gameplay and physical acceptance remain open. No APK/AAB or private data was published.