### PR TITLE
Add Android Retro Rewind installer UI

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <application>
         <activity
             android:name=".RetroRewindWorkerFixtureActivity"
             android:exported="true"
             android:permission="android.permission.DUMP" />
+        <activity
+            android:name=".RetroRewindInstallActivity"
+            android:exported="true"
+            android:permission="android.permission.DUMP"
+            tools:replace="android:exported" />
     </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <uses-feature android:glEsVersion="0x00030000" android:required="false" />
     <uses-feature android:name="android.hardware.vulkan.level" android:required="false" android:version="1" />
@@ -22,6 +23,10 @@
             android:name="androidx.work.impl.foreground.SystemForegroundService"
             android:foregroundServiceType="dataSync"
             tools:node="merge" />
+        <activity
+            android:name=".RetroRewindInstallActivity"
+            android:exported="false"
+            android:screenOrientation="sensorLandscape" />
         <activity
             android:name=".KartPadActivity"
             android:configChanges="keyboard|keyboardHidden|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode"

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallActivity.kt
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallActivity.kt
@@ -1,0 +1,330 @@
+package dev.kartpad.android
+
+import android.Manifest
+import android.app.Activity
+import android.content.pm.PackageManager
+import android.graphics.Color
+import android.os.Build
+import android.os.Bundle
+import android.util.Log
+import android.view.Gravity
+import android.view.View
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.ProgressBar
+import android.widget.ScrollView
+import android.widget.TextView
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.lifecycle.LiveData
+import java.util.concurrent.Executors
+
+/** Production owner for visible, lifecycle-independent Retro Rewind installation work. */
+internal class RetroRewindInstallActivity : Activity() {
+    private lateinit var status: TextView
+    private lateinit var detail: TextView
+    private lateinit var progress: ProgressBar
+    private lateinit var primary: Button
+    private lateinit var cancel: Button
+    private lateinit var workLiveData: LiveData<List<WorkInfo>>
+    private val validator = Executors.newSingleThreadExecutor()
+    private var validationGeneration = 0
+    private var lastLoggedState = ""
+    private val workObserver = androidx.lifecycle.Observer<List<WorkInfo>> { work ->
+        renderWork(selectCurrent(work.orEmpty()))
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(buildContent())
+        primary.setOnClickListener { requestNotificationPermissionOrInstall() }
+        cancel.setOnClickListener {
+            Log.i(LOG_TAG, "A3 installer UI cancel requested")
+            RetroRewindInstallWork.cancel(this)
+        }
+        workLiveData = WorkManager.getInstance(applicationContext)
+            .getWorkInfosForUniqueWorkLiveData(RetroRewindInstallWork.UNIQUE_NAME)
+        workLiveData.observeForever(workObserver)
+        if (BuildConfig.DEBUG && savedInstanceState == null &&
+            intent.getBooleanExtra(EXTRA_DEBUG_FIXTURE, false)
+        ) {
+            primary.performClick()
+        }
+    }
+
+    override fun onDestroy() {
+        workLiveData.removeObserver(workObserver)
+        validationGeneration += 1
+        validator.shutdownNow()
+        super.onDestroy()
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray,
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode != NOTIFICATION_PERMISSION_REQUEST) return
+        if (grantResults.singleOrNull() == PackageManager.PERMISSION_GRANTED) {
+            enqueueInstall()
+        } else {
+            logState("notification-permission-required")
+            renderRetry(
+                "Notification permission is required so this long installation remains visible and controllable.",
+            )
+        }
+    }
+
+    private fun requestNotificationPermissionOrInstall() {
+        if (Build.VERSION.SDK_INT >= 33 &&
+            checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) !=
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            requestPermissions(
+                arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                NOTIFICATION_PERMISSION_REQUEST,
+            )
+            return
+        }
+        enqueueInstall()
+    }
+
+    private fun enqueueInstall() {
+        if (BuildConfig.DEBUG && intent.getBooleanExtra(EXTRA_DEBUG_FIXTURE, false)) {
+            RetroRewindInstallWork.enqueueDebugFixture(this, steps = 120, delayMillis = 250)
+        } else {
+            RetroRewindInstallWork.enqueue(this)
+        }
+    }
+
+    private fun buildContent(): View {
+        val density = resources.displayMetrics.density
+        fun dp(value: Int) = (value * density + 0.5f).toInt()
+        fun label(text: String, size: Float, color: Int): TextView = TextView(this).apply {
+            this.text = text
+            textSize = size
+            setTextColor(color)
+            gravity = Gravity.CENTER
+        }
+
+        val column = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            gravity = Gravity.CENTER_HORIZONTAL
+            setPadding(dp(32), dp(28), dp(32), dp(28))
+            setBackgroundColor(Color.rgb(24, 12, 22))
+        }
+        column.addView(label("KartPad", 34f, Color.WHITE), matchWrap(bottom = dp(4)))
+        column.addView(
+            label("Retro Rewind ${RetroRewindRelease.VERSION}", 22f, Color.rgb(255, 117, 76)),
+            matchWrap(bottom = dp(18)),
+        )
+        column.addView(
+            label(
+                "Optional community content for extra tracks, characters, and Retro WFC. " +
+                    "KartPad downloads the pinned official full pack and verifies it before use.",
+                16f,
+                Color.rgb(220, 211, 218),
+            ),
+            matchWrap(bottom = dp(22)),
+        )
+        status = label("Checking installation…", 20f, Color.WHITE)
+        status.id = R.id.retro_rewind_install_status
+        status.accessibilityLiveRegion = View.ACCESSIBILITY_LIVE_REGION_POLITE
+        column.addView(status, matchWrap(bottom = dp(8)))
+        detail = label("", 15f, Color.rgb(190, 180, 188))
+        detail.id = R.id.retro_rewind_install_detail
+        column.addView(detail, matchWrap(bottom = dp(16)))
+        progress = ProgressBar(this, null, android.R.attr.progressBarStyleHorizontal).apply {
+            id = R.id.retro_rewind_install_progress
+            max = 1000
+            isIndeterminate = true
+        }
+        column.addView(progress, matchFixed(dp(360), dp(8), dp(18)))
+        primary = Button(this).apply {
+            id = R.id.retro_rewind_install_primary
+            text = "Download official pack"
+            contentDescription = text
+        }
+        column.addView(primary, matchFixed(dp(360), dp(56), dp(10)))
+        cancel = Button(this).apply {
+            id = R.id.retro_rewind_install_cancel
+            text = "Cancel installation"
+            contentDescription = text
+            visibility = View.GONE
+        }
+        column.addView(cancel, matchFixed(dp(360), dp(56), 0))
+
+        return ScrollView(this).apply {
+            isFillViewport = true
+            addView(column)
+        }
+    }
+
+    private fun matchWrap(bottom: Int) = LinearLayout.LayoutParams(
+        LinearLayout.LayoutParams.MATCH_PARENT,
+        LinearLayout.LayoutParams.WRAP_CONTENT,
+    ).apply { bottomMargin = bottom }
+
+    private fun matchFixed(width: Int, height: Int, bottom: Int) = LinearLayout.LayoutParams(
+        width,
+        height,
+    ).apply { bottomMargin = bottom }
+
+    private fun selectCurrent(work: List<WorkInfo>): WorkInfo? =
+        work.firstOrNull { !it.state.isFinished } ?: work.lastOrNull()
+
+    private fun renderWork(info: WorkInfo?) {
+        if (info == null) {
+            validateInstalled()
+            return
+        }
+        validationGeneration += 1
+        val data = if (info.state.isFinished) info.outputData else info.progress
+        val phase = data.getString(RetroRewindInstallWork.KEY_PHASE).orEmpty()
+        val completed = data.getLong(RetroRewindInstallWork.KEY_COMPLETED_BYTES, 0)
+        val total = data.getLong(RetroRewindInstallWork.KEY_TOTAL_BYTES, 0)
+        val active = !info.state.isFinished
+        cancel.visibility = if (active) View.VISIBLE else View.GONE
+        primary.visibility = if (active) View.GONE else View.VISIBLE
+        when (info.state) {
+            WorkInfo.State.ENQUEUED, WorkInfo.State.BLOCKED -> renderWaiting()
+            WorkInfo.State.RUNNING -> renderProgress(phase, completed, total)
+            WorkInfo.State.SUCCEEDED -> {
+                if (BuildConfig.DEBUG && intent.getBooleanExtra(EXTRA_DEBUG_FIXTURE, false)) {
+                    renderFixtureComplete()
+                } else {
+                    validateInstalled()
+                }
+            }
+            WorkInfo.State.CANCELLED -> {
+                logState("cancelled")
+                renderRetry("Installation cancelled. The partial download was kept for resume.")
+            }
+            WorkInfo.State.FAILED -> {
+                logState("failed")
+                val error = data.getString(RetroRewindInstallWork.KEY_ERROR) ?: "unknown"
+                renderRetry(friendlyError(error))
+            }
+        }
+    }
+
+    private fun validateInstalled() {
+        val generation = ++validationGeneration
+        renderChecking()
+        validator.execute {
+            val result = RetroRewindInstallValidator.validate(
+                RetroRewindInstallStorage.installedRoot(filesDir).resolve(RetroRewindRelease.ROOT),
+                RetroRewindInstallValidator.productionContract(),
+            )
+            runOnUiThread {
+                if (generation != validationGeneration || isFinishing || isDestroyed) return@runOnUiThread
+                if (result.isValid) renderInstalled() else renderNotInstalled()
+            }
+        }
+    }
+
+    private fun renderChecking() {
+        status.text = "Checking installation…"
+        detail.text = "Verifying the installed version and required files."
+        progress.isIndeterminate = true
+        progress.visibility = View.VISIBLE
+        primary.visibility = View.GONE
+        cancel.visibility = View.GONE
+    }
+
+    private fun renderWaiting() {
+        logState("waiting")
+        status.text = "Waiting to download…"
+        detail.text = "Connect to the internet to continue. You can leave this screen."
+        progress.isIndeterminate = true
+        progress.visibility = View.VISIBLE
+    }
+
+    private fun renderProgress(phase: String, completed: Long, total: Long) {
+        logState("running-$phase")
+        status.text = when (phase) {
+            "space" -> "Checking free space…"
+            "extract" -> "Installing Retro Rewind…"
+            else -> "Downloading Retro Rewind…"
+        }
+        if (total > 0 && completed in 0..total) {
+            val percent = (completed * 100 / total).toInt()
+            progress.isIndeterminate = false
+            progress.progress = (completed * progress.max / total).toInt()
+            detail.text = "$percent% • ${formatBytes(completed)} of ${formatBytes(total)}"
+        } else {
+            progress.isIndeterminate = true
+            detail.text = "You can leave this screen; installation continues in the background."
+        }
+        progress.visibility = View.VISIBLE
+    }
+
+    private fun renderInstalled() {
+        logState("installed")
+        status.text = "Retro Rewind is ready"
+        detail.text = "Installed version ${RetroRewindRelease.VERSION} passed KartPad's pinned checks."
+        progress.visibility = View.GONE
+        primary.visibility = View.GONE
+        cancel.visibility = View.GONE
+    }
+
+    private fun renderFixtureComplete() {
+        logState("fixture-complete")
+        status.text = "Installer UI fixture completed"
+        detail.text = "The bounded test worker finished; no game data was installed."
+        progress.visibility = View.GONE
+        primary.visibility = View.GONE
+        cancel.visibility = View.GONE
+    }
+
+    private fun renderNotInstalled() {
+        logState("not-installed")
+        status.text = "Retro Rewind is not installed"
+        detail.text = "The download is 1.73 GiB. Installation requires about 4.03 GiB free on shared app storage."
+        progress.visibility = View.GONE
+        primary.text = "Download official pack"
+        primary.contentDescription = primary.text
+        primary.visibility = View.VISIBLE
+        cancel.visibility = View.GONE
+    }
+
+    private fun renderRetry(message: String) {
+        status.text = "Retro Rewind needs attention"
+        detail.text = message
+        progress.visibility = View.GONE
+        primary.text = "Retry installation"
+        primary.contentDescription = primary.text
+    }
+
+    private fun friendlyError(error: String): String = when {
+        error.startsWith("space-") -> "Not enough safe app storage is available for this installation."
+        error.startsWith("download-network_failure") -> "The download could not reach the official server."
+        error.startsWith("download-") -> "The official download failed its pinned integrity or protocol checks."
+        error.startsWith("install-") -> "The pack could not be safely verified and installed."
+        error == "recovery" -> "KartPad could not safely recover the previous installation."
+        else -> "Installation failed ($error)."
+    }
+
+    private fun formatBytes(bytes: Long): String {
+        val gib = bytes.toDouble() / (1024.0 * 1024.0 * 1024.0)
+        val mib = bytes.toDouble() / (1024.0 * 1024.0)
+        return when {
+            gib >= 0.1 -> String.format(java.util.Locale.US, "%.2f GiB", gib)
+            mib >= 0.1 -> String.format(java.util.Locale.US, "%.1f MiB", mib)
+            else -> "$bytes B"
+        }
+    }
+
+    private fun logState(state: String) {
+        if (state == lastLoggedState) return
+        lastLoggedState = state
+        Log.i(LOG_TAG, "A3 installer UI state=$state")
+    }
+
+    companion object {
+        private const val LOG_TAG = "KartPadInstaller"
+        private const val NOTIFICATION_PERMISSION_REQUEST = 0x4b50
+        private const val EXTRA_DEBUG_FIXTURE = "dev.kartpad.android.TEST_RETRO_REWIND_INSTALLER_UI"
+    }
+}

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallStorage.java
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallStorage.java
@@ -136,6 +136,10 @@ final class RetroRewindInstallStorage {
                 .toAbsolutePath().normalize();
     }
 
