### PR TITLE
Test Android installer activity recreation

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity
+            android:name=".RetroRewindWorkerFixtureActivity"
+            android:exported="true"
+            android:permission="android.permission.DUMP" />
+    </application>
+</manifest>

--- a/android/app/src/debug/java/dev/kartpad/android/RetroRewindWorkerFixtureActivity.kt
+++ b/android/app/src/debug/java/dev/kartpad/android/RetroRewindWorkerFixtureActivity.kt
@@ -1,0 +1,57 @@
+package dev.kartpad.android
+
+import android.app.Activity
+import android.os.Bundle
+import android.util.Log
+
+/** Debug-only non-SDL owner for proving installer work across UI recreation. */
+internal class RetroRewindWorkerFixtureActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (BuildConfig.GAME_RUNTIME) {
+            finish()
+            return
+        }
+        if (intent.getBooleanExtra(EXTRA_INIT_ONLY, false)) {
+            Log.i(LOG_TAG, "A3 worker initializer activity created")
+            return
+        }
+        if (intent.getBooleanExtra(EXTRA_RESUME_PROCESS_DEATH, false)) {
+            if (savedInstanceState == null) {
+                val id = RetroRewindInstallWork.enqueueDebugFixture(
+                    this,
+                    steps = 60,
+                    delayMillis = 500,
+                    resumeProcessDeath = true,
+                )
+                Log.i(LOG_TAG, "A3 durable worker restart fixture enqueued id=$id")
+            }
+            return
+        }
+        val id = RetroRewindInstallWork.enqueueDebugFixture(
+            this,
+            steps = 40,
+            delayMillis = 250,
+        )
+        if (savedInstanceState == null) {
+            Log.i(LOG_TAG, "A3 worker activity-recreation fixture enqueued id=$id")
+            window.decorView.postDelayed(
+                {
+                    Log.i(LOG_TAG, "A3 worker activity recreation requested")
+                    recreate()
+                },
+                1_000,
+            )
+        } else {
+            Log.i(LOG_TAG, "A3 worker activity recreation observed; KEEP reenqueued")
+        }
+    }
+
+    companion object {
+        private const val LOG_TAG = "KartPadFixture"
+        const val EXTRA_RESUME_PROCESS_DEATH =
+            "dev.kartpad.android.TEST_RETRO_REWIND_WORKER_RESTART"
+        const val EXTRA_INIT_ONLY =
+            "dev.kartpad.android.TEST_RETRO_REWIND_WORKER_INIT_ONLY"
+    }
+}

