### PR TITLE
Resume Android Retro Rewind downloads

### DIFF
--- a/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
@@ -5,8 +5,10 @@ import android.content.Context
 import android.system.Os
 import android.util.Log
 import android.view.ViewGroup
+import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.FileOutputStream
+import java.nio.file.Files
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import org.libsdl.app.SDLActivity
@@ -138,14 +140,44 @@ class KartPadActivity : SDLActivity() {
                     this,
                     steps = 60,
                     delayMillis = 500,
+                    resumeProcessDeath = true,
                 )
                 Log.i(TAG, "A3 durable worker restart fixture enqueued id=$id")
             }
             intent.getBooleanExtra(DEBUG_EXTRA_RETRO_REWIND_WORKER, false) -> {
+                runDebugRetroRewindResumeFixture()
                 RetroRewindInstallWork.enqueueDebugFixture(this)
                 RetroRewindInstallWork.enqueueDebugFixture(this)
                 Log.i(TAG, "A3 durable worker fixture enqueued twice with KEEP")
             }
+        }
+    }
+
+    private fun runDebugRetroRewindResumeFixture() {
+        val content = "resume-fixture-content".toByteArray(Charsets.UTF_8)
+        val resumeOffset = 7
+        val partial = Files.createTempFile(cacheDir.toPath(), "resume-fixture-", ".part")
+        try {
+            Files.write(partial, content.copyOf(resumeOffset))
+            val result = RetroRewindArchiveDownload.transferResuming(
+                ByteArrayInputStream(content, resumeOffset, content.size - resumeOffset),
+                partial,
+                content.size.toLong(),
+                DEBUG_RESUME_FIXTURE_SHA256,
+                resumeOffset.toLong(),
+                { false },
+                { _, _ -> },
+            )
+            check(result == RetroRewindArchiveDownload.Error.NONE)
+            check(Files.readAllBytes(partial).contentEquals(content))
+            Log.i(
+                TAG,
+                "A3 resumable transfer passed prefix=$resumeOffset total=${content.size}",
+            )
+        } catch (error: Exception) {
+            Log.e(TAG, "A3 resumable transfer failed", error)
+        } finally {
+            Files.deleteIfExists(partial)
         }
     }
 