+    static Path installedRoot(File filesDirectory) {
+        return supportRoot(filesDirectory).resolve(INSTALLED_DIRECTORY);
+    }
+
     private static void requireToken(String token) {
         if (token == null || token.isEmpty() || token.length() > 64 ||
                 !token.matches("[A-Za-z0-9-]+")) {

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWorker.kt
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWorker.kt
@@ -3,7 +3,9 @@ package dev.kartpad.android
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.util.Log
@@ -217,8 +219,22 @@ internal class RetroRewindInstallWorker(
             .setSmallIcon(R.drawable.ic_kartpad)
             .setContentTitle("KartPad")
             .setContentText(message)
+            .setContentIntent(
+                PendingIntent.getActivity(
+                    applicationContext,
+                    NOTIFICATION_ID,
+                    Intent(applicationContext, RetroRewindInstallActivity::class.java)
+                        .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP),
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+                ),
+            )
             .setOngoing(true)
             .setOnlyAlertOnce(true)
+        if (Build.VERSION.SDK_INT >= 31) {
+            notificationBuilder.setForegroundServiceBehavior(
+                Notification.FOREGROUND_SERVICE_IMMEDIATE,
+            )
+        }
         if (total > 0 && completed in 0..total) {
             notificationBuilder.setProgress(
                 PROGRESS_MAX,

--- a/android/app/src/main/res/values/ids.xml
+++ b/android/app/src/main/res/values/ids.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="retro_rewind_install_status" type="id" />
+    <item name="retro_rewind_install_detail" type="id" />
+    <item name="retro_rewind_install_progress" type="id" />
+    <item name="retro_rewind_install_primary" type="id" />
+    <item name="retro_rewind_install_cancel" type="id" />
+</resources>

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -886,10 +886,11 @@ but they still do not constitute an installed Retro Rewind runtime. Evidence is 
 [`docs/artifacts/2026-09-04/android/`](artifacts/2026-09-04/android/).
 Pinned archive acquisition is also implemented as a source-only contract: it
 uses HTTPS-only bounded redirects/timeouts, exact streamed length/SHA-256,
-cancellation, verified-cache reuse, and atomic publication. INTERNET is the
-network permission required directly by KartPad; WorkManager adds its bounded
-network-state, foreground-service, wake/boot, and app-scoped receiver
-permissions. The strict audit rejects anything outside that exact set.
+cancellation, verified-cache reuse, and atomic publication. KartPad directly
+requests INTERNET plus Android 13's runtime POST_NOTIFICATIONS permission for
+visible long-running install progress; WorkManager adds its bounded network-
+state, foreground-service, wake/boot, and app-scoped receiver permissions. The
+strict audit rejects anything outside that exact set.
 Bounded ZIP extraction is now connected as well: the pinned minizip-ng core
 uses the shared scan, strict UTF-8, directory-relative no-follow/exclusive
 writes, CRC/byte checks, cancellation, and byte progress. A joined Java pipeline
@@ -911,7 +912,14 @@ recreation, and duplicate `KEEP` enqueue. This models setup UI lifecycle
 without conflating it with the game window. The production cancellation facade
 also reaches WorkManager's terminal `CANCELLED` state during active append,
 preserves the nonzero partial, and emits no false completion in the emulator
-fault harness. A user-facing observer and cancel action remain A3/A4 work.
+fault harness. A production-owned installer activity now observes that unique
+work, renders phase/byte progress, exposes Cancel/Retry, revalidates installed
+content before reporting ready, and opens from the foreground notification.
+Android 13+ start is gated on notification permission and Android 12+ requests
+immediate foreground display. Its wiped-AVD fixture proves the actionable
+notification target, visible Cancel action, and persisted cancelled state
+without downloading game data. The first-launch dual-mode chooser is
+still missing, so normal game startup does not yet route into this screen.
 Do not begin the touch-UI port until A2's controller-driven Original-mode proof
 passes. Physical Android hardware remains authoritative for vendor Vulkan and
 controller behavior; Retro Rewind installation and touch parity follow from

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -245,6 +245,19 @@ not block offline Retro Rewind support.
    user-facing observer/cancel screen or official-archive cancellation.
    Evidence:
    `docs/artifacts/2026-09-04/android/a3-worker-cancellation.md`.
+   A production-owned, release-present installer/status activity now observes
+   the unique chain, displays waiting and determinate phase/byte progress,
+   exposes Cancel/Retry, validates installed content off-main before claiming
+   ready, and opens from the foreground notification. Android 13+ install
+   starts require notification permission, and the foreground notice requests
+   immediate display. A wiped API 36 fixture proved that actionable notice and
+   its explicit return target, then activated the real Cancel control, observed
+   terminal `CANCELLED`, rejected completion, and restored that state after
+   force-stop/reopen. Release keeps
+   the activity non-exported; debug ADB access is privileged and bounded. The
+   missing first-launch dual-mode chooser does not yet route normal startup to
+   this screen. Evidence:
+   `docs/artifacts/2026-09-04/android/a3-installer-ui.md`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2451,3 +2451,32 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   cancellation, remaining production faults/gameplay, and physical hardware
   remain open. No artifact or private data was published. Evidence:
   `docs/artifacts/2026-09-04/android/a3-worker-cancellation.md`.
+
+## 2026-09-04 — Android A3 production installer UI
+
+- Added a release-owned, non-exported Retro Rewind installer/status activity.
+  It observes the persisted unique WorkManager chain, shows waiting and
+  determinate phase/byte progress, exposes production Cancel/Retry actions, and
+  is the immutable explicit destination for foreground-notification taps.
+- A prior successful work record is not enough to display ready: installed
+  content is rehashed against the pinned version/artifact contract on a private
+  executor. The debug fixture explicitly says that it installed no game data.
+- On a wiped API 36 AVD, UUID
+  `cf536fba-365b-446d-ba12-51f1884156e9` reached the visible running state. The
+  real Cancel control was activated by focus navigation, terminal `CANCELLED`
+  appeared with Retry, no completion marker was accepted, and an app force-
+  stop/reopen restored the cancelled state.
+- Android 13+ starts now require notification permission and Android 12+
+  requests immediate foreground display. The wiped run proved an active
+  actionable KartPad notification and its explicit installer-activity target.
+- A3 host contracts, the new UI harness, debug/release compile, API-28 lint,
+  package/privacy audit, builder tests, SunPad snapshot, repository safety,
+  shell, and diff checks pass. The exact source-only APK is 33,843,921 bytes at
+  SHA-256
+  `2e0e28fab71ea96e4d17e46fea5b7699b690284736010ff441f795be509d8079`.
+- Classification: **Pass for production UI ownership, visible observation and
+  cancellation, notification return, and validation before ready.** Normal
+  startup still lacks its dual-mode chooser route; production archive/fault,
+  gameplay, and physical acceptance remain open. No artifact or private data
+  was published. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-installer-ui.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -377,6 +377,23 @@ archive. A3 remains open for that UI, production-size fault/gameplay proof, and
 physical hardware. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-worker-cancellation.md`](artifacts/2026-09-04/android/a3-worker-cancellation.md).
 
+Android now also has a production-owned Retro Rewind installer/status screen.
+It observes the persisted unique work, shows waiting and phase/byte progress,
+exposes Cancel and Retry, revalidates installed content off the main thread
+before reporting ready, and is the immutable return target for foreground-
+notification taps. Install start is gated on Android 13+ notification
+permission and requests immediate foreground display on Android 12+. A wiped
+API 36 run proved the visible actionable notification and its explicit target,
+then activated the real Cancel button through
+focus navigation, observed terminal `CANCELLED`, rejected false completion, and
+restored the cancelled state after force-stop/reopen. The release activity is
+non-exported; only the debug manifest grants privileged `DUMP` launch for the
+bounded no-data fixture. A3 remains open because the incomplete Android dual-
+mode chooser does not yet route normal game startup into this screen, and the
+official archive, production-size fault/gameplay proof, and physical hardware
+are untested. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-installer-ui.md`](artifacts/2026-09-04/android/a3-installer-ui.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-04/android/a3-installer-ui.md
+++ b/docs/artifacts/2026-09-04/android/a3-installer-ui.md
@@ -1,0 +1,67 @@
+# Android A3 production installer UI
+
+Date: 2026-09-04
+
+Branch: `codex/android-a3-installer-ui`
+
+Baseline: `b04437b`
+
+## Falsifiable subgoal
+
+Put the existing durable installer behind a production Android screen that
+observes its persisted state, shows determinate phase/byte progress, exposes a
+real cancel/retry action, survives UI-owner loss, and opens from the foreground
+notification. Do not download or install the production archive.
+
+## Result
+
+- Added a release-owned, non-exported `RetroRewindInstallActivity`. Its
+  production action enqueues the pinned unique worker; its cancel action calls
+  the same production facade proven by the prior worker fault test.
+- The screen observes the unique WorkManager chain independently of the
+  activity lifecycle and renders waiting, capacity check, download, extraction,
+  success, cancellation, and failure states. Active byte totals are shown as a
+  determinate percentage, and users are told work continues off-screen.
+- A foreground-notification tap now returns to this status screen through an
+  immutable explicit pending intent. Android 13+ install starts are gated on
+  notification permission, and Android 12+ is told to show the long-running
+  foreground notification immediately rather than deferring it.
+- A historical WorkManager success is not treated as proof that files are still
+  usable. The screen hashes and validates the installed pinned version and
+  required artifacts on a private executor before reporting ready.
+- The debug manifest alone permits privileged ADB launch with
+  `android.permission.DUMP`; release keeps the activity non-exported. The debug
+  path uses a bounded worker and labels its completion as a fixture, never as
+  installed game data.
+
+## Verification
+
+- On a wiped API 36 / 4 KiB AVD, worker UUID
+  `cf536fba-365b-446d-ba12-51f1884156e9` entered the visible running state.
+  Keyboard focus activated the real production Cancel button without using
+  screen coordinates. The activity observed terminal `CANCELLED`, exposed
+  Retry, rejected any worker completion marker, and restored the same cancelled
+  state after an app force-stop and ordinary reopen.
+- The same run granted the runtime notification permission, required an active
+  KartPad notification with a content intent, and resolved that pending intent
+  to the non-exported production installer activity.
+- The progress and cancelled layouts were visually inspected at the emulator's
+  2400×1080 landscape framebuffer. Text, progress, and the single active action
+  remained readable without scrolling.
+- All seven pre-existing A3 host contracts plus the new UI harness pass. Debug
+  assemble, release Kotlin/Java compilation, API-28 lint, strict package/privacy
+  audit, the 22-test builder suite (one expected private-payload skip), SunPad
+  snapshot, repository safety, shell syntax/lint, and diff checks pass.
+- The exact source-only debug APK is 33,843,921 bytes with SHA-256
+  `2e0e28fab71ea96e4d17e46fea5b7699b690284736010ff441f795be509d8079`.
+
+## Classification
+
+**Pass for a production-owned installer observer, notification return path,
+visible progress, explicit cancellation, retry presentation, and validation
+before ready.** The current Android product still lacks its first-launch dual-
+mode chooser, so this screen is not yet routed from normal game startup; only
+active installer notifications and future in-app callers can open it in
+release. Official-archive cancellation, a production-size install/fault matrix,
+Retro Rewind gameplay/mode switching, and physical hardware remain open. No
+APK/AAB, archive, private data, device identifier, or raw log was published.

--- a/scripts/audit-android-package.sh
+++ b/scripts/audit-android-package.sh
@@ -29,6 +29,7 @@ expected_permission_names="$(printf '%s\n' \
   android.permission.FOREGROUND_SERVICE \
   android.permission.FOREGROUND_SERVICE_DATA_SYNC \
   android.permission.INTERNET \
+  android.permission.POST_NOTIFICATIONS \
   android.permission.RECEIVE_BOOT_COMPLETED \
   android.permission.WAKE_LOCK \
   dev.kartpad.android.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION | sort)"

--- a/scripts/test-android-retro-rewind-installer-ui.sh
+++ b/scripts/test-android-retro-rewind-installer-ui.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+# shellcheck source=android-toolchain-versions.sh
+source "$repo_root/scripts/android-toolchain-versions.sh"
+sdk_root="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/Library/Android/sdk}}"
+adb="$sdk_root/platform-tools/adb"
+emulator="$sdk_root/emulator/emulator"
+avd="$KARTPAD_ANDROID_PHONE_AVD"
+package="dev.kartpad.android"
+component="$package/.RetroRewindInstallActivity"
+
+if "$adb" devices | sed -n '2,$p' | grep -q '[[:space:]]device$'; then
+  echo "ERROR: an Android device/emulator is already connected; preserve the one-emulator rule" >&2
+  exit 1
+fi
+
+"$repo_root/scripts/build-android-fixture.sh"
+"$repo_root/scripts/audit-android-package.sh"
+emulator_log="$repo_root/.android-bootstrap/emulator-$avd-installer-ui.raw.log"
+"$emulator" "@$avd" -no-window -no-audio -no-boot-anim -no-snapshot \
+  -gpu auto -wipe-data >"$emulator_log" 2>&1 &
+emulator_pid=$!
+cleanup() {
+  "$adb" emu kill >/dev/null 2>&1 || true
+  wait "$emulator_pid" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+"$adb" wait-for-device
+booted=0
+for _ in {1..60}; do
+  if [[ "$("$adb" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" == "1" ]]; then
+    booted=1
+    break
+  fi
+  sleep 1
+done
+[[ "$booted" == 1 ]] || { echo "ERROR: emulator did not finish booting" >&2; exit 1; }
+
+"$adb" shell input keyevent KEYCODE_WAKEUP >/dev/null
+"$adb" shell wm dismiss-keyguard >/dev/null 2>&1 || true
+"$adb" shell settings put system accelerometer_rotation 0
+"$adb" shell settings put system user_rotation 1
+"$adb" install -r "$repo_root/android/app/build/outputs/apk/debug/app-debug.apk" >/dev/null
+"$adb" logcat -c
+
+wait_for_marker() {
+  local marker="$1"
+  for _ in {1..40}; do
+    if "$adb" logcat -d -v brief KartPadInstaller:I KartPadFixture:I AndroidRuntime:E '*:S' |
+        grep -Fq "$marker"; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "ERROR: installer UI marker was not observed: $marker" >&2
+  "$adb" logcat -d -v brief KartPadInstaller:V KartPadFixture:V AndroidRuntime:E '*:S' >&2
+  return 1
+}
+
+"$adb" shell am start -W -n "$component" >/dev/null
+wait_for_marker "A3 installer UI state=not-installed"
+if ! "$adb" shell dumpsys activity activities |
+    grep -F "topResumedActivity=" | grep -Fq "$component"; then
+  echo "ERROR: production installer UI is not the resumed activity" >&2
+  exit 1
+fi
+"$adb" shell am force-stop "$package"
+"$adb" shell pm grant "$package" android.permission.POST_NOTIFICATIONS
+"$adb" logcat -c
+
+"$adb" shell am start -W -n "$component" \
+  --ez dev.kartpad.android.TEST_RETRO_REWIND_INSTALLER_UI true >/dev/null
+wait_for_marker "A3 installer UI state=running-fixture"
+if ! "$adb" shell dumpsys activity activities |
+    grep -F "topResumedActivity=" | grep -Fq "$component"; then
+  echo "ERROR: production installer UI is not the resumed activity" >&2
+  exit 1
+fi
+notification_dump="$("$adb" shell dumpsys notification --noredact)"
+if [[ "$notification_dump" != *"pkg=$package"* ||
+      "$notification_dump" != *"contentIntent=PendingIntent"* ]]; then
+  echo "ERROR: foreground progress notification is not visible and actionable" >&2
+  exit 1
+fi
+if ! "$adb" shell dumpsys activity intents |
+    grep -Fq "cmp=$package/.RetroRewindInstallActivity"; then
+  echo "ERROR: installer notification does not return to the production UI" >&2
+  exit 1
+fi
+
+# The bounded fixture exposes only one active control. Keyboard activation
+# exercises the real production Cancel button without coordinate assumptions.
+"$adb" shell input keyevent KEYCODE_TAB
+"$adb" shell input keyevent KEYCODE_ENTER
+wait_for_marker "A3 installer UI cancel requested"
+wait_for_marker "A3 installer UI state=cancelled"
+
+worker_id="$("$adb" logcat -d -v brief KartPadFixture:I '*:S' |
+  sed -n 's/.*A3 durable worker fixture started id=\([^ ]*\).*/\1/p' | tail -1)"
+[[ "$worker_id" =~ ^[0-9a-f-]{36}$ ]] || {
+  echo "ERROR: could not parse installer UI worker id: $worker_id" >&2
+  exit 1
+}
+if "$adb" logcat -d -v brief KartPadFixture:I '*:S' |
+    grep -Fq "A3 durable worker fixture completed id=$worker_id"; then
+  echo "ERROR: cancelled installer UI worker emitted a completion marker" >&2
+  exit 1
+fi
+
+"$adb" shell am force-stop "$package"
+"$adb" shell am start -W -n "$component" >/dev/null
+wait_for_marker "A3 installer UI state=cancelled"
+if "$adb" logcat -d -v brief KartPadInstaller:E KartPadFixture:E AndroidRuntime:E '*:S' |
+    grep -q .; then
+  echo "ERROR: installer UI fixture emitted an error" >&2
+  "$adb" logcat -d -v brief KartPadInstaller:V KartPadFixture:V AndroidRuntime:E '*:S' >&2
+  exit 1
+fi
+
+echo "Android A3 production installer UI passed: avd=$avd worker_id=$worker_id final_state=cancelled"


### PR DESCRIPTION
## Summary
- add a production-owned Retro Rewind install/status activity with persisted WorkManager observation, progress, cancel, retry, and installed-content revalidation
- make foreground progress immediately visible and actionable, including Android 13+ notification permission gating and an explicit return intent
- add a wiped API 36 UI/cancellation/persistence harness and update Android evidence/status docs

## Verification
- `scripts/test-android-retro-rewind-installer-ui.sh`
- all seven pre-existing Android A3 host contract runners
- source-only debug assemble and strict package/privacy audit
- source-only release Kotlin/Java compile and API-28 lint
- private game-runtime debug/release Kotlin/Java compile
- 22 builder tests (one expected private-payload skip), SunPad snapshot, repository safety, shellcheck, and diff checks

## Limits
- no production archive bytes were downloaded
- normal game startup still lacks the first-launch dual-mode chooser route
- production-size install/faults, Retro Rewind gameplay, and physical-device acceptance remain open
- no APK/AAB is published