--- a/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
@@ -135,15 +135,6 @@ class KartPadActivity : SDLActivity() {
             return
         }
         when {
-            intent.getBooleanExtra(DEBUG_EXTRA_RETRO_REWIND_WORKER_RESTART, false) -> {
-                val id = RetroRewindInstallWork.enqueueDebugFixture(
-                    this,
-                    steps = 60,
-                    delayMillis = 500,
-                    resumeProcessDeath = true,
-                )
-                Log.i(TAG, "A3 durable worker restart fixture enqueued id=$id")
-            }
             intent.getBooleanExtra(DEBUG_EXTRA_RETRO_REWIND_WORKER, false) -> {
                 runDebugRetroRewindResumeFixture()
                 RetroRewindInstallWork.enqueueDebugFixture(this)
@@ -194,8 +185,6 @@ class KartPadActivity : SDLActivity() {
             "dev.kartpad.android.TEST_RETRO_REWIND_EXTRACTION"
         private const val DEBUG_EXTRA_RETRO_REWIND_WORKER =
             "dev.kartpad.android.TEST_RETRO_REWIND_WORKER"
-        private const val DEBUG_EXTRA_RETRO_REWIND_WORKER_RESTART =
-            "dev.kartpad.android.TEST_RETRO_REWIND_WORKER_RESTART"
         private const val DEBUG_RESUME_FIXTURE_SHA256 =
             "cb9d5fc3b83611af65032f73119285de4e97d4b2b9f7b2e9567443635358483a"
         private const val MIN_RKG_BYTES = 0x90L

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -905,7 +905,10 @@ restarts when a server returns the full representation, and publishes only a
 complete pinned digest. An injected process death preserved seven bytes and the
 same worker resumed from that exact offset. The official server's range
 behavior, production-size install, remaining fault matrix, and Retro Rewind
-gameplay remain open.
+gameplay remain open. A debug-only non-SDL installer activity also proves that
+active work retains one UUID/start across same-process activity destruction,
+recreation, and duplicate `KEEP` enqueue. This models setup UI lifecycle
+without conflating it with the game window.
 Do not begin the touch-UI port until A2's controller-driven Original-mode proof
 passes. Physical Android hardware remains authoritative for vendor Vulkan and
 controller behavior; Retro Rewind installation and touch parity follow from

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -230,6 +230,14 @@ not block offline Retro Rewind support.
    production fault matrix, gameplay/mode switching, and physical acceptance
    remain open. Evidence:
    `docs/artifacts/2026-09-04/android/a3-resumable-download.md`.
+   A debug-only native installer activity now recreates in the same PID while
+   work is active, re-enqueues with `KEEP`, and observes the original UUID
+   complete after exactly one start. It is absent from release and requires
+   privileged `DUMP` permission for ADB launch. This replaces a rejected
+   experiment that recreated SDL during game-window startup and therefore
+   restarted the native process rather than modeling installer UI lifecycle.
+   Evidence:
+   `docs/artifacts/2026-09-04/android/a3-worker-activity-recreation.md`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2406,3 +2406,27 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   gameplay/mode switching, and physical acceptance remain open. No APK/AAB,
   archive, or private data was published. Evidence:
   `docs/artifacts/2026-09-04/android/a3-resumable-download.md`.
+
+## 2026-09-04 — Android A3 install-worker activity recreation
+
+- Added a debug-source-only lightweight installer activity, absent from
+  release and protected by Android's privileged `DUMP` permission for ADB
+  launch. It runs outside SDL, requests recreation while work is active, and
+  re-enqueues after recreation to exercise unique `KEEP` behavior.
+- The final wiped API 36 run kept PID 4580, observed destruction/recreation,
+  and completed the original worker UUID after exactly one attempt-0 start.
+  The same harness first reconfirmed process-death resume from a six-byte
+  persisted prefix at attempt 1.
+- An initial experiment recreated `SDLActivity` during native window startup;
+  its expected game-window teardown caused process restart, so that code was
+  removed and is not claimed as installer activity evidence.
+- Public debug build, release compilation, API-28 lint, private game-source
+  compilation, package/privacy audit, relevant A3 tests, builder suite, SunPad
+  snapshot, safety, shell, and diff checks pass. The source-only APK is
+  33,843,921 bytes at SHA-256
+  `e1a06115225c52e9749349a14d6fa22fd9688dd84b084604ddc679fe31a52b84`.
+- Classification: **Pass for same-process installer activity recreation
+  without duplicate foreground work.** Production UI observation/cancellation,
+  official archive/fault execution, gameplay/mode switching, and physical
+  hardware remain open. No artifact or private data was published. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-worker-activity-recreation.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -354,6 +354,18 @@ remains open for the official 1.86 GB server/transfer, the remaining production
 fault matrix, gameplay/mode switching, and physical hardware. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-resumable-download.md`](artifacts/2026-09-04/android/a3-resumable-download.md).
 
+A debug-only native installer-activity owner now proves the remaining
+activity-recreation interruption independently of SDL gameplay startup. On a
+wiped API 36 AVD, the activity recreated in the same PID, re-enqueued with
+`KEEP`, and the original foreground work UUID started and completed exactly
+once. The ADB-only fixture is absent from release builds and protected by the
+privileged `DUMP` permission in debug builds. A rejected first experiment
+correctly showed that explicitly recreating SDL during native window startup is
+not valid installer evidence, so that path was removed. A3 remains open for
+production UI observation/cancellation, the official archive/fault matrix,
+gameplay/mode switching, and physical hardware. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-worker-activity-recreation.md`](artifacts/2026-09-04/android/a3-worker-activity-recreation.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-04/android/a3-worker-activity-recreation.md
+++ b/docs/artifacts/2026-09-04/android/a3-worker-activity-recreation.md
@@ -1,0 +1,58 @@
+# Android A3 install-worker activity recreation
+
+Date: 2026-09-04
+
+Branch: `codex/android-a3-worker-recreation`
+
+Baseline: `0ecc0290d2bb688dbffe0aede84c058c131c78e3`
+
+## Falsifiable subgoal
+
+Destroy and recreate an installer-owning Android activity while a foreground
+Retro Rewind work request is active. Require the same application process, one
+worker UUID/start, duplicate suppression when the recreated UI enqueues again,
+and successful completion.
+
+## Result
+
+- Added a debug-source-only, non-SDL activity that models the future native
+  installer UI owner. It starts a bounded foreground worker, requests its own
+  recreation after one second, and re-enqueues after recreation so
+  `ExistingWorkPolicy.KEEP` is exercised across the real lifecycle.
+- The fixture activity is absent from release builds. Its debug manifest is
+  exported only for automation and requires Android's signature/privileged
+  `android.permission.DUMP`, which permits ADB shell launch but rejects
+  ordinary applications.
+- The process-death/resume fault also moved to this lightweight owner, isolating
+  installer lifecycle from SDL game-window startup.
+
+## Verification
+
+- On the final wiped API 36 / 4 KiB AVD, work UUID
+  `c61d6ecd-0d8b-4d22-af3e-93572eb7c133` started once at attempt 0, the
+  activity requested and observed recreation in PID 4580, the recreated
+  activity re-enqueued with `KEEP`, and the original UUID completed once.
+- In the preceding fault within the same harness, UUID
+  `c00ecc2f-c283-4c6b-be1d-983ffe552c6e` persisted six bytes, lost its
+  process, restarted at attempt 1 from byte 6, and completed. This confirms the
+  lightweight owner still initializes durable work after process death.
+- The first experimental implementation recreated `SDLActivity` during
+  native startup. Android correctly destroyed its game window and the process
+  restarted; that was not accepted as UI-recreation evidence. The implementation
+  was removed in favor of the installer-specific owner above.
+- Debug assemble, release Kotlin/Java compilation, API-28 lint, private
+  game-runtime Kotlin/Java configuration compilation, strict package/privacy
+  audit, relevant A3 contract runners, the 22-test builder suite, SunPad
+  snapshot, repository safety, shell syntax/lint, and diff checks pass. No ADB
+  target remains.
+- The exact source-only debug APK is 33,843,921 bytes with SHA-256
+  `e1a06115225c52e9749349a14d6fa22fd9688dd84b084604ddc679fe31a52b84`.
+
+## Classification
+
+**Pass for foreground install work surviving real same-process installer
+activity destruction/recreation without duplicate execution.** This does not
+prove production UI observation/cancellation, the official archive install,
+complete production fault injection, Retro Rewind gameplay/mode switching, or
+physical hardware. A2 and A3 remain open. No APK/AAB, production archive,
+private data, device identifier, or raw log was published.

--- a/scripts/test-android-retro-rewind-worker-restart.sh
+++ b/scripts/test-android-retro-rewind-worker-restart.sh
@@ -9,7 +9,7 @@ adb="$sdk_root/platform-tools/adb"
 emulator="$sdk_root/emulator/emulator"
 avd="$KARTPAD_ANDROID_PHONE_AVD"
 package="dev.kartpad.android"
-component="$package/.KartPadActivity"
+fixture_component="$package/.RetroRewindWorkerFixtureActivity"
 
 if "$adb" devices | sed -n '2,$p' | grep -q '[[:space:]]device$'; then
   echo "ERROR: an Android device/emulator is already connected; preserve the one-emulator rule" >&2
@@ -60,7 +60,7 @@ wait_for_marker() {
   return 1
 }
 
-"$adb" shell am start -W -n "$component" \
+"$adb" shell am start -W -n "$fixture_component" \
   --ez dev.kartpad.android.TEST_RETRO_REWIND_WORKER_RESTART true >/dev/null
 wait_for_marker "A3 durable worker restart fixture enqueued id="
 worker_id="$("$adb" logcat -d -v brief KartPadFixture:I '*:S' |
@@ -78,7 +78,8 @@ if "$adb" shell pidof "$package" | grep -q '[0-9]'; then
   echo "ERROR: KartPad process survived force-stop" >&2
   exit 1
 fi
-"$adb" shell am start -W -n "$component" >/dev/null
+"$adb" shell am start -W -n "$fixture_component" \
+  --ez dev.kartpad.android.TEST_RETRO_REWIND_WORKER_INIT_ONLY true >/dev/null
 wait_for_marker "A3 durable resume fixture started id=$worker_id attempt=1 prefix="
 resumed_from="$("$adb" logcat -d -v brief KartPadFixture:I '*:S' |
   sed -n "s/.*A3 durable resume fixture started id=$worker_id attempt=1 prefix=\([0-9][0-9]*\).*/\1/p" |
@@ -102,4 +103,41 @@ if "$adb" logcat -d -v brief KartPadFixture:E AndroidRuntime:E '*:S' | grep -q .
   exit 1
 fi
 
-echo "Android A3 durable worker resume passed: avd=$avd worker_id=$worker_id process_starts=$worker_starts resumed_from=$resumed_from final_state=completed"
+"$adb" shell am force-stop "$package"
+"$adb" logcat -c
+"$adb" shell am start -W -n "$fixture_component" >/dev/null
+wait_for_marker "A3 worker activity-recreation fixture enqueued id="
+recreation_worker_id="$("$adb" logcat -d -v brief KartPadFixture:I '*:S' |
+  sed -n 's/.*A3 worker activity-recreation fixture enqueued id=\([^ ]*\).*/\1/p' |
+  tail -1)"
+[[ "$recreation_worker_id" =~ ^[0-9a-f-]{36}$ ]] || {
+  echo "ERROR: could not parse activity-recreation worker id: $recreation_worker_id" >&2
+  exit 1
+}
+wait_for_marker "A3 durable worker fixture started id=$recreation_worker_id attempt=0 steps=40"
+wait_for_marker "A3 worker activity recreation requested"
+wait_for_marker "A3 worker activity recreation observed; KEEP reenqueued"
+wait_for_marker "A3 durable worker fixture completed id=$recreation_worker_id attempt=0"
+recreation_starts="$("$adb" logcat -d -v brief KartPadFixture:I '*:S' |
+  grep -Fc "A3 durable worker fixture started id=$recreation_worker_id")"
+[[ "$recreation_starts" == 1 ]] || {
+  echo "ERROR: activity recreation started worker $recreation_worker_id $recreation_starts times" >&2
+  exit 1
+}
+first_pid="$("$adb" logcat -d -v brief KartPadFixture:I '*:S' |
+  sed -n 's/.*KartPadFixture( *\([0-9][0-9]*\)): A3 worker activity-recreation fixture enqueued.*/\1/p' |
+  tail -1)"
+recreated_pid="$("$adb" logcat -d -v brief KartPadFixture:I '*:S' |
+  sed -n 's/.*KartPadFixture( *\([0-9][0-9]*\)): A3 worker activity recreation observed.*/\1/p' |
+  tail -1)"
+[[ -n "$first_pid" && "$first_pid" == "$recreated_pid" ]] || {
+  echo "ERROR: activity recreation did not retain one process: $first_pid -> $recreated_pid" >&2
+  exit 1
+}
+if "$adb" logcat -d -v brief KartPadFixture:E AndroidRuntime:E '*:S' | grep -q .; then
+  echo "ERROR: worker activity-recreation fixture emitted an error" >&2
+  "$adb" logcat -d -v brief KartPadFixture:V AndroidRuntime:E '*:S' >&2
+  exit 1
+fi
+
+echo "Android A3 durable worker interruptions passed: avd=$avd resume_worker_id=$worker_id process_starts=$worker_starts resumed_from=$resumed_from recreation_worker_id=$recreation_worker_id recreation_starts=$recreation_starts recreation_pid=$first_pid final_state=completed"


### PR DESCRIPTION
## Summary
- add a debug-only non-SDL installer activity protected by Android's privileged DUMP permission
- recreate that activity while foreground install work is active and re-enqueue with KEEP
- require the original UUID to start once, remain in the same process, and complete; isolate process-death resume from SDL startup too

## Verification
- wiped API 36 AVD: same-PID activity recreation, one worker start, original UUID completion
- same harness: exact UUID process-death restart from a nonzero persisted prefix
- debug fixture is absent from the release manifest
- debug/release compile, API-28 lint, private game-runtime source compile, package/privacy audit, worker/download/pipeline tests, builder suite, SunPad snapshot, repository safety, shell lint, and diff checks pass

A3 remains open for production UI observation/cancellation, the official archive/fault matrix, gameplay/mode switching, and physical hardware. No APK/AAB or game data is published.