### PR TITLE
Add durable Android Retro Rewind worker

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -88,4 +88,5 @@ kotlin {
 
 dependencies {
     implementation(files("libs/SDL3-3.4.4.aar"))
+    implementation("androidx.work:work-runtime-ktx:2.11.1")
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <uses-feature android:glEsVersion="0x00030000" android:required="false" />
     <uses-feature android:name="android.hardware.vulkan.level" android:required="false" android:version="1" />
@@ -14,6 +18,10 @@
         android:label="@string/app_name"
         android:roundIcon="@drawable/ic_kartpad"
         android:theme="@style/KartPadTheme">
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
         <activity
             android:name=".KartPadActivity"
             android:configChanges="keyboard|keyboardHidden|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode"

--- a/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
@@ -26,6 +26,7 @@ class KartPadActivity : SDLActivity() {
         }
         super.onCreate(savedInstanceState)
         runDebugRetroRewindExtractionFixture()
+        runDebugRetroRewindWorkerFixture()
         val overlay = KartPadOverlayView(this)
         mLayout.addView(
             overlay,
@@ -127,6 +128,27 @@ class KartPadActivity : SDLActivity() {
         }
     }
 
+    private fun runDebugRetroRewindWorkerFixture() {
+        if (!BuildConfig.DEBUG || BuildConfig.GAME_RUNTIME) {
+            return
+        }
+        when {
+            intent.getBooleanExtra(DEBUG_EXTRA_RETRO_REWIND_WORKER_RESTART, false) -> {
+                val id = RetroRewindInstallWork.enqueueDebugFixture(
+                    this,
+                    steps = 60,
+                    delayMillis = 500,
+                )
+                Log.i(TAG, "A3 durable worker restart fixture enqueued id=$id")
+            }
+            intent.getBooleanExtra(DEBUG_EXTRA_RETRO_REWIND_WORKER, false) -> {
+                RetroRewindInstallWork.enqueueDebugFixture(this)
+                RetroRewindInstallWork.enqueueDebugFixture(this)
+                Log.i(TAG, "A3 durable worker fixture enqueued twice with KEEP")
+            }
+        }
+    }
+
     companion object {
         private const val TAG = "KartPadFixture"
         private const val DEBUG_RKG_RELATIVE_PATH = "KartPad/Diagnostics/TestInput.rkg"
@@ -138,6 +160,10 @@ class KartPadActivity : SDLActivity() {
             "KartPad/Diagnostics/StateTrace.csv"
         private const val DEBUG_EXTRA_RETRO_REWIND_EXTRACTION =
             "dev.kartpad.android.TEST_RETRO_REWIND_EXTRACTION"
+        private const val DEBUG_EXTRA_RETRO_REWIND_WORKER =
+            "dev.kartpad.android.TEST_RETRO_REWIND_WORKER"
+        private const val DEBUG_EXTRA_RETRO_REWIND_WORKER_RESTART =
+            "dev.kartpad.android.TEST_RETRO_REWIND_WORKER_RESTART"
         private const val MIN_RKG_BYTES = 0x90L
         private const val MAX_RKG_BYTES = 1024L * 1024L
         private val RKG_MAGIC = byteArrayOf('R'.code.toByte(), 'K'.code.toByte(), 'G'.code.toByte(), 'D'.code.toByte())

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindArchiveDownload.java
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindArchiveDownload.java
@@ -25,6 +25,10 @@ final class RetroRewindArchiveDownload {
         boolean isCancelled();
     }
 
+    interface Progress {
+        void onProgress(long downloadedBytes, long totalBytes);
+    }
+
     enum Error {
         NONE,
         CANCELLED,
@@ -55,12 +59,16 @@ final class RetroRewindArchiveDownload {
     private RetroRewindArchiveDownload() {}
 
     static Result downloadRelease(Path cacheDirectory, Cancellation cancellation) {
+        return downloadRelease(cacheDirectory, cancellation, (downloaded, total) -> {});
+    }
+
+    static Result downloadRelease(
+            Path cacheDirectory, Cancellation cancellation, Progress progress) {
         if (!isRealDirectory(cacheDirectory)) {
             return result(Error.INVALID_CACHE, false);
         }
 
-        Path archive = cacheDirectory.resolve(
-                "RetroRewind-" + RetroRewindRelease.VERSION + ".zip");
+        Path archive = archivePath(cacheDirectory);
         if (verifyFile(archive, RetroRewindRelease.ARCHIVE_BYTES,
                 RetroRewindRelease.ARCHIVE_SHA256) == Error.NONE) {
             return result(Error.NONE, true);
@@ -75,7 +83,7 @@ final class RetroRewindArchiveDownload {
         }
 
         try {
-            Result transfer = downloadPinned(partial, cancellation);
+            Result transfer = downloadPinned(partial, cancellation, progress);
             if (!transfer.isReady()) {
                 return transfer;
             }
@@ -95,7 +103,13 @@ final class RetroRewindArchiveDownload {
         }
     }
 
-    private static Result downloadPinned(Path partial, Cancellation cancellation) {
+    static Path archivePath(Path cacheDirectory) {
+        return cacheDirectory.resolve(
+                "RetroRewind-" + RetroRewindRelease.VERSION + ".zip");
+    }
+
+    private static Result downloadPinned(
+            Path partial, Cancellation cancellation, Progress progress) {
         URL current;
         try {
             current = new URL(RetroRewindRelease.ARCHIVE_URL);
@@ -140,7 +154,7 @@ final class RetroRewindArchiveDownload {
                 }
                 try (InputStream input = new BufferedInputStream(connection.getInputStream())) {
                     Error error = transfer(input, partial, RetroRewindRelease.ARCHIVE_BYTES,
-                            RetroRewindRelease.ARCHIVE_SHA256, cancellation);
+                            RetroRewindRelease.ARCHIVE_SHA256, cancellation, progress);
                     return result(error, false);
                 }
             } catch (IOException exception) {
@@ -160,8 +174,20 @@ final class RetroRewindArchiveDownload {
             long expectedBytes,
             String expectedSha256,
             Cancellation cancellation) {
+        return transfer(input, partial, expectedBytes, expectedSha256,
+                cancellation, (downloaded, total) -> {});
+    }
+
+    static Error transfer(
+            InputStream input,
+            Path partial,
+            long expectedBytes,
+            String expectedSha256,
+            Cancellation cancellation,
+            Progress progress) {
         byte[] expectedDigest = decodeSha256(expectedSha256);
-        if (expectedBytes < 0 || expectedDigest == null || cancellation == null) {
+        if (expectedBytes < 0 || expectedDigest == null || cancellation == null ||
+                progress == null) {
             return Error.STORAGE_FAILURE;
         }
 
@@ -209,6 +235,7 @@ final class RetroRewindArchiveDownload {
                 }
                 digest.update(buffer, 0, count);
                 total += count;
+                progress.onProgress(total, expectedBytes);
             }
         } catch (IOException exception) {
             return Error.STORAGE_FAILURE;

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWork.kt
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWork.kt
@@ -1,0 +1,73 @@
+package dev.kartpad.android
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import java.util.UUID
+
+/** Stable entry point for the one durable Retro Rewind installation. */
+internal object RetroRewindInstallWork {
+    const val UNIQUE_NAME = "kartpad-retro-rewind-install"
+    const val TAG = "kartpad-retro-rewind-install"
+    const val KEY_TOKEN = "install_token"
+    const val KEY_PHASE = "phase"
+    const val KEY_COMPLETED_BYTES = "completed_bytes"
+    const val KEY_TOTAL_BYTES = "total_bytes"
+    const val KEY_ERROR = "error"
+    const val KEY_DEBUG_FIXTURE = "debug_fixture"
+    const val KEY_DEBUG_FIXTURE_STEPS = "debug_fixture_steps"
+    const val KEY_DEBUG_FIXTURE_DELAY_MILLIS = "debug_fixture_delay_millis"
+
+    fun enqueue(context: Context) {
+        val token = UUID.randomUUID().toString()
+        val request = OneTimeWorkRequestBuilder<RetroRewindInstallWorker>()
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .build(),
+            )
+            .setInputData(workDataOf(KEY_TOKEN to token))
+            .addTag(TAG)
+            .build()
+        WorkManager.getInstance(context.applicationContext).enqueueUniqueWork(
+            UNIQUE_NAME,
+            ExistingWorkPolicy.KEEP,
+            request,
+        )
+    }
+
+    fun cancel(context: Context) {
+        WorkManager.getInstance(context.applicationContext).cancelUniqueWork(UNIQUE_NAME)
+    }
+
+    fun enqueueDebugFixture(
+        context: Context,
+        steps: Int = 3,
+        delayMillis: Long = 250,
+    ): UUID {
+        check(BuildConfig.DEBUG && !BuildConfig.GAME_RUNTIME)
+        check(steps in 1..120)
+        check(delayMillis in 1..5_000)
+        val request = OneTimeWorkRequestBuilder<RetroRewindInstallWorker>()
+            .setInputData(
+                workDataOf(
+                    KEY_TOKEN to "debug-fixture",
+                    KEY_DEBUG_FIXTURE to true,
+                    KEY_DEBUG_FIXTURE_STEPS to steps,
+                    KEY_DEBUG_FIXTURE_DELAY_MILLIS to delayMillis,
+                ),
+            )
+            .addTag(TAG)
+            .build()
+        WorkManager.getInstance(context.applicationContext).enqueueUniqueWork(
+            UNIQUE_NAME,
+            ExistingWorkPolicy.KEEP,
+            request,
+        )
+        return request.id
+    }
+}

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWorkPolicy.java
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWorkPolicy.java
@@ -1,0 +1,36 @@
+package dev.kartpad.android;
+
+/** Pure retry/failure policy for the durable Retro Rewind install worker. */
+final class RetroRewindInstallWorkPolicy {
+    enum Action {
+        CONTINUE,
+        RETRY,
+        FAILURE,
+        CANCELLED,
+    }
+
+    private RetroRewindInstallWorkPolicy() {}
+
+    static Action afterDownload(RetroRewindArchiveDownload.Error error) {
+        if (error == RetroRewindArchiveDownload.Error.NONE) {
+            return Action.CONTINUE;
+        }
+        if (error == RetroRewindArchiveDownload.Error.CANCELLED) {
+            return Action.CANCELLED;
+        }
+        if (error == RetroRewindArchiveDownload.Error.NETWORK_FAILURE) {
+            return Action.RETRY;
+        }
+        return Action.FAILURE;
+    }
+
+    static Action afterInstall(RetroRewindInstallPipeline.Result result) {
+        if (result.isInstalled()) {
+            return Action.CONTINUE;
+        }
+        if (result.extractionError == RetroRewindArchiveExtractor.Error.CANCELLED) {
+            return Action.CANCELLED;
+        }
+        return Action.FAILURE;
+    }
+}

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWorker.kt
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWorker.kt
@@ -1,0 +1,199 @@
+package dev.kartpad.android
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.ForegroundInfo
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import java.nio.file.Files
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+
+/** Durable, unique foreground worker for the production Retro Rewind install. */
+internal class RetroRewindInstallWorker(
+    appContext: Context,
+    parameters: WorkerParameters,
+) : CoroutineWorker(appContext, parameters) {
+    override suspend fun getForegroundInfo(): ForegroundInfo = foregroundInfo("Preparing installation…")
+
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
+        val token = inputData.getString(RetroRewindInstallWork.KEY_TOKEN)
+            ?: return@withContext failure("missing-token")
+        setForeground(foregroundInfo("Preparing installation…"))
+        if (inputData.getBoolean(RetroRewindInstallWork.KEY_DEBUG_FIXTURE, false)) {
+            if (!BuildConfig.DEBUG || BuildConfig.GAME_RUNTIME) {
+                return@withContext failure("fixture-disabled")
+            }
+            return@withContext runDebugFixture()
+        }
+        try {
+            RetroRewindInstallStorage.recover(applicationContext.filesDir)
+        } catch (_: Exception) {
+            return@withContext failure("recovery")
+        }
+
+        setPhase("space", 0, 0)
+        val space = RetroRewindSpaceProbe.check(
+            applicationContext.filesDir,
+            applicationContext.cacheDir,
+        )
+        if (!space.isReady) {
+            return@withContext failure("space-${space.error.name.lowercase()}")
+        }
+
+        setForeground(foregroundInfo("Downloading Retro Rewind…"))
+        setPhase("download", 0, RetroRewindRelease.ARCHIVE_BYTES)
+        var lastDownloadPercent = -1L
+        val download = RetroRewindArchiveDownload.downloadRelease(
+            applicationContext.cacheDir.toPath(),
+            { isStopped },
+            { completed, total ->
+                val percent = if (total == 0L) 0L else completed * 100L / total
+                if (percent != lastDownloadPercent) {
+                    lastDownloadPercent = percent
+                    setProgressAsync(progressData("download", completed, total))
+                    setForegroundAsync(
+                        foregroundInfo("Downloading Retro Rewind…", completed, total),
+                    )
+                }
+            },
+        )
+        when (RetroRewindInstallWorkPolicy.afterDownload(download.error)) {
+            RetroRewindInstallWorkPolicy.Action.RETRY -> return@withContext Result.retry()
+            RetroRewindInstallWorkPolicy.Action.FAILURE ->
+                return@withContext failure("download-${download.error.name.lowercase()}")
+            RetroRewindInstallWorkPolicy.Action.CANCELLED ->
+                return@withContext failure("cancelled")
+            RetroRewindInstallWorkPolicy.Action.CONTINUE -> Unit
+        }
+
+        setForeground(foregroundInfo("Installing Retro Rewind…"))
+        setPhase("extract", 0, 0)
+        var lastExtractPercent = -1L
+        val install = RetroRewindInstallPipeline.install(
+            applicationContext.filesDir,
+            RetroRewindArchiveDownload.archivePath(applicationContext.cacheDir.toPath()),
+            token,
+            { isStopped },
+            { completed, total ->
+                val percent = if (total == 0L) 0L else completed * 100L / total
+                if (percent != lastExtractPercent) {
+                    lastExtractPercent = percent
+                    setProgressAsync(progressData("extract", completed, total))
+                    setForegroundAsync(
+                        foregroundInfo("Installing Retro Rewind…", completed, total),
+                    )
+                }
+            },
+        )
+        when (RetroRewindInstallWorkPolicy.afterInstall(install)) {
+            RetroRewindInstallWorkPolicy.Action.CONTINUE -> Unit
+            RetroRewindInstallWorkPolicy.Action.CANCELLED ->
+                return@withContext failure("cancelled")
+            else -> return@withContext failure("install-${install.error.name.lowercase()}")
+        }
+
+        try {
+            Files.deleteIfExists(
+                RetroRewindArchiveDownload.archivePath(applicationContext.cacheDir.toPath()),
+            )
+        } catch (_: Exception) {
+            // A verified cache file is safe to reuse or remove on a later launch.
+        }
+        setPhase("installed", 1, 1)
+        Result.success(progressData("installed", 1, 1))
+    }
+
+    private suspend fun setPhase(phase: String, completed: Long, total: Long) {
+        setProgress(progressData(phase, completed, total))
+    }
+
+    private suspend fun runDebugFixture(): Result {
+        val steps = inputData.getInt(RetroRewindInstallWork.KEY_DEBUG_FIXTURE_STEPS, 3)
+        val delayMillis = inputData.getLong(
+            RetroRewindInstallWork.KEY_DEBUG_FIXTURE_DELAY_MILLIS,
+            250,
+        )
+        if (steps !in 1..120 || delayMillis !in 1..5_000) {
+            return failure("invalid-fixture-input")
+        }
+        Log.i(
+            LOG_TAG,
+            "A3 durable worker fixture started id=$id attempt=$runAttemptCount steps=$steps",
+        )
+        for (step in 1L..steps.toLong()) {
+            if (isStopped) return failure("cancelled")
+            setPhase("fixture", step, steps.toLong())
+            delay(delayMillis)
+        }
+        Log.i(LOG_TAG, "A3 durable worker fixture completed id=$id attempt=$runAttemptCount")
+        return Result.success(progressData("installed", 1, 1))
+    }
+
+    private fun failure(error: String): Result = Result.failure(
+        workDataOf(
+            RetroRewindInstallWork.KEY_PHASE to "failed",
+            RetroRewindInstallWork.KEY_ERROR to error,
+        ),
+    )
+
+    private fun foregroundInfo(
+        message: String,
+        completed: Long = 0,
+        total: Long = 0,
+    ): ForegroundInfo {
+        val notifications = applicationContext.getSystemService(NotificationManager::class.java)
+        notifications.createNotificationChannel(
+            NotificationChannel(
+                NOTIFICATION_CHANNEL,
+                "Game data installation",
+                NotificationManager.IMPORTANCE_LOW,
+            ),
+        )
+        val notificationBuilder = Notification.Builder(applicationContext, NOTIFICATION_CHANNEL)
+            .setSmallIcon(R.drawable.ic_kartpad)
+            .setContentTitle("KartPad")
+            .setContentText(message)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+        if (total > 0 && completed in 0..total) {
+            notificationBuilder.setProgress(
+                PROGRESS_MAX,
+                (completed * PROGRESS_MAX / total).toInt(),
+                false,
+            )
+        } else {
+            notificationBuilder.setProgress(0, 0, true)
+        }
+        val notification = notificationBuilder.build()
+        return if (Build.VERSION.SDK_INT >= 29) {
+            ForegroundInfo(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        } else {
+            ForegroundInfo(NOTIFICATION_ID, notification)
+        }
+    }
+
+    private fun progressData(phase: String, completed: Long, total: Long) = workDataOf(
+        RetroRewindInstallWork.KEY_PHASE to phase,
+        RetroRewindInstallWork.KEY_COMPLETED_BYTES to completed,
+        RetroRewindInstallWork.KEY_TOTAL_BYTES to total,
+    )
+
+    companion object {
+        private const val NOTIFICATION_CHANNEL = "kartpad-game-data-install"
+        private const val NOTIFICATION_ID = 0x4b50
+        private const val PROGRESS_MAX = 100
+        private const val LOG_TAG = "KartPadFixture"
+    }
+}

--- a/android/app/src/test/java/dev/kartpad/android/RetroRewindArchiveDownloadTestMain.java
+++ b/android/app/src/test/java/dev/kartpad/android/RetroRewindArchiveDownloadTestMain.java
@@ -21,8 +21,17 @@ public final class RetroRewindArchiveDownloadTestMain {
             Path partial = directory.resolve("fixture.part");
             Files.write(partial, new byte[0]);
 
-            expectError(transfer(content, partial, content.length, hash, () -> false),
+            long[] progress = {0, 0};
+            expectError(RetroRewindArchiveDownload.transfer(
+                            new ByteArrayInputStream(content), partial,
+                            content.length, hash, () -> false,
+                            (downloaded, total) -> {
+                                progress[0] = downloaded;
+                                progress[1] = total;
+                            }),
                     RetroRewindArchiveDownload.Error.NONE);
+            expect(progress[0] == content.length && progress[1] == content.length,
+                    "successful transfer did not report final progress");
             expect(java.util.Arrays.equals(content, Files.readAllBytes(partial)),
                     "successful transfer bytes changed");
             expectError(RetroRewindArchiveDownload.verifyFile(

--- a/android/app/src/test/java/dev/kartpad/android/RetroRewindInstallWorkPolicyTestMain.java
+++ b/android/app/src/test/java/dev/kartpad/android/RetroRewindInstallWorkPolicyTestMain.java
@@ -1,0 +1,60 @@
+package dev.kartpad.android;
+
+public final class RetroRewindInstallWorkPolicyTestMain {
+    private RetroRewindInstallWorkPolicyTestMain() {}
+
+    public static void main(String[] args) {
+        expectDownload(RetroRewindArchiveDownload.Error.NONE,
+                RetroRewindInstallWorkPolicy.Action.CONTINUE);
+        expectDownload(RetroRewindArchiveDownload.Error.NETWORK_FAILURE,
+                RetroRewindInstallWorkPolicy.Action.RETRY);
+        expectDownload(RetroRewindArchiveDownload.Error.HTTP_FAILURE,
+                RetroRewindInstallWorkPolicy.Action.FAILURE);
+        expectDownload(RetroRewindArchiveDownload.Error.CANCELLED,
+                RetroRewindInstallWorkPolicy.Action.CANCELLED);
+        expectDownload(RetroRewindArchiveDownload.Error.HASH_MISMATCH,
+                RetroRewindInstallWorkPolicy.Action.FAILURE);
+        expectDownload(RetroRewindArchiveDownload.Error.SIZE_MISMATCH,
+                RetroRewindInstallWorkPolicy.Action.FAILURE);
+
+        expectInstall(
+                new RetroRewindInstallPipeline.Result(
+                        RetroRewindInstallPipeline.Error.NONE,
+                        RetroRewindArchiveExtractor.Error.NONE,
+                        RetroRewindInstallValidator.Error.NONE),
+                RetroRewindInstallWorkPolicy.Action.CONTINUE);
+        expectInstall(
+                new RetroRewindInstallPipeline.Result(
+                        RetroRewindInstallPipeline.Error.EXTRACTION_FAILURE,
+                        RetroRewindArchiveExtractor.Error.CANCELLED,
+                        null),
+                RetroRewindInstallWorkPolicy.Action.CANCELLED);
+        expectInstall(
+                new RetroRewindInstallPipeline.Result(
+                        RetroRewindInstallPipeline.Error.CONTENT_INVALID,
+                        RetroRewindArchiveExtractor.Error.NONE,
+                        RetroRewindInstallValidator.Error.HASH_MISMATCH),
+                RetroRewindInstallWorkPolicy.Action.FAILURE);
+        System.out.println("Android Retro Rewind worker policy passed.");
+    }
+
+    private static void expectDownload(
+            RetroRewindArchiveDownload.Error error,
+            RetroRewindInstallWorkPolicy.Action expected) {
+        expect(RetroRewindInstallWorkPolicy.afterDownload(error) == expected,
+                "unexpected download action for " + error);
+    }
+
+    private static void expectInstall(
+            RetroRewindInstallPipeline.Result result,
+            RetroRewindInstallWorkPolicy.Action expected) {
+        expect(RetroRewindInstallWorkPolicy.afterInstall(result) == expected,
+                "unexpected install action for " + result.error);
+    }
+
+    private static void expect(boolean condition, String message) {
+        if (!condition) {
+            throw new AssertionError(message);
+        }
+    }
+}

--- a/dependencies.lock.json
+++ b/dependencies.lock.json
@@ -131,6 +131,14 @@
       "role": "Pinned ZIP directory and decompression implementation for the bounded Android Retro Rewind installer"
     },
     {
+      "name": "AndroidX WorkManager",
+      "repository": "https://android.googlesource.com/platform/frameworks/support",
+      "version": "2.11.1",
+      "coordinates": "androidx.work:work-runtime-ktx:2.11.1",
+      "releaseNotes": "https://developer.android.com/jetpack/androidx/releases/work#2.11.1",
+      "role": "Unique durable foreground orchestration, retry, cancellation, constraints, and persisted progress for Android Retro Rewind installation"
+    },
+    {
       "name": "sse2neon",
       "repository": "https://github.com/DLTcollab/sse2neon.git",
       "commit": "13a42df35dc7fcc94f987568e7274a998bb6cc86",

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -881,20 +881,26 @@ Independent A3 source work now includes generated release pins, validated
 same-volume activation/recovery, installed-content validation, and an
 overflow-safe filesystem-aware free-space preflight. The current production
 profile requires 4,327,477,355 bytes when cache and files share storage. The
-download/extraction worker is still absent, so these are tested contracts rather
-than an installed Retro Rewind runtime. Evidence is under
+source-only contracts are now consumed by a unique AndroidX foreground worker,
+but they still do not constitute an installed Retro Rewind runtime. Evidence is under
 [`docs/artifacts/2026-09-04/android/`](artifacts/2026-09-04/android/).
 Pinned archive acquisition is also implemented as a source-only contract: it
 uses HTTPS-only bounded redirects/timeouts, exact streamed length/SHA-256,
 cancellation, verified-cache reuse, and atomic publication. INTERNET is the
-only allowed manifest permission. A worker/UI and ZIP extraction still need to
-consume these layers before A3 can claim an install.
+network permission required directly by KartPad; WorkManager adds its bounded
+network-state, foreground-service, wake/boot, and app-scoped receiver
+permissions. The strict audit rejects anything outside that exact set.
 Bounded ZIP extraction is now connected as well: the pinned minizip-ng core
 uses the shared scan, strict UTF-8, directory-relative no-follow/exclusive
 writes, CRC/byte checks, cancellation, and byte progress. A joined Java pipeline
 revalidates the archive and gates atomic activation on the installed-content
 contract. Fixture-sized JNI extraction passes on both supported AVD page sizes;
-production download/worker/process-death and Retro Rewind gameplay remain open.
+the unique worker now orders recovery, capacity, download, extraction,
+validation, activation, and cache cleanup, with persisted visible progress,
+cancellation, transport retry, and duplicate suppression. Fixture work passes
+on both page-size lanes, and the same UUID restarts after an injected app
+process death on API 36. Partial HTTP transfer is not yet resumable, and the
+production-size install and Retro Rewind gameplay remain open.
 Do not begin the touch-UI port until A2's controller-driven Original-mode proof
 passes. Physical Android hardware remains authoritative for vendor Vulkan and
 controller behavior; Retro Rewind installation and touch parity follow from

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -204,10 +204,21 @@ not block offline Retro Rewind support.
    no-follow directory-relative output, JNI cancellation/progress, exact
    staging cleanup, and a joined validation/atomic-activation pipeline. Host
    faults, full private native linkage, public build/lint/audit, and wiped 4 KiB
-   plus 16 KiB AVD JNI execution pass. Production-size install, a durable
-   worker, injected process death, and Retro Rewind gameplay remain open.
+   plus 16 KiB AVD JNI execution pass. At that checkpoint, production-size
+   install, durable orchestration, and Retro Rewind gameplay remained open.
    Evidence:
    `docs/artifacts/2026-09-04/android/a3-archive-extraction.md`.
+   The next stacked slice adds that durable owner: one unique AndroidX
+   foreground worker now sequences recovery, capacity preflight, pinned
+   download, extraction, validation, activation, and cache cleanup. It persists
+   phase/byte progress, updates its data-sync notification, exposes
+   cancellation, retries transport loss, and suppresses duplicate enqueue.
+   Wiped 4 KiB and 16 KiB AVDs each prove exactly one start after two enqueues.
+   A separate API 36 fault run kills the application during active work; the
+   same persisted UUID restarts at attempt 1 after relaunch and completes.
+   Partial HTTP resume, production-size installation/faults, Retro Rewind
+   gameplay/mode switching, and physical acceptance remain open. Evidence:
+   `docs/artifacts/2026-09-04/android/a3-install-worker.md`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2345,3 +2345,31 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   download, durable worker/process-death behavior, Retro Rewind runtime, and
   physical acceptance remain open. No artifact or private data was published.
   Evidence: `docs/artifacts/2026-09-04/android/a3-archive-extraction.md`.
+
+## 2026-09-04 — Android A3 durable foreground install worker
+
+- Locked AndroidX WorkManager 2.11.1 and added one unique connected-network
+  foreground job that orders recovery, exact space preflight, pinned download,
+  bounded extraction, content validation, atomic activation, and cache cleanup.
+- Work phase and byte progress are persisted and mirrored in the visible
+  data-sync notification. Duplicate enqueue uses `KEEP`; transport faults
+  retry, integrity/storage/install faults fail closed, and a stable facade
+  exposes cancellation for the future A4 setup UI.
+- Wiped 4 KiB and 16 KiB AVDs each started one fixture after two enqueue calls
+  and completed it. A separate wiped API 36 run force-stopped the app during
+  active work, confirmed the process was absent, then observed the same work
+  UUID restart at attempt 1 and complete after an ordinary activity relaunch.
+- All seven underlying A3 contract runners, public build/release compilation,
+  lint, private game-source compilation, strict package/privacy audit, the
+  22-test builder suite, SunPad snapshot, safety, shell, and diff checks pass.
+  The source verifier reaches the known unrelated ignored `rr-pulsar`
+  checkout/lock mismatch.
+- The source-only APK is 33,843,921 bytes with SHA-256
+  `5ee1edf08ceb2173f9fc32824872c1489d80e1fddf6dd8f41738a73b5cfa19a7`.
+- Classification: **Pass for unique foreground orchestration, progress,
+  cancellation/retry policy, duplicate suppression, and injected app-process
+  death recovery on the emulator.** Partial HTTP resume, the production
+  download/install and interruption matrix, Retro Rewind gameplay/mode
+  switching, and physical hardware remain open. No APK/AAB, production archive,
+  or private data was published. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-install-worker.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -327,6 +327,20 @@ lifecycle, process-death injection, and Retro Rewind gameplay are still open.
 Evidence:
 [`docs/artifacts/2026-09-04/android/a3-archive-extraction.md`](artifacts/2026-09-04/android/a3-archive-extraction.md).
 
+The next A3 layer now joins recovery, capacity preflight, verified download,
+bounded extraction, content validation, activation, and cache cleanup behind
+one unique AndroidX WorkManager foreground job. It persists phase/byte progress,
+updates a data-sync notification, suppresses duplicate enqueue with `KEEP`,
+retries transport loss, and exposes cancellation for the future setup UI.
+Wiped 4 KiB and 16 KiB AVDs each started exactly one fixture after two
+enqueues. A separate API 36 run force-stopped KartPad during active work; the
+same persisted UUID restarted at attempt 1 after a plain relaunch and completed.
+Package, build/lint, private-source configuration, and all underlying A3
+contracts pass. A3 remains open for resumable partial transfer, production-size
+installation and fault injection, Retro Rewind gameplay/mode switching, and
+physical hardware. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-install-worker.md`](artifacts/2026-09-04/android/a3-install-worker.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-04/android/a3-install-worker.md
+++ b/docs/artifacts/2026-09-04/android/a3-install-worker.md
@@ -1,0 +1,79 @@
+# Android A3 durable install worker
+
+Date: 2026-09-04
+
+Branch: `codex/android-a3-install-worker`
+
+Baseline: `93e5a1c5724e9c1f0d9c1ae45d66abb4378a5c42`
+
+## Falsifiable subgoal
+
+Join the existing Retro Rewind space, download, extraction, validation, and
+atomic-activation owners behind one unique foreground-capable Android job.
+Prove that duplicate enqueue does not duplicate work and that the exact
+persisted request restarts and finishes after its application process is
+force-stopped. Do not download or publish the production archive.
+
+## Result
+
+- Locked AndroidX WorkManager 2.11.1 and added one unique
+  `kartpad-retro-rewind-install` job using `ExistingWorkPolicy.KEEP`.
+  Production work requires a connected network and carries a fresh
+  app-private staging token.
+- The worker performs startup recovery, exact free-space preflight, pinned
+  acquisition, bounded extraction, installed-content validation, atomic
+  activation, and verified-cache cleanup in that order. Network transport
+  failure retries; HTTP, integrity, storage, extraction, and validation faults
+  fail closed; cancellation reaches the synchronous download/extraction
+  callbacks.
+- Work phase and byte counts are persisted through WorkManager progress data.
+  The Android data-sync foreground notification displays the same bounded
+  download/extraction progress. A stable facade exposes unique enqueue and
+  cancellation for the future A4 setup UI.
+- The merged manifest declares WorkManager's foreground service as
+  `dataSync`. The strict package audit allows exactly INTERNET,
+  ACCESS_NETWORK_STATE, FOREGROUND_SERVICE, FOREGROUND_SERVICE_DATA_SYNC,
+  RECEIVE_BOOT_COMPLETED, WAKE_LOCK, and WorkManager's app-scoped
+  `DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION`; it rejects any other used or
+  declared permission.
+- Debug source-only builds have a bounded worker fixture. Enqueuing it twice
+  starts exactly one UUID. A separate 30-second fixture is killed by
+  `am force-stop`; a plain activity relaunch restarts the same UUID at
+  attempt 1 and completes it. Debug fixture entry points are disabled when the
+  private game-runtime configuration is selected.
+
+## Verification
+
+- Worker retry/failure policy and all seven existing Android A3 download,
+  pipeline, extraction, free-space, content, and storage contract runners pass
+  with the pinned JDK. The download test also requires exact final progress.
+- Wiped API 36 / 4 KiB and API 35 / 16 KiB ARM64 AVDs each observed exactly one
+  worker start after two unique-work enqueues, plus completion at attempt 0.
+  Both also passed the existing JNI extraction, memory, scheduler/fiber,
+  controller, Vulkan, orientation, and repeated lifecycle markers.
+- On a separate wiped API 36 AVD, work UUID
+  `1fe6dfba-9f9d-42e0-a825-77668a62a9cf` started at attempt 0, the KartPad
+  process was confirmed absent after force-stop, and the same UUID restarted
+  at attempt 1 and completed. The harness required exactly two starts and no
+  KartPad/Android fatal marker.
+- Public source-only assemble, release Kotlin/Java compilation, API-28 lint,
+  and private game-runtime Kotlin/Java configuration compilation pass.
+  The strict package/privacy audit passes. No ADB target remains.
+- The 22-test builder suite passes with its expected unavailable-private-input
+  skip. The pinned SunPad snapshot, repository safety, shell syntax/lint, and
+  diff checks pass. The broad source verifier reaches all 446 patch hunks and
+  then reports the previously documented ignored `rr-pulsar` checkout
+  mismatch (`b566a5d` local versus `29e76d4` locked); this checkpoint does
+  not alter that checkout.
+- The exact source-only debug APK is 33,843,921 bytes with SHA-256
+  `5ee1edf08ceb2173f9fc32824872c1489d80e1fddf6dd8f41738a73b5cfa19a7`.
+
+## Classification
+
+**Pass for unique foreground orchestration, persisted phase/byte progress,
+cancellation/retry policy, duplicate suppression, and real app-process-death
+restart on the emulator.** This does not prove resumable partial HTTP transfer,
+the 1.86 GB production download, activity/UI cancellation, network loss during
+the production job, complete Retro Rewind gameplay, or physical hardware.
+A2 and A3 remain open. No APK/AAB, production archive, private data, device
+identifier, or raw log was published.

--- a/scripts/audit-android-package.sh
+++ b/scripts/audit-android-package.sh
@@ -24,8 +24,23 @@ badging="$("$aapt2" dump badging "$apk")"
 permissions="$("$aapt2" dump permissions "$apk")"
 permission_names="$(printf '%s\n' "$permissions" |
   sed -n "s/^uses-permission: name='\([^']*\)'.*$/\1/p" | sort)"
-if [[ "$permission_names" != "android.permission.INTERNET" ]]; then
-  echo "ERROR: KartPad Android permission set differs from the network-only allowlist" >&2
+expected_permission_names="$(printf '%s\n' \
+  android.permission.ACCESS_NETWORK_STATE \
+  android.permission.FOREGROUND_SERVICE \
+  android.permission.FOREGROUND_SERVICE_DATA_SYNC \
+  android.permission.INTERNET \
+  android.permission.RECEIVE_BOOT_COMPLETED \
+  android.permission.WAKE_LOCK \
+  dev.kartpad.android.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION | sort)"
+if [[ "$permission_names" != "$expected_permission_names" ]]; then
+  echo "ERROR: KartPad Android permission set differs from the install-worker allowlist" >&2
+  exit 1
+fi
+declared_permissions="$(printf '%s\n' "$permissions" |
+  sed -n "s/^permission: \([^[:space:]]*\).*$/\1/p" | sort)"
+if [[ "$declared_permissions" != \
+      "dev.kartpad.android.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION" ]]; then
+  echo "ERROR: KartPad Android declared-permission set differs from the allowlist" >&2
   exit 1
 fi
 

--- a/scripts/run-android-fixture.sh
+++ b/scripts/run-android-fixture.sh
@@ -66,7 +66,8 @@ apk="$repo_root/android/app/build/outputs/apk/debug/app-debug.apk"
 "$adb" logcat -c
 "$adb" shell am force-stop dev.kartpad.android
 "$adb" shell am start -W -n dev.kartpad.android/.KartPadActivity \
-  --ez dev.kartpad.android.TEST_RETRO_REWIND_EXTRACTION true >/dev/null
+  --ez dev.kartpad.android.TEST_RETRO_REWIND_EXTRACTION true \
+  --ez dev.kartpad.android.TEST_RETRO_REWIND_WORKER true >/dev/null
 wait_for_marker() {
   local marker="$1"
   for _ in {1..60}; do
@@ -87,6 +88,22 @@ wait_for_marker \
   "A1 ELF scheduler passed operations=2000000 hash=0x7287563387fb1677 fiber_switches=1000000"
 wait_for_marker "A2 SDL gamepad contract passed"
 wait_for_marker "A3 JNI archive extraction passed entries=2 bytes=7"
+wait_for_marker "A3 durable worker fixture enqueued twice with KEEP"
+wait_for_marker "A3 durable worker fixture started id="
+worker_id="$("$adb" logcat -d -v brief KartPadFixture:I '*:S' |
+  sed -n 's/.*A3 durable worker fixture started id=\([^ ]*\).*/\1/p' |
+  tail -1)"
+[[ "$worker_id" =~ ^[0-9a-f-]{36}$ ]] || {
+  echo "ERROR: could not parse unique worker id: $worker_id" >&2
+  exit 1
+}
+wait_for_marker "A3 durable worker fixture completed id=$worker_id attempt=0"
+worker_starts="$("$adb" logcat -d -v brief KartPadFixture:I '*:S' |
+  grep -Fc "A3 durable worker fixture started id=$worker_id")"
+[[ "$worker_starts" == 1 ]] || {
+  echo "ERROR: unique worker fixture started $worker_starts times" >&2
+  exit 1
+}
 wait_for_marker \
   "A1 Vulkan present passed abi=arm64-v8a page_size=$expected_page_size"
 

--- a/scripts/test-android-retro-rewind-worker-policy.sh
+++ b/scripts/test-android-retro-rewind-worker-policy.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
+# shellcheck source=android-toolchain-versions.sh
+source "${repo_root}/scripts/android-toolchain-versions.sh"
+java_home="${repo_root}/.android-bootstrap/jdk-${KARTPAD_ANDROID_JDK_VERSION}/Contents/Home"
+classes="${repo_root}/build/android-retro-rewind-worker-policy-tests"
+
+if [[ ! -x "${java_home}/bin/javac" || ! -x "${java_home}/bin/java" ]]; then
+  echo "ERROR: pinned Android JDK is unavailable; run scripts/bootstrap-android-host.sh" >&2
+  exit 1
+fi
+
+mkdir -p "${classes}"
+find "${classes}" -type f -delete
+"${java_home}/bin/javac" -Werror -Xlint:all -d "${classes}" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindRelease.java" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindArchiveDownload.java" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindArchiveExtractor.java" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallStorage.java" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallValidator.java" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallPipeline.java" \
+  "${repo_root}/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWorkPolicy.java" \
+  "${repo_root}/android/app/src/test/java/dev/kartpad/android/RetroRewindInstallWorkPolicyTestMain.java"
+"${java_home}/bin/java" -cp "${classes}" \
+  dev.kartpad.android.RetroRewindInstallWorkPolicyTestMain

--- a/scripts/test-android-retro-rewind-worker-restart.sh
+++ b/scripts/test-android-retro-rewind-worker-restart.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+# shellcheck source=android-toolchain-versions.sh
+source "$repo_root/scripts/android-toolchain-versions.sh"
+sdk_root="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/Library/Android/sdk}}"
+adb="$sdk_root/platform-tools/adb"
+emulator="$sdk_root/emulator/emulator"
+avd="$KARTPAD_ANDROID_PHONE_AVD"
+package="dev.kartpad.android"
+component="$package/.KartPadActivity"
+
+if "$adb" devices | sed -n '2,$p' | grep -q '[[:space:]]device$'; then
+  echo "ERROR: an Android device/emulator is already connected; preserve the one-emulator rule" >&2
+  exit 1
+fi
+
+"$repo_root/scripts/build-android-fixture.sh"
+"$repo_root/scripts/audit-android-package.sh"
+emulator_log="$repo_root/.android-bootstrap/emulator-$avd-worker-restart.raw.log"
+"$emulator" "@$avd" -no-window -no-audio -no-boot-anim -no-snapshot \
+  -gpu auto -wipe-data >"$emulator_log" 2>&1 &
+emulator_pid=$!
+cleanup() {
+  "$adb" emu kill >/dev/null 2>&1 || true
+  wait "$emulator_pid" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+"$adb" wait-for-device
+booted=0
+for _ in {1..60}; do
+  if [[ "$("$adb" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" == "1" ]]; then
+    booted=1
+    break
+  fi
+  sleep 2
+done
+[[ "$booted" == 1 ]] || { echo "ERROR: emulator did not finish booting" >&2; exit 1; }
+
+"$adb" shell input keyevent KEYCODE_WAKEUP >/dev/null
+"$adb" shell wm dismiss-keyguard >/dev/null 2>&1 || true
+"$adb" shell settings put system accelerometer_rotation 0
+"$adb" shell settings put system user_rotation 1
+"$adb" install -r "$repo_root/android/app/build/outputs/apk/debug/app-debug.apk" >/dev/null
+"$adb" logcat -c
+
+wait_for_marker() {
+  local marker="$1"
+  for _ in {1..60}; do
+    if "$adb" logcat -d -v brief KartPadFixture:I AndroidRuntime:E '*:S' |
+        grep -Fq "$marker"; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "ERROR: worker restart marker was not observed: $marker" >&2
+  "$adb" logcat -d -v brief KartPadFixture:V WM-WorkerWrapper:V AndroidRuntime:E '*:S' >&2
+  return 1
+}
+
+"$adb" shell am start -W -n "$component" \
+  --ez dev.kartpad.android.TEST_RETRO_REWIND_WORKER_RESTART true >/dev/null
+wait_for_marker "A3 durable worker restart fixture enqueued id="
+worker_id="$("$adb" logcat -d -v brief KartPadFixture:I '*:S' |
+  sed -n 's/.*A3 durable worker restart fixture enqueued id=\([^ ]*\).*/\1/p' |
+  tail -1)"
+[[ "$worker_id" =~ ^[0-9a-f-]{36}$ ]] || {
+  echo "ERROR: could not parse durable worker id: $worker_id" >&2
+  exit 1
+}
+wait_for_marker "A3 durable worker fixture started id=$worker_id attempt=0 steps=60"
+
+"$adb" shell am force-stop "$package"
+if "$adb" shell pidof "$package" | grep -q '[0-9]'; then
+  echo "ERROR: KartPad process survived force-stop" >&2
+  exit 1
+fi
+"$adb" shell am start -W -n "$component" >/dev/null
+wait_for_marker "A3 durable worker fixture completed id=$worker_id attempt=1"
+
+worker_starts="$("$adb" logcat -d -v brief KartPadFixture:I '*:S' |
+  grep -Fc "A3 durable worker fixture started id=$worker_id")"
+[[ "$worker_starts" == 2 ]] || {
+  echo "ERROR: persisted worker $worker_id started $worker_starts times; expected exactly 2" >&2
+  exit 1
+}
+if "$adb" logcat -d -v brief KartPadFixture:E AndroidRuntime:E '*:S' | grep -q .; then
+  echo "ERROR: worker restart fixture emitted an error" >&2
+  "$adb" logcat -d -v brief KartPadFixture:V AndroidRuntime:E '*:S' >&2
+  exit 1
+fi
+
+echo "Android A3 durable worker restart passed: avd=$avd worker_id=$worker_id process_starts=$worker_starts final_state=completed"


### PR DESCRIPTION
## Summary
- join recovery, space preflight, pinned download, extraction, validation, and atomic activation behind one unique foreground WorkManager job
- persist and display bounded progress, expose cancellation, suppress duplicate enqueue, and classify retry/failure outcomes
- prove exact-work restart after app process death and extend the strict Android package audit for the bounded WorkManager permission set

## Verification
- all seven Android A3 contract runners pass
- wiped API 36 / 4 KiB and API 35 / 16 KiB AVD fixture runs pass with exactly one worker start after two KEEP enqueues
- separate wiped API 36 force-stop test restarts and completes the same persisted UUID at attempt 1
- source-only assemble, release Kotlin/Java compile, API-28 lint, private game-runtime source configuration compile, package/privacy audit, builder suite, SunPad snapshot, repository safety, shell lint, and diff checks pass

A3 remains open for resumable partial HTTP transfer, the production-size install/fault matrix, Retro Rewind gameplay and mode switching, and physical hardware. No APK/AAB or private game data is published.