@@ -164,6 +196,8 @@ class KartPadActivity : SDLActivity() {
             "dev.kartpad.android.TEST_RETRO_REWIND_WORKER"
         private const val DEBUG_EXTRA_RETRO_REWIND_WORKER_RESTART =
             "dev.kartpad.android.TEST_RETRO_REWIND_WORKER_RESTART"
+        private const val DEBUG_RESUME_FIXTURE_SHA256 =
+            "cb9d5fc3b83611af65032f73119285de4e97d4b2b9f7b2e9567443635358483a"
         private const val MIN_RKG_BYTES = 0x90L
         private const val MAX_RKG_BYTES = 1024L * 1024L
         private val RKG_MAGIC = byteArrayOf('R'.code.toByte(), 'K'.code.toByte(), 'G'.code.toByte(), 'D'.code.toByte())

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindArchiveDownload.java
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindArchiveDownload.java
@@ -13,6 +13,8 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /** Downloads and verifies the one profile-pinned Retro Rewind archive. */
 final class RetroRewindArchiveDownload {
@@ -20,6 +22,8 @@ final class RetroRewindArchiveDownload {
     private static final int MAXIMUM_REDIRECTS = 5;
     private static final int CONNECT_TIMEOUT_MILLIS = 30_000;
     private static final int READ_TIMEOUT_MILLIS = 30_000;
+    private static final Pattern CONTENT_RANGE = Pattern.compile(
+            "bytes ([0-9]+)-([0-9]+)/([0-9]+)");
 
     interface Cancellation {
         boolean isCancelled();
@@ -71,21 +75,43 @@ final class RetroRewindArchiveDownload {
         Path archive = archivePath(cacheDirectory);
         if (verifyFile(archive, RetroRewindRelease.ARCHIVE_BYTES,
                 RetroRewindRelease.ARCHIVE_SHA256) == Error.NONE) {
+            deletePartial(partialPath(cacheDirectory));
             return result(Error.NONE, true);
         }
 
-        Path partial;
+        Path partial = partialPath(cacheDirectory);
+        long existingBytes;
         try {
-            partial = Files.createTempFile(cacheDirectory,
-                    ".RetroRewind-" + RetroRewindRelease.VERSION + "-", ".part");
+            existingBytes = preparePartial(partial, RetroRewindRelease.ARCHIVE_BYTES,
+                    RetroRewindRelease.ARCHIVE_SHA256);
         } catch (IOException exception) {
             return result(Error.STORAGE_FAILURE, false);
         }
 
+        if (existingBytes == RetroRewindRelease.ARCHIVE_BYTES) {
+            try {
+                Files.move(partial, archive, StandardCopyOption.ATOMIC_MOVE,
+                        StandardCopyOption.REPLACE_EXISTING);
+                return result(Error.NONE, true);
+            } catch (IOException exception) {
+                return result(Error.STORAGE_FAILURE, false);
+            }
+        }
+
+        Result transfer = downloadPinned(partial, existingBytes, cancellation, progress);
+        if (!transfer.isReady()) {
+            if (transfer.error != Error.CANCELLED &&
+                    transfer.error != Error.NETWORK_FAILURE &&
+                    transfer.error != Error.STORAGE_FAILURE) {
+                deletePartial(partial);
+            }
+            return transfer;
+        }
         try {
-            Result transfer = downloadPinned(partial, cancellation, progress);
-            if (!transfer.isReady()) {
-                return transfer;
+            if (verifyFile(partial, RetroRewindRelease.ARCHIVE_BYTES,
+                    RetroRewindRelease.ARCHIVE_SHA256) != Error.NONE) {
+                deletePartial(partial);
+                return result(Error.HASH_MISMATCH, false);
             }
             try {
                 Files.move(partial, archive, StandardCopyOption.ATOMIC_MOVE,
@@ -94,12 +120,9 @@ final class RetroRewindArchiveDownload {
             } catch (IOException exception) {
                 return result(Error.STORAGE_FAILURE, false);
             }
-        } finally {
-            try {
-                Files.deleteIfExists(partial);
-            } catch (IOException ignored) {
-                // A private, unverified .part file is never treated as an archive.
-            }
+        } catch (RuntimeException exception) {
+            deletePartial(partial);
+            return result(Error.STORAGE_FAILURE, false);
         }
     }
 
@@ -108,17 +131,39 @@ final class RetroRewindArchiveDownload {
                 "RetroRewind-" + RetroRewindRelease.VERSION + ".zip");
     }
 
+    static Path partialPath(Path cacheDirectory) {
+        return cacheDirectory.resolve(
+                ".RetroRewind-" + RetroRewindRelease.VERSION + ".part");
+    }
+
     private static Result downloadPinned(
-            Path partial, Cancellation cancellation, Progress progress) {
-        URL current;
+            Path partial, long resumeOffset, Cancellation cancellation, Progress progress) {
+        URL initial;
         try {
-            current = new URL(RetroRewindRelease.ARCHIVE_URL);
+            initial = new URL(RetroRewindRelease.ARCHIVE_URL);
         } catch (IOException exception) {
             return result(Error.NETWORK_FAILURE, false);
         }
+        return downloadFrom(initial, partial, resumeOffset,
+                RetroRewindRelease.ARCHIVE_BYTES, RetroRewindRelease.ARCHIVE_SHA256,
+                cancellation, progress);
+    }
 
+    static Result downloadFrom(
+            URL initial,
+            Path partial,
+            long resumeOffset,
+            long expectedBytes,
+            String expectedSha256,
+            Cancellation cancellation,
+            Progress progress) {
+        if (resumeOffset < 0 || resumeOffset > expectedBytes ||
+                cancellation == null || progress == null) {
+            return result(Error.STORAGE_FAILURE, false);
+        }
+        URL current = initial;
         for (int redirects = 0; redirects <= MAXIMUM_REDIRECTS; redirects++) {
-            if (!"https".equalsIgnoreCase(current.getProtocol())) {
+            if (current == null || !"https".equalsIgnoreCase(current.getProtocol())) {
                 return result(Error.INSECURE_REDIRECT, false);
             }
 
@@ -129,6 +174,9 @@ final class RetroRewindArchiveDownload {
                 connection.setConnectTimeout(CONNECT_TIMEOUT_MILLIS);
                 connection.setReadTimeout(READ_TIMEOUT_MILLIS);
                 connection.setRequestProperty("Accept-Encoding", "identity");
+                if (resumeOffset > 0) {
+                    connection.setRequestProperty("Range", "bytes=" + resumeOffset + "-");
+                }
                 int response = connection.getResponseCode();
                 if (isRedirect(response)) {
                     if (redirects == MAXIMUM_REDIRECTS) {
@@ -141,7 +189,14 @@ final class RetroRewindArchiveDownload {
                     current = new URL(current, location);
                     continue;
                 }
-                if (response != HttpURLConnection.HTTP_OK) {
+                long transferOffset;
+                if (response == HttpURLConnection.HTTP_OK) {
+                    transferOffset = 0;
+                } else if (response == HttpURLConnection.HTTP_PARTIAL && resumeOffset > 0 &&
+                        isCompleteContentRange(connection.getHeaderField("Content-Range"),
+                                resumeOffset, expectedBytes)) {
+                    transferOffset = resumeOffset;
+                } else {
                     return result(Error.HTTP_FAILURE, false);
                 }
                 String encoding = connection.getContentEncoding();
@@ -149,12 +204,14 @@ final class RetroRewindArchiveDownload {
                     return result(Error.HTTP_FAILURE, false);
                 }
                 long declaredBytes = connection.getContentLengthLong();
-                if (declaredBytes >= 0 && declaredBytes != RetroRewindRelease.ARCHIVE_BYTES) {
+                long expectedResponseBytes = expectedBytes - transferOffset;
+                if (declaredBytes >= 0 && declaredBytes != expectedResponseBytes) {
                     return result(Error.SIZE_MISMATCH, false);
                 }
                 try (InputStream input = new BufferedInputStream(connection.getInputStream())) {
-                    Error error = transfer(input, partial, RetroRewindRelease.ARCHIVE_BYTES,
-                            RetroRewindRelease.ARCHIVE_SHA256, cancellation, progress);
+                    Error error = transferResuming(input, partial,
+                            expectedBytes, expectedSha256, transferOffset,
+                            cancellation, progress);
                     return result(error, false);
                 }
             } catch (IOException exception) {
@@ -185,9 +242,21 @@ final class RetroRewindArchiveDownload {
             String expectedSha256,
             Cancellation cancellation,
             Progress progress) {
+        return transferResuming(input, partial, expectedBytes, expectedSha256, 0,
+                cancellation, progress);
+    }
+
+    static Error transferResuming(
+            InputStream input,
+            Path partial,
+            long expectedBytes,
+            String expectedSha256,
+            long resumeOffset,
+            Cancellation cancellation,
+            Progress progress) {
         byte[] expectedDigest = decodeSha256(expectedSha256);
         if (expectedBytes < 0 || expectedDigest == null || cancellation == null ||
-                progress == null) {
+                progress == null || resumeOffset < 0 || resumeOffset > expectedBytes) {
             return Error.STORAGE_FAILURE;
         }
 
@@ -198,16 +267,50 @@ final class RetroRewindArchiveDownload {
             return Error.STORAGE_FAILURE;
         }
 
-        OutputStream openedOutput;
+        long total = 0;
+        byte[] buffer = new byte[BUFFER_BYTES];
         try {
-            openedOutput = Files.newOutputStream(partial,
-                    StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+            if (!Files.isRegularFile(partial, LinkOption.NOFOLLOW_LINKS) ||
+                    (resumeOffset > 0 && Files.size(partial) != resumeOffset)) {
+                return Error.STORAGE_FAILURE;
+            }
+            if (resumeOffset > 0) {
+                try (InputStream prefix = Files.newInputStream(partial)) {
+                    while (total < resumeOffset) {
+                        if (cancellation.isCancelled()) {
+                            return Error.CANCELLED;
+                        }
+                        int request = (int) Math.min(buffer.length, resumeOffset - total);
+                        int count = prefix.read(buffer, 0, request);
+                        if (count <= 0) {
+                            return Error.STORAGE_FAILURE;
+                        }
+                        digest.update(buffer, 0, count);
+                        total += count;
+                        progress.onProgress(total, expectedBytes);
+                    }
+                    if (prefix.read() != -1) {
+                        return Error.STORAGE_FAILURE;
+                    }
+                }
+            }
         } catch (IOException exception) {
             return Error.STORAGE_FAILURE;
         }
 
-        long total = 0;
-        byte[] buffer = new byte[BUFFER_BYTES];
+        OutputStream openedOutput;
+        try {
+            if (resumeOffset == 0) {
+                openedOutput = Files.newOutputStream(partial,
+                        StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+            } else {
+                openedOutput = Files.newOutputStream(partial,
+                        StandardOpenOption.WRITE, StandardOpenOption.APPEND);
+            }
+        } catch (IOException exception) {
+            return Error.STORAGE_FAILURE;
+        }
+
         try (OutputStream output = openedOutput) {
             while (true) {
                 if (cancellation.isCancelled()) {
@@ -295,6 +398,58 @@ final class RetroRewindArchiveDownload {
                 response == HttpURLConnection.HTTP_MOVED_TEMP ||
                 response == HttpURLConnection.HTTP_SEE_OTHER ||
                 response == 307 || response == 308;
+    }
+
+    static boolean isCompleteContentRange(String value, long offset, long expectedBytes) {
+        if (value == null || offset <= 0 || offset >= expectedBytes) {
+            return false;
+        }
+        Matcher match = CONTENT_RANGE.matcher(value);
+        if (!match.matches()) {
+            return false;
+        }
+        try {
+            long first = Long.parseLong(match.group(1));
+            long last = Long.parseLong(match.group(2));
+            long total = Long.parseLong(match.group(3));
+            return first == offset && last == expectedBytes - 1 && total == expectedBytes;
+        } catch (NumberFormatException exception) {
+            return false;
+        }
+    }
+
+    static long preparePartial(
+            Path partial, long expectedBytes, String expectedSha256) throws IOException {
+        if (Files.exists(partial, LinkOption.NOFOLLOW_LINKS)) {
+            if (!Files.isRegularFile(partial, LinkOption.NOFOLLOW_LINKS)) {
+                Files.delete(partial);
+                Files.createFile(partial);
+                return 0;
+            }
+            long bytes = Files.size(partial);
+            if (bytes < 0 || bytes > expectedBytes) {
+                Files.delete(partial);
+                Files.createFile(partial);
+                return 0;
+            }
+            if (bytes == expectedBytes &&
+                    verifyFile(partial, expectedBytes, expectedSha256) != Error.NONE) {
+                Files.delete(partial);
+                Files.createFile(partial);
+                return 0;
+            }
+            return bytes;
+        }
+        Files.createFile(partial);
+        return 0;
+    }
+
+    private static void deletePartial(Path partial) {
+        try {
+            Files.deleteIfExists(partial);
+        } catch (IOException ignored) {
+            // The stable app-private partial is never accepted without full verification.
+        }
     }
 
     private static byte[] decodeSha256(String value) {

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWork.kt
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWork.kt
@@ -21,6 +21,7 @@ internal object RetroRewindInstallWork {
     const val KEY_DEBUG_FIXTURE = "debug_fixture"
     const val KEY_DEBUG_FIXTURE_STEPS = "debug_fixture_steps"
     const val KEY_DEBUG_FIXTURE_DELAY_MILLIS = "debug_fixture_delay_millis"
+    const val KEY_DEBUG_RESUME_PROCESS_DEATH = "debug_resume_process_death"
 
     fun enqueue(context: Context) {
         val token = UUID.randomUUID().toString()
@@ -48,6 +49,7 @@ internal object RetroRewindInstallWork {
         context: Context,
         steps: Int = 3,
         delayMillis: Long = 250,
+        resumeProcessDeath: Boolean = false,
     ): UUID {
         check(BuildConfig.DEBUG && !BuildConfig.GAME_RUNTIME)
         check(steps in 1..120)
@@ -59,6 +61,7 @@ internal object RetroRewindInstallWork {
                     KEY_DEBUG_FIXTURE to true,
                     KEY_DEBUG_FIXTURE_STEPS to steps,
                     KEY_DEBUG_FIXTURE_DELAY_MILLIS to delayMillis,
+                    KEY_DEBUG_RESUME_PROCESS_DEATH to resumeProcessDeath,
                 ),
             )
             .addTag(TAG)

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWorker.kt
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWorker.kt
@@ -11,6 +11,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
+import java.io.InputStream
 import java.nio.file.Files
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -116,6 +117,13 @@ internal class RetroRewindInstallWorker(
     }
 
     private suspend fun runDebugFixture(): Result {
+        if (inputData.getBoolean(
+                RetroRewindInstallWork.KEY_DEBUG_RESUME_PROCESS_DEATH,
+                false,
+            )
+        ) {
+            return runDebugResumeProcessDeathFixture()
+        }
         val steps = inputData.getInt(RetroRewindInstallWork.KEY_DEBUG_FIXTURE_STEPS, 3)
         val delayMillis = inputData.getLong(
             RetroRewindInstallWork.KEY_DEBUG_FIXTURE_DELAY_MILLIS,
@@ -134,6 +142,52 @@ internal class RetroRewindInstallWorker(
             delay(delayMillis)
         }
         Log.i(LOG_TAG, "A3 durable worker fixture completed id=$id attempt=$runAttemptCount")
+        return Result.success(progressData("installed", 1, 1))
+    }
+
+    private suspend fun runDebugResumeProcessDeathFixture(): Result {
+        val content = DEBUG_RESUME_CONTENT.toByteArray(Charsets.UTF_8)
+        val partial = applicationContext.cacheDir.toPath().resolve(DEBUG_RESUME_PARTIAL)
+        val prefix = try {
+            RetroRewindArchiveDownload.preparePartial(
+                partial,
+                content.size.toLong(),
+                DEBUG_RESUME_SHA256,
+            )
+        } catch (_: Exception) {
+            return failure("fixture-storage")
+        }
+        Log.i(
+            LOG_TAG,
+            "A3 durable resume fixture started id=$id attempt=$runAttemptCount prefix=$prefix",
+        )
+        var checkpointLogged = false
+        val result = RetroRewindArchiveDownload.transferResuming(
+            SlowFixtureInputStream(content, prefix.toInt()),
+            partial,
+            content.size.toLong(),
+            DEBUG_RESUME_SHA256,
+            prefix,
+            { isStopped },
+            { completed, total ->
+                setProgressAsync(progressData("fixture-resume", completed, total))
+                if (!checkpointLogged && completed >= DEBUG_RESUME_CHECKPOINT) {
+                    checkpointLogged = true
+                    Log.i(
+                        LOG_TAG,
+                        "A3 durable resume fixture checkpoint id=$id bytes=$completed",
+                    )
+                }
+            },
+        )
+        if (result != RetroRewindArchiveDownload.Error.NONE) {
+            return failure("fixture-${result.name.lowercase()}")
+        }
+        Files.deleteIfExists(partial)
+        Log.i(
+            LOG_TAG,
+            "A3 durable resume fixture completed id=$id attempt=$runAttemptCount",
+        )
         return Result.success(progressData("installed", 1, 1))
     }
 
@@ -195,5 +249,31 @@ internal class RetroRewindInstallWorker(
         private const val NOTIFICATION_ID = 0x4b50
         private const val PROGRESS_MAX = 100
         private const val LOG_TAG = "KartPadFixture"
+        private const val DEBUG_RESUME_PARTIAL = ".kartpad-worker-resume-fixture.part"
+        private const val DEBUG_RESUME_CONTENT =
+            "durable-resume-fixture-durable-resume-fixture-" +
+                "durable-resume-fixture-durable-resume-fixture-"
+        private const val DEBUG_RESUME_SHA256 =
+            "4eba5a46f29cdb266bf45bfe41d037dfcbe7cfe9d785f12e59af84ea4ecd3e34"
+        private const val DEBUG_RESUME_CHECKPOINT = 4L
+    }
+
+    private class SlowFixtureInputStream(
+        private val content: ByteArray,
+        private var offset: Int,
+    ) : InputStream() {
+        override fun read(): Int {
+            if (offset >= content.size) return -1
+            Thread.sleep(250)
+            return content[offset++].toInt() and 0xff
+        }
+
+        override fun read(output: ByteArray, outputOffset: Int, length: Int): Int {
+            if (offset >= content.size) return -1
+            if (length == 0) return 0
+            Thread.sleep(250)
+            output[outputOffset] = content[offset++]
+            return 1
+        }
     }
 }

--- a/android/app/src/test/java/dev/kartpad/android/RetroRewindArchiveDownloadTestMain.java
+++ b/android/app/src/test/java/dev/kartpad/android/RetroRewindArchiveDownloadTestMain.java
@@ -3,11 +3,16 @@ package dev.kartpad.android;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.HexFormat;
 
 public final class RetroRewindArchiveDownloadTestMain {
@@ -20,6 +25,10 @@ public final class RetroRewindArchiveDownloadTestMain {
             String hash = sha256(content);
             Path partial = directory.resolve("fixture.part");
             Files.write(partial, new byte[0]);
+            expect(RetroRewindArchiveDownload.partialPath(directory).equals(
+                            directory.resolve(".RetroRewind-" +
+                                    RetroRewindRelease.VERSION + ".part")),
+                    "partial path is not stable and version-scoped");
 
             long[] progress = {0, 0};
             expectError(RetroRewindArchiveDownload.transfer(
@@ -36,6 +45,138 @@ public final class RetroRewindArchiveDownloadTestMain {
                     "successful transfer bytes changed");
             expectError(RetroRewindArchiveDownload.verifyFile(
                     partial, content.length, hash), RetroRewindArchiveDownload.Error.NONE);
+
+            int resumeOffset = 7;
+            Files.write(partial, Arrays.copyOf(content, resumeOffset));
+            long[] resumedProgress = {-1, -1};
+            expectError(RetroRewindArchiveDownload.transferResuming(
+                            new ByteArrayInputStream(
+                                    Arrays.copyOfRange(content, resumeOffset, content.length)),
+                            partial, content.length, hash, resumeOffset, () -> false,
+                            (downloaded, total) -> {
+                                if (resumedProgress[0] < 0) {
+                                    resumedProgress[0] = downloaded;
+                                }
+                                resumedProgress[1] = downloaded;
+                            }),
+                    RetroRewindArchiveDownload.Error.NONE);
+            expect(resumedProgress[0] == resumeOffset &&
+                            resumedProgress[1] == content.length,
+                    "resumed transfer did not include cached and final progress");
+            expect(Arrays.equals(content, Files.readAllBytes(partial)),
+                    "resumed transfer bytes changed");
+
+            Files.write(partial, Arrays.copyOf(content, resumeOffset));
+            expectError(RetroRewindArchiveDownload.transferResuming(
+                            new ByteArrayInputStream(
+                                    Arrays.copyOfRange(content, resumeOffset, content.length)),
+                            partial, content.length, hash, resumeOffset, () -> true,
+                            (downloaded, total) -> {}),
+                    RetroRewindArchiveDownload.Error.CANCELLED);
+            expect(Files.size(partial) == resumeOffset,
+                    "cancellation during prefix hashing changed partial bytes");
+
+            Files.write(partial, Arrays.copyOf(content, resumeOffset));
+            int bytesBeforeFailure = 3;
+            expectError(RetroRewindArchiveDownload.transferResuming(
+                            new FailingAfterInputStream(
+                                    Arrays.copyOfRange(content, resumeOffset, content.length),
+                                    bytesBeforeFailure),
+                            partial, content.length, hash, resumeOffset, () -> false,
+                            (downloaded, total) -> {}),
+                    RetroRewindArchiveDownload.Error.NETWORK_FAILURE);
+            long persistedBytes = Files.size(partial);
+            expect(persistedBytes == resumeOffset + bytesBeforeFailure,
+                    "network loss did not preserve appended partial bytes");
+            expectError(RetroRewindArchiveDownload.transferResuming(
+                            new ByteArrayInputStream(
+                                    Arrays.copyOfRange(
+                                            content, (int) persistedBytes, content.length)),
+                            partial, content.length, hash, persistedBytes, () -> false,
+                            (downloaded, total) -> {}),
+                    RetroRewindArchiveDownload.Error.NONE);
+            expect(Arrays.equals(content, Files.readAllBytes(partial)),
+                    "second resume after network loss changed bytes");
+
+            Files.write(partial, Arrays.copyOf(content, resumeOffset));
+            expectError(RetroRewindArchiveDownload.transferResuming(
+                            new ByteArrayInputStream(
+                                    Arrays.copyOfRange(content, resumeOffset, content.length)),
+                            partial, content.length, hash, resumeOffset + 1, () -> false,
+                            (downloaded, total) -> {}),
+                    RetroRewindArchiveDownload.Error.STORAGE_FAILURE);
+            expect(Files.size(partial) == resumeOffset,
+                    "invalid resume offset changed partial bytes");
+
+            expect(RetroRewindArchiveDownload.isCompleteContentRange(
+                            "bytes 7-" + (content.length - 1) + "/" + content.length,
+                            7, content.length),
+                    "valid complete Content-Range rejected");
+            expect(!RetroRewindArchiveDownload.isCompleteContentRange(
+                            "bytes 6-" + (content.length - 1) + "/" + content.length,
+                            7, content.length),
+                    "wrong Content-Range start accepted");
+            expect(!RetroRewindArchiveDownload.isCompleteContentRange(
+                            "bytes 7-8/*", 7, content.length),
+                    "incomplete Content-Range accepted");
+            expect(!RetroRewindArchiveDownload.isCompleteContentRange(
+                            "bytes 7-999999999999999999999999999999/23",
+                            7, content.length),
+                    "overflowing Content-Range accepted");
+
+            Files.write(partial, Arrays.copyOf(content, resumeOffset));
+            FixtureHandler rangeHandler = new FixtureHandler(
+                    HttpURLConnection.HTTP_PARTIAL,
+                    Arrays.copyOfRange(content, resumeOffset, content.length),
+                    "bytes " + resumeOffset + "-" + (content.length - 1) +
+                            "/" + content.length,
+                    null);
+            var rangeResult = RetroRewindArchiveDownload.downloadFrom(
+                    fixtureUrl(rangeHandler), partial, resumeOffset, content.length, hash,
+                    () -> false, (downloaded, total) -> {});
+            expect(rangeResult.isReady(), "valid ranged response failed");
+            expect(("bytes=" + resumeOffset + "-").equals(
+                            rangeHandler.connection.getRequestProperty("Range")),
+                    "resume request did not send the exact Range header");
+            expect(Arrays.equals(content, Files.readAllBytes(partial)),
+                    "ranged response did not complete the archive");
+
+            Files.write(partial, Arrays.copyOf(content, resumeOffset));
+            FixtureHandler restartHandler = new FixtureHandler(
+                    HttpURLConnection.HTTP_OK, content, null, null);
+            var restartResult = RetroRewindArchiveDownload.downloadFrom(
+                    fixtureUrl(restartHandler), partial, resumeOffset, content.length, hash,
+                    () -> false, (downloaded, total) -> {});
+            expect(restartResult.isReady(), "200 response did not restart partial transfer");
+            expect(Arrays.equals(content, Files.readAllBytes(partial)),
+                    "200 restart response appended instead of truncating");
+
+            Files.write(partial, Arrays.copyOf(content, resumeOffset));
+            FixtureHandler badRangeHandler = new FixtureHandler(
+                    HttpURLConnection.HTTP_PARTIAL,
+                    Arrays.copyOfRange(content, resumeOffset, content.length),
+                    "bytes 0-" + (content.length - 1) + "/" + content.length,
+                    null);
+            var badRangeResult = RetroRewindArchiveDownload.downloadFrom(
+                    fixtureUrl(badRangeHandler), partial, resumeOffset,
+                    content.length, hash, () -> false, (downloaded, total) -> {});
+            expectError(badRangeResult.error,
+                    RetroRewindArchiveDownload.Error.HTTP_FAILURE);
+            expect(Files.size(partial) == resumeOffset,
+                    "invalid range response changed the partial");
+
+            Files.write(partial, content);
+            expect(RetroRewindArchiveDownload.preparePartial(
+                            partial, content.length, hash) == content.length,
+                    "verified complete partial was not reusable");
+            Files.write(partial, new byte[content.length + 1]);
+            expect(RetroRewindArchiveDownload.preparePartial(
+                            partial, content.length, hash) == 0 && Files.size(partial) == 0,
+                    "oversized partial was not reset");
+            Files.write(partial, new byte[content.length]);
+            expect(RetroRewindArchiveDownload.preparePartial(
+                            partial, content.length, hash) == 0 && Files.size(partial) == 0,
+                    "complete corrupt partial was not reset");
 
             expectError(transfer(content, partial, content.length + 1, hash, () -> false),
                     RetroRewindArchiveDownload.Error.SIZE_MISMATCH);
@@ -57,6 +198,8 @@ public final class RetroRewindArchiveDownloadTestMain {
                     new ChunkedInputStream(content), partial,
                     content.length, hash, cancellation),
                     RetroRewindArchiveDownload.Error.CANCELLED);
+            expect(Files.size(partial) == 1,
+                    "cancelled transfer did not preserve completed bytes");
 
             expectError(RetroRewindArchiveDownload.transfer(
                     new FailingInputStream(), partial, content.length, hash, () -> false),
@@ -68,6 +211,23 @@ public final class RetroRewindArchiveDownloadTestMain {
                 expectError(RetroRewindArchiveDownload.verifyFile(
                         symlink, content.length, hash),
                         RetroRewindArchiveDownload.Error.STORAGE_FAILURE);
+            } catch (UnsupportedOperationException | IOException exception) {
+                // Symlink creation is not guaranteed on every host running this harness.
+            }
+
+            Path outside = directory.resolve("outside");
+            Path partialSymlink = directory.resolve("partial-link");
+            Files.write(outside, content);
+            try {
+                Files.createSymbolicLink(partialSymlink, outside.getFileName());
+                expect(RetroRewindArchiveDownload.preparePartial(
+                                partialSymlink, content.length, hash) == 0,
+                        "partial symlink was not reset");
+                expect(Files.isRegularFile(partialSymlink) &&
+                                Files.size(partialSymlink) == 0,
+                        "partial symlink was not replaced by an empty regular file");
+                expect(Arrays.equals(content, Files.readAllBytes(outside)),
+                        "partial symlink reset changed its target");
             } catch (UnsupportedOperationException | IOException exception) {
                 // Symlink creation is not guaranteed on every host running this harness.
             }
@@ -99,6 +259,10 @@ public final class RetroRewindArchiveDownloadTestMain {
 
     private static String sha256(byte[] content) throws NoSuchAlgorithmException {
         return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(content));
+    }
+
+    private static URL fixtureUrl(FixtureHandler handler) throws IOException {
+        return new URL(null, "https://fixture.invalid/archive.zip", handler);
     }
 
     private static void expectError(
@@ -149,5 +313,108 @@ public final class RetroRewindArchiveDownloadTestMain {
         public int read(byte[] output, int offset, int length) throws IOException {
             throw new IOException("injected network loss");
         }
+    }
+
+    private static final class FailingAfterInputStream extends InputStream {
+        private final byte[] content;
+        private final int failAfter;
+        private int offset;
+
+        FailingAfterInputStream(byte[] content, int failAfter) {
+            this.content = content;
+            this.failAfter = failAfter;
+        }
+
+        @Override
+        public int read() throws IOException {
+            if (offset >= failAfter) {
+                throw new IOException("injected network loss after bytes");
+            }
+            return content[offset++] & 0xff;
+        }
+
+        @Override
+        public int read(byte[] output, int outputOffset, int length) throws IOException {
+            if (offset >= failAfter) {
+                throw new IOException("injected network loss after bytes");
+            }
+            output[outputOffset] = content[offset++];
+            return 1;
+        }
+    }
+
+    private static final class FixtureHandler extends URLStreamHandler {
+        private final int response;
+        private final byte[] content;
+        private final String contentRange;
+        private final String contentEncoding;
+        private FixtureConnection connection;
+
+        FixtureHandler(
+                int response, byte[] content, String contentRange, String contentEncoding) {
+            this.response = response;
+            this.content = content;
+            this.contentRange = contentRange;
+            this.contentEncoding = contentEncoding;
+        }
+
+        @Override
+        protected URLConnection openConnection(URL url) {
+            connection = new FixtureConnection(
+                    url, response, content, contentRange, contentEncoding);
+            return connection;
+        }
+    }
+
+    private static final class FixtureConnection extends HttpURLConnection {
+        private final byte[] content;
+        private final String contentRange;
+        private final String contentEncoding;
+
+        FixtureConnection(
+                URL url, int response, byte[] content,
+                String contentRange, String contentEncoding) {
+            super(url);
+            this.responseCode = response;
+            this.content = content;
+            this.contentRange = contentRange;
+            this.contentEncoding = contentEncoding;
+        }
+
+        @Override
+        public int getResponseCode() {
+            return responseCode;
+        }
+
+        @Override
+        public String getHeaderField(String name) {
+            return "Content-Range".equalsIgnoreCase(name) ? contentRange : null;
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            return content.length;
+        }
+
+        @Override
+        public String getContentEncoding() {
+            return contentEncoding;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return new ByteArrayInputStream(content);
+        }
+
+        @Override
+        public void disconnect() {}
+
+        @Override
+        public boolean usingProxy() {
+            return false;
+        }
+
+        @Override
+        public void connect() {}
     }
 }

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -899,8 +899,13 @@ the unique worker now orders recovery, capacity, download, extraction,
 validation, activation, and cache cleanup, with persisted visible progress,
 cancellation, transport retry, and duplicate suppression. Fixture work passes
 on both page-size lanes, and the same UUID restarts after an injected app
-process death on API 36. Partial HTTP transfer is not yet resumable, and the
-production-size install and Retro Rewind gameplay remain open.
+process death on API 36. The downloader now retains a version-scoped partial,
+requires an exact HTTPS byte range before prefix-hashing and appending, safely
+restarts when a server returns the full representation, and publishes only a
+complete pinned digest. An injected process death preserved seven bytes and the
+same worker resumed from that exact offset. The official server's range
+behavior, production-size install, remaining fault matrix, and Retro Rewind
+gameplay remain open.
 Do not begin the touch-UI port until A2's controller-driven Original-mode proof
 passes. Physical Android hardware remains authoritative for vendor Vulkan and
 controller behavior; Retro Rewind installation and touch parity follow from

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -216,9 +216,20 @@ not block offline Retro Rewind support.
    Wiped 4 KiB and 16 KiB AVDs each prove exactly one start after two enqueues.
    A separate API 36 fault run kills the application during active work; the
    same persisted UUID restarts at attempt 1 after relaunch and completes.
-   Partial HTTP resume, production-size installation/faults, Retro Rewind
-   gameplay/mode switching, and physical acceptance remain open. Evidence:
+   At that checkpoint, partial HTTP resume, production-size
+   installation/faults, Retro Rewind gameplay/mode switching, and physical
+   acceptance remained open. Evidence:
    `docs/artifacts/2026-09-04/android/a3-install-worker.md`.
+   The downloader now retains a stable version-scoped partial and accepts
+   append only after an exact HTTPS `206 Content-Range`; a full `200`
+   response safely truncates/restarts and final publication still requires the
+   complete pinned digest. Host faults cover range negotiation and repeated
+   network-loss resume, both AVD page sizes execute prefix append, and the
+   process-death worker test now resumes the same UUID from a measured nonzero
+   prefix (seven bytes in the final run). The official 1.86 GB server/transfer,
+   production fault matrix, gameplay/mode switching, and physical acceptance
+   remain open. Evidence:
+   `docs/artifacts/2026-09-04/android/a3-resumable-download.md`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2391,6 +2391,10 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   Android API. The durable API 36 fault run additionally persisted seven bytes,
   killed the app process, and observed the same UUID restart at attempt 1 from
   byte 7 and finish the fully verified fixture.
+- A body-free HTTPS `HEAD` request to the profile URL returned 200, the exact
+  pinned 1,859,041,899-byte length, ZIP content type, and
+  `Accept-Ranges: bytes`. No production archive bytes were downloaded, and a
+  real ranged GET remains unproven.
 - All A3 contract runners, public/private source configurations, release
   compilation, lint, package/privacy audit, builder suite, SunPad snapshot,
   safety, shell, and diff checks pass. The source-only APK is 33,843,921 bytes

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2373,3 +2373,32 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   switching, and physical hardware remain open. No APK/AAB, production archive,
   or private data was published. Evidence:
   `docs/artifacts/2026-09-04/android/a3-install-worker.md`.
+
+## 2026-09-04 — Android A3 resumable archive download
+
+- Replaced random disposable download files with one version-scoped
+  app-private partial. Resume rehashes the exact existing prefix, requests the
+  remaining range, appends only after an exact `206 Content-Range`, and safely
+  truncates when a conforming server ignores Range and returns `200`.
+- Oversized, complete-corrupt, symlinked, or non-regular partial state resets
+  without following links. Network loss/cancellation preserves progress;
+  permanent protocol/integrity faults discard it. Atomic publication still
+  requires the complete profile size and SHA-256.
+- Host tests cover exact request headers, valid/malformed/overflowing ranges,
+  safe full restart, a second resume after injected network loss, offset
+  mismatch, progress, corrupt/oversized reset, and an untouched symlink target.
+- Wiped 4 KiB and 16 KiB AVDs execute a seven-byte prefix append through the
+  Android API. The durable API 36 fault run additionally persisted seven bytes,
+  killed the app process, and observed the same UUID restart at attempt 1 from
+  byte 7 and finish the fully verified fixture.
+- All A3 contract runners, public/private source configurations, release
+  compilation, lint, package/privacy audit, builder suite, SunPad snapshot,
+  safety, shell, and diff checks pass. The source-only APK is 33,843,921 bytes
+  at SHA-256
+  `f5b001c206abb5dd05bc0c58f8f6e6f2b5c684361ccaaa0f079f259e9f173364`.
+- Classification: **Pass for bounded resumable acquisition and verified
+  nonzero-prefix recovery after real app-process death on the emulator.** The
+  official production server/1.86 GB transfer, remaining production faults,
+  gameplay/mode switching, and physical acceptance remain open. No APK/AAB,
+  archive, or private data was published. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-resumable-download.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -341,6 +341,19 @@ installation and fault injection, Retro Rewind gameplay/mode switching, and
 physical hardware. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-install-worker.md`](artifacts/2026-09-04/android/a3-install-worker.md).
 
+Android's archive acquisition is now restartable rather than throwaway. A
+stable version-scoped partial is prefix-hashed and appended only after an exact
+HTTPS `206 Content-Range`; a server `200` fallback truncates and restarts,
+while malformed ranges fail without modifying the prefix. Network loss and
+cancellation preserve partial bytes, but full corrupt/oversized/link state is
+reset and final publication still requires the complete pinned digest. The
+actual durable-worker fault fixture persisted seven bytes, lost its process,
+then resumed the same UUID from byte 7 and completed. Host response/fault tests,
+both AVD page-size lanes, builds/lint, and package/privacy checks pass. A3
+remains open for the official 1.86 GB server/transfer, the remaining production
+fault matrix, gameplay/mode switching, and physical hardware. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-resumable-download.md`](artifacts/2026-09-04/android/a3-resumable-download.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-04/android/a3-resumable-download.md
+++ b/docs/artifacts/2026-09-04/android/a3-resumable-download.md
@@ -1,0 +1,71 @@
+# Android A3 resumable archive download
+
+Date: 2026-09-04
+
+Branch: `codex/android-a3-resumable-download`
+
+Baseline: `6a7db19833cbe0eb1e5588994a128db8a368169e`
+
+## Falsifiable subgoal
+
+Preserve a bounded, version-scoped partial Retro Rewind archive across network
+loss or application process death, resume it only from an exactly validated
+HTTP byte range, and still accept the final archive only after its complete
+size and SHA-256 match the profile. Do not fetch or publish the production
+archive.
+
+## Result
+
+- Replaced random throwaway transfer files with the exact app-private
+  `.RetroRewind-6.12.5.part` path. A regular partial shorter than the pinned
+  archive is reusable; oversized, complete-but-corrupt, symlinked, or
+  non-regular state is reset without following links.
+- A resumed request sends `Range: bytes=<verified-size>-`. A `206` response
+  is accepted only when `Content-Range` exactly covers that offset through
+  byte 1,859,041,898 of the pinned 1,859,041,899-byte representation. Decimal
+  overflow, an unexpected start/end/total, non-identity encoding, or a
+  contradictory declared length fails closed.
+- If a conforming server ignores `Range` and returns the full representation
+  with `200`, the partial is truncated and safely restarted at byte zero.
+  Redirects remain HTTPS-only and bounded.
+- Resume hashes the existing prefix before appending new bytes. Network loss
+  and cancellation preserve the partial; permanent HTTP/integrity failures
+  discard it. Final publication still requires a complete streamed SHA-256 and
+  byte-count check followed by an atomic move.
+- A valid already-published archive removes any redundant stale partial.
+
+## Verification
+
+- The warning-as-error host harness proves fresh transfer, prefix append,
+  progress beginning at the cached offset, a second resume after injected
+  network loss, wrong-offset refusal without mutation, exact and malformed
+  `Content-Range`, decimal overflow, valid-complete reuse, oversized/corrupt
+  reset, and symlink replacement with an untouched target.
+- Fake HTTPS connections prove the exact outgoing `Range` header, a valid
+  `206` remainder, safe `200` restart/truncation, and rejection of a
+  mismatched range without changing partial bytes.
+- A debug Android fixture resumed a 22-byte file from a seven-byte prefix and
+  verified the final digest on wiped API 36 / 4 KiB and API 35 / 16 KiB ARM64
+  AVDs. Both runs also passed all existing worker, extraction, memory,
+  scheduler/fiber, controller, Vulkan, orientation, and lifecycle markers.
+- A stronger wiped API 36 fault run used the actual append path inside the
+  durable worker. It persisted seven bytes, force-stopped KartPad, confirmed
+  the process was absent, then restarted the same UUID at attempt 1 from byte
+  7 and completed the verified 92-byte fixture.
+- All seven Android A3 contract runners, public assemble/release compilation,
+  API-28 lint, private game-runtime Kotlin/Java configuration compilation,
+  strict package/privacy audit, the 22-test builder suite, SunPad snapshot,
+  repository safety, shell syntax/lint, and diff checks pass. No ADB target
+  remains.
+- The exact source-only debug APK is 33,843,921 bytes with SHA-256
+  `f5b001c206abb5dd05bc0c58f8f6e6f2b5c684361ccaaa0f079f259e9f173364`.
+
+## Classification
+
+**Pass for safe partial persistence, exact HTTP range negotiation, prefix
+rehashing/appending, fallback restart, and verified resume after real app
+process death on the emulator.** This does not prove the official server's
+range behavior, the 1.86 GB production transfer, UI cancellation, complete
+production interruption/full-disk tests, Retro Rewind gameplay/mode switching,
+or physical hardware. A2 and A3 remain open. No APK/AAB, production archive,
+private data, device identifier, or raw log was published.

--- a/docs/artifacts/2026-09-04/android/a3-resumable-download.md
+++ b/docs/artifacts/2026-09-04/android/a3-resumable-download.md
@@ -52,6 +52,10 @@ archive.
   durable worker. It persisted seven bytes, force-stopped KartPad, confirmed
   the process was absent, then restarted the same UUID at attempt 1 from byte
   7 and completed the verified 92-byte fixture.
+- A body-free HTTPS `HEAD` request to the exact profile URL returned 200,
+  `Content-Length: 1859041899`, `Content-Type: application/zip`, and
+  `Accept-Ranges: bytes`. This confirms current metadata only; it does not
+  prove a ranged GET or download any archive content.
 - All seven Android A3 contract runners, public assemble/release compilation,
   API-28 lint, private game-runtime Kotlin/Java configuration compilation,
   strict package/privacy audit, the 22-test builder suite, SunPad snapshot,

--- a/scripts/run-android-fixture.sh
+++ b/scripts/run-android-fixture.sh
@@ -88,6 +88,7 @@ wait_for_marker \
   "A1 ELF scheduler passed operations=2000000 hash=0x7287563387fb1677 fiber_switches=1000000"
 wait_for_marker "A2 SDL gamepad contract passed"
 wait_for_marker "A3 JNI archive extraction passed entries=2 bytes=7"
+wait_for_marker "A3 resumable transfer passed prefix=7 total=22"
 wait_for_marker "A3 durable worker fixture enqueued twice with KEEP"
 wait_for_marker "A3 durable worker fixture started id="
 worker_id="$("$adb" logcat -d -v brief KartPadFixture:I '*:S' |

--- a/scripts/test-android-retro-rewind-worker-restart.sh
+++ b/scripts/test-android-retro-rewind-worker-restart.sh
@@ -70,7 +70,8 @@ worker_id="$("$adb" logcat -d -v brief KartPadFixture:I '*:S' |
   echo "ERROR: could not parse durable worker id: $worker_id" >&2
   exit 1
 }
-wait_for_marker "A3 durable worker fixture started id=$worker_id attempt=0 steps=60"
+wait_for_marker "A3 durable resume fixture started id=$worker_id attempt=0 prefix=0"
+wait_for_marker "A3 durable resume fixture checkpoint id=$worker_id bytes="
 
 "$adb" shell am force-stop "$package"
 if "$adb" shell pidof "$package" | grep -q '[0-9]'; then
@@ -78,10 +79,19 @@ if "$adb" shell pidof "$package" | grep -q '[0-9]'; then
   exit 1
 fi
 "$adb" shell am start -W -n "$component" >/dev/null
-wait_for_marker "A3 durable worker fixture completed id=$worker_id attempt=1"
+wait_for_marker "A3 durable resume fixture started id=$worker_id attempt=1 prefix="
+resumed_from="$("$adb" logcat -d -v brief KartPadFixture:I '*:S' |
+  sed -n "s/.*A3 durable resume fixture started id=$worker_id attempt=1 prefix=\([0-9][0-9]*\).*/\1/p" |
+  tail -1)"
+if ! [[ "$resumed_from" =~ ^[0-9]+$ ]] ||
+    ! (( resumed_from > 0 && resumed_from < 92 )); then
+  echo "ERROR: persisted worker resumed from invalid offset: $resumed_from" >&2
+  exit 1
+fi
+wait_for_marker "A3 durable resume fixture completed id=$worker_id attempt=1"
 
 worker_starts="$("$adb" logcat -d -v brief KartPadFixture:I '*:S' |
-  grep -Fc "A3 durable worker fixture started id=$worker_id")"
+  grep -Fc "A3 durable resume fixture started id=$worker_id")"
 [[ "$worker_starts" == 2 ]] || {
   echo "ERROR: persisted worker $worker_id started $worker_starts times; expected exactly 2" >&2
   exit 1
@@ -92,4 +102,4 @@ if "$adb" logcat -d -v brief KartPadFixture:E AndroidRuntime:E '*:S' | grep -q .
   exit 1
 fi
 
-echo "Android A3 durable worker restart passed: avd=$avd worker_id=$worker_id process_starts=$worker_starts final_state=completed"
+echo "Android A3 durable worker resume passed: avd=$avd worker_id=$worker_id process_starts=$worker_starts resumed_from=$resumed_from final_state=completed"


### PR DESCRIPTION
## Summary
- preserve one version-scoped partial and prefix-hash it before appending
- require an exact HTTPS 206 Content-Range, safely restart on a full 200 response, and retain partial bytes across cancellation/network loss
- prove a real WorkManager process-death recovery resumes the same UUID from a measured nonzero offset

## Verification
- host fault harness covers exact Range headers, 206 append, 200 restart, repeated network-loss resume, malformed/overflowing ranges, cancellation, corrupt/oversized state, and symlinks
- wiped API 36 / 4 KiB and API 35 / 16 KiB AVDs execute the prefix append plus existing native/worker fixtures
- wiped API 36 force-stop test resumed the same UUID from byte 7 and verified final content
- public assemble/release compile/API-28 lint, private game-runtime source compile, package/privacy audit, all A3 contract runners, builder suite, SunPad snapshot, repository safety, shell lint, and diff checks pass

A3 remains open for the official 1.86 GB server/transfer, remaining production fault injection, gameplay/mode switching, and physical hardware. No APK/AAB or game archive is published.