### PR TITLE
Test Android install worker cancellation

### DIFF
--- a/android/app/src/debug/java/dev/kartpad/android/RetroRewindWorkerFixtureActivity.kt
+++ b/android/app/src/debug/java/dev/kartpad/android/RetroRewindWorkerFixtureActivity.kt
@@ -3,6 +3,9 @@ package dev.kartpad.android
 import android.app.Activity
 import android.os.Bundle
 import android.util.Log
+import androidx.work.WorkManager
+import java.nio.file.Files
+import java.nio.file.LinkOption
 
 /** Debug-only non-SDL owner for proving installer work across UI recreation. */
 internal class RetroRewindWorkerFixtureActivity : Activity() {
@@ -28,6 +31,12 @@ internal class RetroRewindWorkerFixtureActivity : Activity() {
             }
             return
         }
+        if (intent.getBooleanExtra(EXTRA_CANCEL, false)) {
+            if (savedInstanceState == null) {
+                runCancellationFixture()
+            }
+            return
+        }
         val id = RetroRewindInstallWork.enqueueDebugFixture(
             this,
             steps = 40,
@@ -47,11 +56,64 @@ internal class RetroRewindWorkerFixtureActivity : Activity() {
         }
     }
 
+    private fun runCancellationFixture() {
+        val id = RetroRewindInstallWork.enqueueDebugFixture(
+            this,
+            steps = 60,
+            delayMillis = 500,
+            resumeProcessDeath = true,
+        )
+        Log.i(LOG_TAG, "A3 worker cancellation fixture enqueued id=$id")
+        window.decorView.postDelayed(
+            {
+                RetroRewindInstallWork.cancel(this)
+                Log.i(LOG_TAG, "A3 worker cancellation requested id=$id")
+                val appContext = applicationContext
+                Thread {
+                    try {
+                        val workManager = WorkManager.getInstance(appContext)
+                        repeat(60) {
+                            val info = workManager.getWorkInfoById(id).get()
+                            if (info != null && info.state.isFinished) {
+                                val partial = appContext.cacheDir.toPath().resolve(
+                                    RetroRewindInstallWork.DEBUG_RESUME_PARTIAL,
+                                )
+                                val bytes = if (Files.isRegularFile(
+                                        partial,
+                                        LinkOption.NOFOLLOW_LINKS,
+                                    )
+                                ) {
+                                    Files.size(partial)
+                                } else {
+                                    -1
+                                }
+                                Log.i(
+                                    LOG_TAG,
+                                    "A3 worker cancellation observed id=$id " +
+                                        "state=${info.state} partial=$bytes",
+                                )
+                                Files.deleteIfExists(partial)
+                                return@Thread
+                            }
+                            Thread.sleep(100)
+                        }
+                        Log.e(LOG_TAG, "A3 worker cancellation observation timed out id=$id")
+                    } catch (error: Exception) {
+                        Log.e(LOG_TAG, "A3 worker cancellation observation failed id=$id", error)
+                    }
+                }.start()
+            },
+            2_000,
+        )
+    }
+
     companion object {
         private const val LOG_TAG = "KartPadFixture"
         const val EXTRA_RESUME_PROCESS_DEATH =
             "dev.kartpad.android.TEST_RETRO_REWIND_WORKER_RESTART"
         const val EXTRA_INIT_ONLY =
             "dev.kartpad.android.TEST_RETRO_REWIND_WORKER_INIT_ONLY"
+        const val EXTRA_CANCEL =
+            "dev.kartpad.android.TEST_RETRO_REWIND_WORKER_CANCEL"
     }
 }

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWork.kt
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWork.kt
@@ -22,6 +22,7 @@ internal object RetroRewindInstallWork {
     const val KEY_DEBUG_FIXTURE_STEPS = "debug_fixture_steps"
     const val KEY_DEBUG_FIXTURE_DELAY_MILLIS = "debug_fixture_delay_millis"
     const val KEY_DEBUG_RESUME_PROCESS_DEATH = "debug_resume_process_death"
+    const val DEBUG_RESUME_PARTIAL = ".kartpad-worker-resume-fixture.part"
 
     fun enqueue(context: Context) {
         val token = UUID.randomUUID().toString()

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWorker.kt
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWorker.kt
@@ -147,7 +147,9 @@ internal class RetroRewindInstallWorker(
 
     private suspend fun runDebugResumeProcessDeathFixture(): Result {
         val content = DEBUG_RESUME_CONTENT.toByteArray(Charsets.UTF_8)
-        val partial = applicationContext.cacheDir.toPath().resolve(DEBUG_RESUME_PARTIAL)
+        val partial = applicationContext.cacheDir.toPath().resolve(
+            RetroRewindInstallWork.DEBUG_RESUME_PARTIAL,
+        )
         val prefix = try {
             RetroRewindArchiveDownload.preparePartial(
                 partial,
@@ -249,7 +251,6 @@ internal class RetroRewindInstallWorker(
         private const val NOTIFICATION_ID = 0x4b50
         private const val PROGRESS_MAX = 100
         private const val LOG_TAG = "KartPadFixture"
-        private const val DEBUG_RESUME_PARTIAL = ".kartpad-worker-resume-fixture.part"
         private const val DEBUG_RESUME_CONTENT =
             "durable-resume-fixture-durable-resume-fixture-" +
                 "durable-resume-fixture-durable-resume-fixture-"
@@ -264,16 +265,24 @@ internal class RetroRewindInstallWorker(
     ) : InputStream() {
         override fun read(): Int {
             if (offset >= content.size) return -1
-            Thread.sleep(250)
+            if (!sleep()) return -1
             return content[offset++].toInt() and 0xff
         }
 
         override fun read(output: ByteArray, outputOffset: Int, length: Int): Int {
             if (offset >= content.size) return -1
             if (length == 0) return 0
-            Thread.sleep(250)
+            if (!sleep()) return -1
             output[outputOffset] = content[offset++]
             return 1
+        }
+
+        private fun sleep(): Boolean = try {
+            Thread.sleep(250)
+            true
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+            false
         }
     }
 }

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -908,7 +908,10 @@ behavior, production-size install, remaining fault matrix, and Retro Rewind
 gameplay remain open. A debug-only non-SDL installer activity also proves that
 active work retains one UUID/start across same-process activity destruction,
 recreation, and duplicate `KEEP` enqueue. This models setup UI lifecycle
-without conflating it with the game window.
+without conflating it with the game window. The production cancellation facade
+also reaches WorkManager's terminal `CANCELLED` state during active append,
+preserves the nonzero partial, and emits no false completion in the emulator
+fault harness. A user-facing observer and cancel action remain A3/A4 work.
 Do not begin the touch-UI port until A2's controller-driven Original-mode proof
 passes. Physical Android hardware remains authoritative for vendor Vulkan and
 controller behavior; Retro Rewind installation and touch parity follow from

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -238,6 +238,13 @@ not block offline Retro Rewind support.
    restarted the native process rather than modeling installer UI lifecycle.
    Evidence:
    `docs/artifacts/2026-09-04/android/a3-worker-activity-recreation.md`.
+   The production cancellation facade now has an Android runtime proof: one
+   active UUID was cancelled after seven appended bytes, WorkManager reported
+   terminal `CANCELLED`, the partial was retained, and no success marker was
+   accepted. This closes the worker control/state contract, not the missing
+   user-facing observer/cancel screen or official-archive cancellation.
+   Evidence:
+   `docs/artifacts/2026-09-04/android/a3-worker-cancellation.md`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2430,3 +2430,24 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   official archive/fault execution, gameplay/mode switching, and physical
   hardware remain open. No artifact or private data was published. Evidence:
   `docs/artifacts/2026-09-04/android/a3-worker-activity-recreation.md`.
+
+## 2026-09-04 — Android A3 install-worker cancellation
+
+- Added a cancellation mode to the shell-protected debug installer activity.
+  It starts the actual resumable worker fixture, calls the production
+  unique-work cancellation facade during append, and observes the request by
+  UUID until WorkManager reaches a terminal state.
+- The final wiped API 36 run cancelled one attempt-0 worker after seven bytes,
+  observed terminal `CANCELLED`, retained the seven-byte partial, and found no
+  worker completion or application fatal. The same run reconfirmed nonzero
+  process-death resume and same-PID activity recreation.
+- Debug/release compilation, API-28 lint, private game-source compilation,
+  package/privacy audit, relevant A3 and builder tests, SunPad snapshot,
+  repository safety, shell syntax/lint, and diff checks pass. The source-only
+  APK is 33,843,921 bytes at SHA-256
+  `b18b26c878a94b071859d389730f9e37ed7526f40739552a814e245fea7f3d6b`.
+- Classification: **Pass for explicit worker cancellation, partial retention,
+  and no false success on the emulator.** The production UI, official archive
+  cancellation, remaining production faults/gameplay, and physical hardware
+  remain open. No artifact or private data was published. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-worker-cancellation.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -366,6 +366,17 @@ production UI observation/cancellation, the official archive/fault matrix,
 gameplay/mode switching, and physical hardware. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-worker-activity-recreation.md`](artifacts/2026-09-04/android/a3-worker-activity-recreation.md).
 
+The worker's production cancellation facade now passes an Android runtime
+fault. A shell-protected debug installer activity cancelled one active UUID
+after seven bytes; WorkManager reached terminal `CANCELLED`, the partial
+remained nonzero, the worker started once, and no success marker appeared. The
+same final wiped API 36 run reconfirmed nonzero process-death resume and
+same-PID activity recreation. This proves the control/state boundary, not the
+missing user-facing installer screen or cancellation against the official
+archive. A3 remains open for that UI, production-size fault/gameplay proof, and
+physical hardware. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-worker-cancellation.md`](artifacts/2026-09-04/android/a3-worker-cancellation.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-04/android/a3-worker-cancellation.md
+++ b/docs/artifacts/2026-09-04/android/a3-worker-cancellation.md
@@ -1,0 +1,53 @@
+# Android A3 install-worker cancellation
+
+Date: 2026-09-04
+
+Branch: `codex/android-a3-worker-cancellation`
+
+Baseline: `c39e1645a4f7749a3de5b931a68b5e3297bad410`
+
+## Falsifiable subgoal
+
+Cancel the unique foreground installer through its production facade while it
+is actively appending bytes. Require one worker start, WorkManager's terminal
+`CANCELLED` state, a preserved nonzero partial, and no success marker.
+
+## Result
+
+- Extended the shell-protected debug installer activity with a cancellation
+  path that starts the actual resumable worker fixture and calls
+  `RetroRewindInstallWork.cancel` while bytes are being appended.
+- The fixture observes the exact request by UUID through WorkManager, reports
+  only after its state is terminal, verifies the stable partial without
+  following links, and removes only that debug fixture after recording the
+  result.
+- The slow debug stream now handles thread interruption without emitting an
+  application exception. Production synchronous callbacks already observe
+  WorkManager's stopped state, while either cancellation or an interrupted
+  network read preserves the version-scoped production partial.
+
+## Verification
+
+- On the final wiped API 36 / 4 KiB AVD, UUID
+  `6c06261e-cb0d-4cfe-8d71-f4b03c7572b2` started once, emitted a nonzero
+  checkpoint, received cancellation through the production facade, reached
+  WorkManager state `CANCELLED`, and retained seven partial bytes. The harness
+  rejected a success marker and any KartPad/Android fatal.
+- The same final run reconfirmed exact-UUID process-death resume from a
+  six-byte prefix and same-PID installer activity recreation with one worker
+  start.
+- Debug assemble, release Kotlin/Java compilation, API-28 lint, strict
+  package/privacy audit, shell syntax/lint, and diff checks pass. Relevant A3
+  host contracts, builder tests, SunPad snapshot, and repository safety pass.
+  The private game-runtime Kotlin/Java configuration also compiles.
+- The exact source-only debug APK is 33,843,921 bytes with SHA-256
+  `b18b26c878a94b071859d389730f9e37ed7526f40739552a814e245fea7f3d6b`.
+
+## Classification
+
+**Pass for explicit unique-work cancellation, terminal-state observation,
+partial retention, and no false success on the emulator.** This does not
+provide the production user interface, exercise cancellation against the
+official 1.86 GB response, or close production full-disk/network/gameplay and
+physical-device rows. A2 and A3 remain open. No APK/AAB, production archive,
+private data, device identifier, or raw log was published.

--- a/scripts/test-android-retro-rewind-worker-restart.sh
+++ b/scripts/test-android-retro-rewind-worker-restart.sh
@@ -140,4 +140,45 @@ if "$adb" logcat -d -v brief KartPadFixture:E AndroidRuntime:E '*:S' | grep -q .
   exit 1
 fi
 
-echo "Android A3 durable worker interruptions passed: avd=$avd resume_worker_id=$worker_id process_starts=$worker_starts resumed_from=$resumed_from recreation_worker_id=$recreation_worker_id recreation_starts=$recreation_starts recreation_pid=$first_pid final_state=completed"
+"$adb" shell am force-stop "$package"
+"$adb" logcat -c
+"$adb" shell am start -W -n "$fixture_component" \
+  --ez dev.kartpad.android.TEST_RETRO_REWIND_WORKER_CANCEL true >/dev/null
+wait_for_marker "A3 worker cancellation fixture enqueued id="
+cancellation_worker_id="$("$adb" logcat -d -v brief KartPadFixture:I '*:S' |
+  sed -n 's/.*A3 worker cancellation fixture enqueued id=\([^ ]*\).*/\1/p' |
+  tail -1)"
+[[ "$cancellation_worker_id" =~ ^[0-9a-f-]{36}$ ]] || {
+  echo "ERROR: could not parse cancellation worker id: $cancellation_worker_id" >&2
+  exit 1
+}
+wait_for_marker "A3 durable resume fixture started id=$cancellation_worker_id attempt=0 prefix=0"
+wait_for_marker "A3 durable resume fixture checkpoint id=$cancellation_worker_id bytes="
+wait_for_marker "A3 worker cancellation requested id=$cancellation_worker_id"
+wait_for_marker "A3 worker cancellation observed id=$cancellation_worker_id state=CANCELLED partial="
+partial_bytes="$("$adb" logcat -d -v brief KartPadFixture:I '*:S' |
+  sed -n "s/.*A3 worker cancellation observed id=$cancellation_worker_id state=CANCELLED partial=\([0-9][0-9]*\).*/\1/p" |
+  tail -1)"
+if ! [[ "$partial_bytes" =~ ^[0-9]+$ ]] ||
+    ! (( partial_bytes > 0 && partial_bytes < 92 )); then
+  echo "ERROR: cancellation preserved invalid partial size: $partial_bytes" >&2
+  exit 1
+fi
+cancellation_starts="$("$adb" logcat -d -v brief KartPadFixture:I '*:S' |
+  grep -Fc "A3 durable resume fixture started id=$cancellation_worker_id")"
+[[ "$cancellation_starts" == 1 ]] || {
+  echo "ERROR: cancellation worker $cancellation_worker_id started $cancellation_starts times" >&2
+  exit 1
+}
+if "$adb" logcat -d -v brief KartPadFixture:I '*:S' |
+    grep -Fq "A3 durable resume fixture completed id=$cancellation_worker_id"; then
+  echo "ERROR: cancelled worker emitted a completion marker" >&2
+  exit 1
+fi
+if "$adb" logcat -d -v brief KartPadFixture:E AndroidRuntime:E '*:S' | grep -q .; then
+  echo "ERROR: worker cancellation fixture emitted an error" >&2
+  "$adb" logcat -d -v brief KartPadFixture:V AndroidRuntime:E '*:S' >&2
+  exit 1
+fi
+
+echo "Android A3 durable worker interruptions passed: avd=$avd resume_worker_id=$worker_id process_starts=$worker_starts resumed_from=$resumed_from recreation_worker_id=$recreation_worker_id recreation_starts=$recreation_starts recreation_pid=$first_pid cancellation_worker_id=$cancellation_worker_id cancellation_starts=$cancellation_starts cancellation_partial=$partial_bytes final_state=cancelled"


### PR DESCRIPTION
## Summary
- exercise the production unique-work cancellation facade during active resumable append
- observe the exact UUID through WorkManager until terminal cancellation
- require preserved nonzero partial bytes, one worker start, and no success marker

## Verification
- wiped API 36 AVD: cancellation worker reached CANCELLED with seven bytes retained and no completion
- same final harness reconfirmed nonzero process-death resume and same-PID activity recreation
- debug/release compile, API-28 lint, private game-runtime source compile, strict package/privacy audit, worker/download/pipeline tests, builder suite, SunPad snapshot, safety, shell lint, and diff checks pass

A3 remains open for a production user-facing observer/cancel screen, official-archive cancellation, production-size fault/gameplay proof, and physical hardware. No APK/AAB or game data is published.