### PR TITLE
Check Android Retro Rewind version freshness

### DIFF
--- a/android/app/src/debug/java/dev/kartpad/android/RetroRewindWorkerFixtureActivity.kt
+++ b/android/app/src/debug/java/dev/kartpad/android/RetroRewindWorkerFixtureActivity.kt
@@ -19,6 +19,26 @@ internal class RetroRewindWorkerFixtureActivity : Activity() {
             Log.i(LOG_TAG, "A3 worker initializer activity created")
             return
         }
+        if (intent.getBooleanExtra(EXTRA_VERSION_CHECK, false)) {
+            if (savedInstanceState == null) {
+                Thread {
+                    val result = RetroRewindVersionCheck.checkRelease { false }
+                    if (result.isReady) {
+                        Log.i(
+                            LOG_TAG,
+                            "A3 Android official version check latest=${result.latestVersion} " +
+                                "update_required=${result.updateRequired}",
+                        )
+                    } else {
+                        Log.e(
+                            LOG_TAG,
+                            "A3 Android official version check failed error=${result.error}",
+                        )
+                    }
+                }.start()
+            }
+            return
+        }
         if (intent.getBooleanExtra(EXTRA_RESUME_PROCESS_DEATH, false)) {
             if (savedInstanceState == null) {
                 val id = RetroRewindInstallWork.enqueueDebugFixture(
@@ -115,5 +135,7 @@ internal class RetroRewindWorkerFixtureActivity : Activity() {
             "dev.kartpad.android.TEST_RETRO_REWIND_WORKER_INIT_ONLY"
         const val EXTRA_CANCEL =
             "dev.kartpad.android.TEST_RETRO_REWIND_WORKER_CANCEL"
+        const val EXTRA_VERSION_CHECK =
+            "dev.kartpad.android.TEST_RETRO_REWIND_VERSION_CHECK"
     }
 }

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallActivity.kt
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallActivity.kt
@@ -204,7 +204,8 @@ internal class RetroRewindInstallActivity : Activity() {
             WorkInfo.State.FAILED -> {
                 logState("failed")
                 val error = data.getString(RetroRewindInstallWork.KEY_ERROR) ?: "unknown"
-                renderRetry(friendlyError(error))
+                val latest = data.getString(RetroRewindInstallWork.KEY_LATEST_VERSION)
+                renderRetry(friendlyError(error, latest))
             }
         }
     }
@@ -244,6 +245,7 @@ internal class RetroRewindInstallActivity : Activity() {
     private fun renderProgress(phase: String, completed: Long, total: Long) {
         logState("running-$phase")
         status.text = when (phase) {
+            "version" -> "Checking Retro Rewind version…"
             "space" -> "Checking free space…"
             "extract" -> "Installing Retro Rewind…"
             else -> "Downloading Retro Rewind…"
@@ -297,7 +299,11 @@ internal class RetroRewindInstallActivity : Activity() {
         primary.contentDescription = primary.text
     }
 
-    private fun friendlyError(error: String): String = when {
+    private fun friendlyError(error: String, latestVersion: String?): String = when {
+        error == "version-update-required" ->
+            "Retro Rewind ${latestVersion ?: "a newer release"} requires a newer KartPad build before installation or online play."
+        error.startsWith("version-") ->
+            "KartPad could not verify the current official Retro Rewind version. Try again before installing."
         error.startsWith("space-") -> "Not enough safe app storage is available for this installation."
         error.startsWith("download-network_failure") -> "The download could not reach the official server."
         error.startsWith("download-") -> "The official download failed its pinned integrity or protocol checks."

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWork.kt
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWork.kt
@@ -18,6 +18,7 @@ internal object RetroRewindInstallWork {
     const val KEY_COMPLETED_BYTES = "completed_bytes"
     const val KEY_TOTAL_BYTES = "total_bytes"
     const val KEY_ERROR = "error"
+    const val KEY_LATEST_VERSION = "latest_version"
     const val KEY_DEBUG_FIXTURE = "debug_fixture"
     const val KEY_DEBUG_FIXTURE_STEPS = "debug_fixture_steps"
     const val KEY_DEBUG_FIXTURE_DELAY_MILLIS = "debug_fixture_delay_millis"

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWorker.kt
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallWorker.kt
@@ -42,6 +42,22 @@ internal class RetroRewindInstallWorker(
             return@withContext failure("recovery")
         }
 
+        setForeground(foregroundInfo("Checking Retro Rewind version…"))
+        setPhase("version", 0, 0)
+        val version = RetroRewindVersionCheck.checkRelease { isStopped }
+        if (!version.isReady) {
+            return@withContext failure(
+                if (version.error == RetroRewindVersionCheck.Error.CANCELLED) {
+                    "cancelled"
+                } else {
+                    "version-${version.error.name.lowercase()}"
+                },
+            )
+        }
+        if (version.updateRequired) {
+            return@withContext failure("version-update-required", version.latestVersion)
+        }
+
         setPhase("space", 0, 0)
         val space = RetroRewindSpaceProbe.check(
             applicationContext.filesDir,
@@ -195,12 +211,16 @@ internal class RetroRewindInstallWorker(
         return Result.success(progressData("installed", 1, 1))
     }
 
-    private fun failure(error: String): Result = Result.failure(
-        workDataOf(
+    private fun failure(error: String, latestVersion: String? = null): Result {
+        val values = mutableMapOf<String, Any>(
             RetroRewindInstallWork.KEY_PHASE to "failed",
             RetroRewindInstallWork.KEY_ERROR to error,
-        ),
-    )
+        )
+        if (latestVersion != null) {
+            values[RetroRewindInstallWork.KEY_LATEST_VERSION] = latestVersion
+        }
+        return Result.failure(androidx.work.Data.Builder().putAll(values).build())
+    }
 
     private fun foregroundInfo(
         message: String,

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindRelease.java
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindRelease.java
@@ -5,6 +5,7 @@ final class RetroRewindRelease {
     private RetroRewindRelease() {}
 
     static final String VERSION = "6.12.5";
+    static final String VERSION_MANIFEST_URL = "https://update.rwfc.net/RetroRewind/RetroRewindVersion.txt";
     static final String ROOT = "RetroRewind6";
     static final String ARCHIVE_URL = "https://cdn.update.rwfc.net/RetroRewind/zip/6.12.5-full.zip";
     static final String ARCHIVE_SHA256 = "d8f7c61636ef76f8a451f4071ec5bbdcfea9d5f2500cfc6c245431f04580f9d9";

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindVersionCheck.java
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindVersionCheck.java
@@ -1,0 +1,257 @@
+package dev.kartpad.android;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+
+/** Bounded official-version check for the code-pinned Retro Rewind profile. */
+final class RetroRewindVersionCheck {
+    private static final int MAXIMUM_MANIFEST_BYTES = 512 * 1024;
+    private static final int MAXIMUM_VERSION_CHARACTERS = 64;
+    private static final int BUFFER_BYTES = 16 * 1024;
+    private static final int MAXIMUM_REDIRECTS = 5;
+    private static final int CONNECT_TIMEOUT_MILLIS = 15_000;
+    private static final int READ_TIMEOUT_MILLIS = 15_000;
+
+    interface Cancellation {
+        boolean isCancelled();
+    }
+
+    enum Error {
+        NONE,
+        CANCELLED,
+        INVALID_MANIFEST,
+        INSECURE_REDIRECT,
+        TOO_MANY_REDIRECTS,
+        HTTP_FAILURE,
+        NETWORK_FAILURE,
+    }
+
+    static final class Result {
+        final Error error;
+        final String latestVersion;
+        final boolean updateRequired;
+
+        Result(Error error, String latestVersion, boolean updateRequired) {
+            this.error = error;
+            this.latestVersion = latestVersion;
+            this.updateRequired = updateRequired;
+        }
+
+        boolean isReady() {
+            return error == Error.NONE;
+        }
+    }
+
+    private RetroRewindVersionCheck() {}
+
+    static Result checkRelease(Cancellation cancellation) {
+        try {
+            return checkFrom(new URL(RetroRewindRelease.VERSION_MANIFEST_URL), cancellation);
+        } catch (IOException exception) {
+            return failed(Error.NETWORK_FAILURE);
+        }
+    }
+
+    static Result checkFrom(URL initial, Cancellation cancellation) {
+        if (cancellation == null) {
+            return failed(Error.NETWORK_FAILURE);
+        }
+        URL current = initial;
+        for (int redirects = 0; redirects <= MAXIMUM_REDIRECTS; redirects++) {
+            if (cancellation.isCancelled()) {
+                return failed(Error.CANCELLED);
+            }
+            if (current == null || !"https".equalsIgnoreCase(current.getProtocol())) {
+                return failed(Error.INSECURE_REDIRECT);
+            }
+
+            HttpURLConnection connection = null;
+            try {
+                connection = (HttpURLConnection) current.openConnection();
+                connection.setInstanceFollowRedirects(false);
+                connection.setConnectTimeout(CONNECT_TIMEOUT_MILLIS);
+                connection.setReadTimeout(READ_TIMEOUT_MILLIS);
+                connection.setRequestProperty("Accept-Encoding", "identity");
+                int response = connection.getResponseCode();
+                if (isRedirect(response)) {
+                    if (redirects == MAXIMUM_REDIRECTS) {
+                        return failed(Error.TOO_MANY_REDIRECTS);
+                    }
+                    String location = connection.getHeaderField("Location");
+                    if (location == null || location.isEmpty()) {
+                        return failed(Error.HTTP_FAILURE);
+                    }
+                    current = new URL(current, location);
+                    continue;
+                }
+                if (response != HttpURLConnection.HTTP_OK) {
+                    return failed(Error.HTTP_FAILURE);
+                }
+                String encoding = connection.getContentEncoding();
+                if (encoding != null && !"identity".equalsIgnoreCase(encoding)) {
+                    return failed(Error.HTTP_FAILURE);
+                }
+                long declaredBytes = connection.getContentLengthLong();
+                if (declaredBytes > MAXIMUM_MANIFEST_BYTES) {
+                    return failed(Error.INVALID_MANIFEST);
+                }
+                byte[] body;
+                try (InputStream input = connection.getInputStream()) {
+                    body = readBounded(input, cancellation);
+                }
+                if (body == null) {
+                    return failed(cancellation.isCancelled()
+                            ? Error.CANCELLED : Error.INVALID_MANIFEST);
+                }
+                if (declaredBytes >= 0 && body.length != declaredBytes) {
+                    return failed(Error.INVALID_MANIFEST);
+                }
+                String latest = parseLatest(body);
+                if (latest == null) {
+                    return failed(Error.INVALID_MANIFEST);
+                }
+                return new Result(Error.NONE, latest,
+                        compareVersions(latest, RetroRewindRelease.VERSION) > 0);
+            } catch (IOException exception) {
+                return failed(Error.NETWORK_FAILURE);
+            } finally {
+                if (connection != null) {
+                    connection.disconnect();
+                }
+            }
+        }
+        return failed(Error.TOO_MANY_REDIRECTS);
+    }
+
+    static String parseLatest(byte[] body) {
+        if (body == null || body.length == 0 || body.length > MAXIMUM_MANIFEST_BYTES) {
+            return null;
+        }
+        final String text;
+        try {
+            text = StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(body)).toString();
+        } catch (CharacterCodingException exception) {
+            return null;
+        }
+
+        String latest = null;
+        for (String line : text.split("\\R", -1)) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            int separator = firstWhitespace(trimmed);
+            String version = separator < 0 ? trimmed : trimmed.substring(0, separator);
+            if (!isValidVersion(version)) {
+                return null;
+            }
+            if (latest == null || compareVersions(version, latest) > 0) {
+                latest = version;
+            }
+        }
+        return latest;
+    }
+
+    static int compareVersions(String left, String right) {
+        if (!isValidVersion(left) || !isValidVersion(right)) {
+            throw new IllegalArgumentException("Invalid Retro Rewind version");
+        }
+        String[] leftParts = left.split("\\.", -1);
+        String[] rightParts = right.split("\\.", -1);
+        int count = Math.max(leftParts.length, rightParts.length);
+        for (int index = 0; index < count; index++) {
+            String leftPart = index < leftParts.length ? normalizedNumber(leftParts[index]) : "0";
+            String rightPart = index < rightParts.length ? normalizedNumber(rightParts[index]) : "0";
+            if (leftPart.length() != rightPart.length()) {
+                return Integer.compare(leftPart.length(), rightPart.length());
+            }
+            int comparison = leftPart.compareTo(rightPart);
+            if (comparison != 0) {
+                return comparison;
+            }
+        }
+        return 0;
+    }
+
+    private static byte[] readBounded(InputStream input, Cancellation cancellation)
+            throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[BUFFER_BYTES];
+        while (true) {
+            if (cancellation.isCancelled()) {
+                return null;
+            }
+            int count = input.read(buffer);
+            if (count == -1) {
+                return output.toByteArray();
+            }
+            if (count == 0) {
+                continue;
+            }
+            if (output.size() > MAXIMUM_MANIFEST_BYTES - count) {
+                return null;
+            }
+            output.write(buffer, 0, count);
+        }
+    }
+
+    private static boolean isValidVersion(String version) {
+        if (version == null || version.length() > MAXIMUM_VERSION_CHARACTERS) {
+            return false;
+        }
+        String[] parts = version.split("\\.", -1);
+        if (parts.length < 2 || parts.length > 4) {
+            return false;
+        }
+        for (String part : parts) {
+            if (part.isEmpty()) {
+                return false;
+            }
+            for (int index = 0; index < part.length(); index++) {
+                char value = part.charAt(index);
+                if (value < '0' || value > '9') {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static String normalizedNumber(String value) {
+        int index = 0;
+        while (index + 1 < value.length() && value.charAt(index) == '0') {
+            index++;
+        }
+        return value.substring(index);
+    }
+
+    private static int firstWhitespace(String value) {
+        for (int index = 0; index < value.length(); index++) {
+            if (Character.isWhitespace(value.charAt(index))) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    private static boolean isRedirect(int response) {
+        return response == HttpURLConnection.HTTP_MOVED_PERM ||
+                response == HttpURLConnection.HTTP_MOVED_TEMP ||
+                response == HttpURLConnection.HTTP_SEE_OTHER ||
+                response == 307 || response == 308;
+    }
+
+    private static Result failed(Error error) {
+        return new Result(error, null, false);
+    }
+}

--- a/android/app/src/test/java/dev/kartpad/android/RetroRewindVersionCheckTestMain.java
+++ b/android/app/src/test/java/dev/kartpad/android/RetroRewindVersionCheckTestMain.java
@@ -1,0 +1,274 @@
+package dev.kartpad.android;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+
+public final class RetroRewindVersionCheckTestMain {
+    private RetroRewindVersionCheckTestMain() {}
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 1 && "--live".equals(args[0])) {
+            var live = RetroRewindVersionCheck.checkRelease(() -> false);
+            expect(live.isReady(), "official version check failed: " + live.error);
+            System.out.println("KartPad pins Retro Rewind " + RetroRewindRelease.VERSION +
+                    "; official feed reports " + live.latestVersion);
+            if (live.updateRequired) {
+                throw new IllegalStateException(
+                        "newer Retro Rewind requires a KartPad profile update");
+            }
+            return;
+        }
+        expect(args.length == 0, "only --live is supported");
+        expectLatest("6.12.5\n", "6.12.5");
+        expectLatest("6.12.4 old\n6.12.6 current\n6.12.5\n", "6.12.6");
+        expectLatest("  006.012.0005  stable  \r\n", "006.012.0005");
+        expectLatest("\n \t\n", null);
+        expectLatest("6.12.5\nnot-a-version\n", null);
+        expectLatest("6..5\n", null);
+        expectLatest("6.12.5.0.1\n", null);
+        expectLatest("6." + "1".repeat(63) + "\n", null);
+        expect(RetroRewindVersionCheck.parseLatest(new byte[] {(byte) 0xc3, 0x28}) == null,
+                "invalid UTF-8 manifest accepted");
+        expect(RetroRewindVersionCheck.parseLatest(new byte[512 * 1024 + 1]) == null,
+                "oversized manifest accepted");
+
+        expect(RetroRewindVersionCheck.compareVersions("6.12.5", "6.12.5.0") == 0,
+                "zero suffix comparison changed");
+        expect(RetroRewindVersionCheck.compareVersions("6.12.10", "6.12.9") > 0,
+                "numeric component comparison became lexical");
+        expect(RetroRewindVersionCheck.compareVersions(
+                        "6.999999999999999999999999999999", "6.12.5") > 0,
+                "large numeric component overflowed");
+        expect(RetroRewindVersionCheck.compareVersions("006.012.0005", "6.12.5") == 0,
+                "leading zero comparison changed");
+
+        QueueHandler currentHandler = new QueueHandler(response(200, "6.12.5\n"));
+        var current = RetroRewindVersionCheck.checkFrom(
+                fixtureUrl("https://fixture.invalid/version", currentHandler), () -> false);
+        expect(current.isReady() && !current.updateRequired &&
+                        "6.12.5".equals(current.latestVersion),
+                "current version did not pass");
+        expect("identity".equals(currentHandler.opened.getRequestProperty("Accept-Encoding")),
+                "version request did not disable content encoding");
+
+        var update = RetroRewindVersionCheck.checkFrom(
+                fixtureUrl("https://fixture.invalid/version",
+                        new QueueHandler(response(200, "6.12.6\n"))), () -> false);
+        expect(update.isReady() && update.updateRequired &&
+                        "6.12.6".equals(update.latestVersion),
+                "newer official version did not block the compiled profile");
+
+        QueueHandler redirectHandler = new QueueHandler(
+                response(302, new byte[0], "/current", null, 0),
+                response(200, "6.12.5\n"));
+        var redirected = RetroRewindVersionCheck.checkFrom(
+                fixtureUrl("https://fixture.invalid/version", redirectHandler), () -> false);
+        expect(redirected.isReady() && redirectHandler.opens == 2,
+                "bounded HTTPS redirect failed");
+
+        QueueHandler redirectLoop = new QueueHandler(
+                response(302, new byte[0], "/again", null, 0),
+                response(302, new byte[0], "/again", null, 0),
+                response(302, new byte[0], "/again", null, 0),
+                response(302, new byte[0], "/again", null, 0),
+                response(302, new byte[0], "/again", null, 0),
+                response(302, new byte[0], "/again", null, 0));
+        expectError(RetroRewindVersionCheck.checkFrom(
+                        fixtureUrl("https://fixture.invalid/version", redirectLoop),
+                        () -> false),
+                RetroRewindVersionCheck.Error.TOO_MANY_REDIRECTS);
+
+        QueueHandler insecureRedirectHandler = new QueueHandler(
+                response(302, new byte[0], "http://fixture.invalid/current", null, 0));
+        expectError(RetroRewindVersionCheck.checkFrom(
+                        fixtureUrl("https://fixture.invalid/version", insecureRedirectHandler),
+                        () -> false),
+                RetroRewindVersionCheck.Error.INSECURE_REDIRECT);
+        expectError(RetroRewindVersionCheck.checkFrom(
+                        fixtureUrl("http://fixture.invalid/version",
+                                new QueueHandler(response(200, "6.12.5\n"))),
+                        () -> false),
+                RetroRewindVersionCheck.Error.INSECURE_REDIRECT);
+        expectError(RetroRewindVersionCheck.checkFrom(
+                        fixtureUrl("https://fixture.invalid/version",
+                                new QueueHandler(response(500, new byte[0], null, null, 0))),
+                        () -> false),
+                RetroRewindVersionCheck.Error.HTTP_FAILURE);
+        expectError(RetroRewindVersionCheck.checkFrom(
+                        fixtureUrl("https://fixture.invalid/version",
+                                new QueueHandler(response(
+                                        200, "6.12.5\n".getBytes(StandardCharsets.UTF_8),
+                                        null, "gzip", 7))),
+                        () -> false),
+                RetroRewindVersionCheck.Error.HTTP_FAILURE);
+        expectError(RetroRewindVersionCheck.checkFrom(
+                        fixtureUrl("https://fixture.invalid/version",
+                                new QueueHandler(response(
+                                        200, "6.12.5\n".getBytes(StandardCharsets.UTF_8),
+                                        null, null, 512 * 1024 + 1))),
+                        () -> false),
+                RetroRewindVersionCheck.Error.INVALID_MANIFEST);
+        expectError(RetroRewindVersionCheck.checkFrom(
+                        fixtureUrl("https://fixture.invalid/version",
+                                new QueueHandler(response(
+                                        200, "6.12.5\n".getBytes(StandardCharsets.UTF_8),
+                                        null, null, 1))),
+                        () -> false),
+                RetroRewindVersionCheck.Error.INVALID_MANIFEST);
+
+        byte[] oversized = new byte[512 * 1024 + 1];
+        Arrays.fill(oversized, (byte) '1');
+        expectError(RetroRewindVersionCheck.checkFrom(
+                        fixtureUrl("https://fixture.invalid/version",
+                                new QueueHandler(response(200, oversized, null, null, -1))),
+                        () -> false),
+                RetroRewindVersionCheck.Error.INVALID_MANIFEST);
+        expectError(RetroRewindVersionCheck.checkFrom(
+                        fixtureUrl("https://fixture.invalid/version",
+                                new QueueHandler(response(200, "6.12.5\n"))),
+                        () -> true),
+                RetroRewindVersionCheck.Error.CANCELLED);
+        expectError(RetroRewindVersionCheck.checkFrom(
+                        fixtureUrl("https://fixture.invalid/version", new QueueHandler()),
+                        () -> false),
+                RetroRewindVersionCheck.Error.NETWORK_FAILURE);
+        var midReadCancellation = new RetroRewindVersionCheck.Cancellation() {
+            private int probes;
+
+            @Override
+            public boolean isCancelled() {
+                probes++;
+                return probes > 1;
+            }
+        };
+        expectError(RetroRewindVersionCheck.checkFrom(
+                        fixtureUrl("https://fixture.invalid/version",
+                                new QueueHandler(response(200, "6.12.5\n"))),
+                        midReadCancellation),
+                RetroRewindVersionCheck.Error.CANCELLED);
+
+        System.out.println("Android Retro Rewind version check passed.");
+    }
+
+    private static void expectLatest(String body, String expected) {
+        String actual = RetroRewindVersionCheck.parseLatest(
+                body.getBytes(StandardCharsets.UTF_8));
+        expect(expected == null ? actual == null : expected.equals(actual),
+                "unexpected latest version: " + actual);
+    }
+
+    private static void expectError(
+            RetroRewindVersionCheck.Result result,
+            RetroRewindVersionCheck.Error expected) {
+        expect(result.error == expected,
+                "expected " + expected + " but received " + result.error);
+    }
+
+    private static void expect(boolean condition, String message) {
+        if (!condition) {
+            throw new IllegalStateException(message);
+        }
+    }
+
+    private static FixtureConnection response(int code, String body) {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        return response(code, bytes, null, null, bytes.length);
+    }
+
+    private static FixtureConnection response(
+            int code, byte[] body, String location, String encoding, long declaredBytes) {
+        return new FixtureConnection(code, body, location, encoding, declaredBytes);
+    }
+
+    private static URL fixtureUrl(String value, QueueHandler handler) throws Exception {
+        return new URL(null, value, handler);
+    }
+
+    private static final class QueueHandler extends URLStreamHandler {
+        private final Queue<FixtureConnection> responses = new ArrayDeque<>();
+        FixtureConnection opened;
+        int opens;
+
+        QueueHandler(FixtureConnection... responses) {
+            this.responses.addAll(Arrays.asList(responses));
+        }
+
+        @Override
+        protected URLConnection openConnection(URL url) throws IOException {
+            FixtureConnection response = responses.poll();
+            if (response == null) {
+                throw new IOException("No fixture response");
+            }
+            opened = response;
+            opens++;
+            return response;
+        }
+    }
+
+    private static final class FixtureConnection extends HttpURLConnection {
+        private final int responseCode;
+        private final byte[] body;
+        private final String location;
+        private final String encoding;
+        private final long declaredBytes;
+
+        FixtureConnection(
+                int responseCode,
+                byte[] body,
+                String location,
+                String encoding,
+                long declaredBytes) {
+            super(null);
+            this.responseCode = responseCode;
+            this.body = body;
+            this.location = location;
+            this.encoding = encoding;
+            this.declaredBytes = declaredBytes;
+        }
+
+        @Override
+        public int getResponseCode() {
+            return responseCode;
+        }
+
+        @Override
+        public String getHeaderField(String name) {
+            return "Location".equalsIgnoreCase(name) ? location : null;
+        }
+
+        @Override
+        public String getContentEncoding() {
+            return encoding;
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            return declaredBytes;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return new ByteArrayInputStream(body);
+        }
+
+        @Override
+        public void disconnect() {}
+
+        @Override
+        public boolean usingProxy() {
+            return false;
+        }
+
+        @Override
+        public void connect() {}
+    }
+}

--- a/builder/kartpad_builder/android_release_contract.py
+++ b/builder/kartpad_builder/android_release_contract.py
@@ -20,6 +20,7 @@ def render_android_release_contract(profile_data: dict) -> str:
     payload = config["payload"]
     strings = {
         "VERSION": config["version"],
+        "VERSION_MANIFEST_URL": config["versionManifestUrl"],
         "ROOT": config["root"],
         "ARCHIVE_URL": archive["url"],
         "ARCHIVE_SHA256": archive["sha256"],

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -920,6 +920,12 @@ immediate foreground display. Its wiped-AVD fixture proves the actionable
 notification target, visible Cancel action, and persisted cancelled state
 without downloading game data. The first-launch dual-mode chooser is
 still missing, so normal game startup does not yet route into this screen.
+Before the worker performs capacity checks or requests archive bytes, it now
+fetches the profile-generated official version feed through bounded HTTPS and
+strict UTF-8 parsing. A valid newer release blocks installation with a KartPad-
+update message; invalid/unavailable responses fail without changing installed
+or partial data. The host JVM and wiped API 36 AVD both currently observe
+official version `6.12.5`, matching the compiled profile.
 Do not begin the touch-UI port until A2's controller-driven Original-mode proof
 passes. Physical Android hardware remains authoritative for vendor Vulkan and
 controller behavior; Retro Rewind installation and touch parity follow from

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -258,6 +258,14 @@ not block offline Retro Rewind support.
    missing first-launch dual-mode chooser does not yet route normal startup to
    this screen. Evidence:
    `docs/artifacts/2026-09-04/android/a3-installer-ui.md`.
+   The worker now performs a profile-generated, bounded HTTPS version check
+   before capacity preflight or archive acquisition. Strict UTF-8/numeric
+   parsing, five redirects, 15-second timeouts, a 512 KiB cap, cancellation,
+   and stale-profile blocking have direct host fault coverage. The host JVM and
+   wiped API 36 Android TLS path each report official `6.12.5`; no archive bytes
+   were requested. Normal startup's chooser/installed fallback remains absent.
+   Evidence:
+   `docs/artifacts/2026-09-04/android/a3-version-freshness.md`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2480,3 +2480,33 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   gameplay, and physical acceptance remain open. No artifact or private data
   was published. Evidence:
   `docs/artifacts/2026-09-04/android/a3-installer-ui.md`.
+
+## 2026-09-04 — Android A3 Retro Rewind version freshness
+
+- Added the profile's official version-manifest URL to Android's generated
+  release contract and placed a fail-closed freshness check after recovery but
+  before capacity preflight/archive acquisition.
+- The HTTPS client permits only secure bounded redirects, identity transfer,
+  15-second timeouts, cancellation, strict UTF-8, and at most 512 KiB. Version
+  comparison handles two to four arbitrary-length numeric components without
+  overflow; any malformed nonempty line invalidates the feed.
+- Direct faults cover current/newer/older and padded versions, huge components,
+  malformed/oversized/encoded bodies, insecure/looping redirects, HTTP/network
+  failure, and cancellation. A newer valid feed returns a specific KartPad-
+  update-required result before any archive state can change.
+- The host JVM and wiped API 36 AVD independently reached the official service
+  and reported `6.12.5`, equal to the compiled profile. The wiped run also
+  reconfirmed PR #55 notification/UI cancellation and persistence with bounded
+  worker UUID `0b41fe6c-0508-4315-a41f-85e777ce577d`. No archive was requested.
+- Eight A3 source contracts, public/private compile configurations, API-28
+  lint, APK audit, builder tests, SunPad snapshot, repository safety, shell,
+  and diff checks pass. Source verification reaches only the unchanged ignored
+  `rr-pulsar` checkout mismatch after all 446 hunks and other pins pass. The
+  source-only APK is 33,843,921 bytes at SHA-256
+  `391f183e6fd4aebb540ad561c6fef436a4bf9cfe1857f205e7480e3e911389e2`.
+- Classification: **Pass for generated version authority, bounded official-
+  feed handling, Android TLS execution, and stale-profile blocking before
+  acquisition.** The normal chooser/installed fallback, archive/install fault
+  execution, gameplay/mode switching, and physical hardware remain open. No
+  artifact or private data was published. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-version-freshness.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -394,6 +394,20 @@ official archive, production-size fault/gameplay proof, and physical hardware
 are untested. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-installer-ui.md`](artifacts/2026-09-04/android/a3-installer-ui.md).
 
+The Android install worker now also fails closed on Retro Rewind version
+freshness before capacity preflight or archive acquisition. The official feed
+URL is generated from the sole profile; its HTTPS client bounds redirects,
+timeouts, encoding, strict UTF-8, and a 512 KiB body, and numeric comparison
+cannot overflow. A newer valid release produces a specific KartPad-update
+requirement, while unavailable/invalid checks preserve all existing install
+state and expose Retry. Host fault tests pass, and both the host JVM and a
+wiped API 36 AVD reached the official service through their real TLS stacks and
+reported the current pinned `6.12.5`. No archive bytes were requested. A3
+remains open for the normal dual-mode route/installed fallback, production
+archive and fault execution, gameplay/mode switching, and physical hardware.
+Evidence:
+[`docs/artifacts/2026-09-04/android/a3-version-freshness.md`](artifacts/2026-09-04/android/a3-version-freshness.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-04/android/a3-version-freshness.md
+++ b/docs/artifacts/2026-09-04/android/a3-version-freshness.md
@@ -1,0 +1,71 @@
+# Android A3 Retro Rewind version freshness
+
+Date: 2026-09-04
+
+Branch: `codex/android-a3-version-freshness`
+
+Baseline: `5105d99`
+
+## Falsifiable subgoal
+
+Before Android allocates installation space or requests any archive byte, fetch
+the profile-owned official version manifest through a bounded HTTPS client.
+Continue only when the feed is valid and no newer version exists; fail closed
+with a specific KartPad-update message when the compiled profile is stale.
+
+## Result
+
+- Android's generated release contract now includes the same official version-
+  manifest URL used by the Apple product, sourced from the sole checked-in
+  profile rather than a second hand-maintained constant.
+- The worker checks freshness after safe storage recovery and before capacity
+  preflight/download. A newer valid version returns `version-update-required`
+  plus only the validated version string. Invalid, unavailable, insecure, or
+  oversized responses fail without touching archive state; the existing Retry
+  UI remains available.
+- The client permits HTTPS only, disables automatic redirects/content encoding,
+  bounds redirects to five, applies 15-second connect/read timeouts, caps the
+  body at 512 KiB even when length is unknown, requires strict UTF-8, and checks
+  cancellation before and during streaming.
+- Version parsing accepts two to four numeric components and compares arbitrary-
+  precision components without integer overflow, within a 64-character result
+  bound suitable for WorkManager data. Every nonempty feed line must be valid,
+  matching the existing fail-closed Apple behavior.
+
+## Verification
+
+- The host contract covers current/newer/older and zero-padded versions,
+  arbitrary-length numeric components, malformed lines, invalid UTF-8, declared
+  and streamed oversize, HTTPS and insecure redirects, redirect exhaustion,
+  HTTP/network failures, compression, and cancellation before/during read.
+- Both the host JVM and a wiped API 36 / 4 KiB AVD reached
+  `https://update.rwfc.net/RetroRewind/RetroRewindVersion.txt`; each reported
+  official version `6.12.5`, equal to the compiled pin. The Android run waited
+  for verified emulator DNS/network readiness before testing the platform TLS
+  path. No archive URL was requested.
+- The same wiped run retained the PR #55 UI result: bounded worker UUID
+  `0b41fe6c-0508-4315-a41f-85e777ce577d` exposed an actionable foreground
+  notification, accepted the real Cancel control, reached terminal `CANCELLED`,
+  emitted no completion marker, and restored that state after force-stop/open.
+- All eight source A3 contract runners, debug assemble, source-only release
+  compile, API-28 lint, private game-runtime debug/release compile, strict APK
+  audit, 22 builder tests (one expected private-payload skip), SunPad snapshot,
+  repository safety, shell lint/syntax, and diff checks pass.
+- Source verification validates all 446 patch hunks plus WiiCompiled, SunPad,
+  and WheelWizard, then reaches the unchanged ignored local `rr-pulsar`
+  mismatch (`b566a5d` present versus `29e76d4` pinned). This branch neither uses
+  nor modifies that checkout.
+- The exact source-only debug APK is 33,843,921 bytes with SHA-256
+  `391f183e6fd4aebb540ad561c6fef436a4bf9cfe1857f205e7480e3e911389e2`.
+
+## Classification
+
+**Pass for profile-generated Android version metadata, bounded official-feed
+transport/parsing, Android TLS execution, and stale-profile blocking before
+archive acquisition.** The newer-version decision is fixture-tested, but its
+rendered UI cannot be observed against today's current feed. Normal startup
+still lacks the dual-mode chooser and installed-version fallback action.
+Production archive/install
+faults, Retro Rewind gameplay/mode switching, and physical hardware remain
+open. No APK/AAB, archive, private data, device identifier, or raw log was
+published.

--- a/scripts/test-android-retro-rewind-installer-ui.sh
+++ b/scripts/test-android-retro-rewind-installer-ui.sh
@@ -10,6 +10,7 @@ emulator="$sdk_root/emulator/emulator"
 avd="$KARTPAD_ANDROID_PHONE_AVD"
 package="dev.kartpad.android"
 component="$package/.RetroRewindInstallActivity"
+fixture_component="$package/.RetroRewindWorkerFixtureActivity"
 
 if "$adb" devices | sed -n '2,$p' | grep -q '[[:space:]]device$'; then
   echo "ERROR: an Android device/emulator is already connected; preserve the one-emulator rule" >&2
@@ -59,6 +60,25 @@ wait_for_marker() {
   "$adb" logcat -d -v brief KartPadInstaller:V KartPadFixture:V AndroidRuntime:E '*:S' >&2
   return 1
 }
+
+network_ready=0
+for _ in {1..45}; do
+  if "$adb" shell ping -c 1 -W 1 update.rwfc.net >/dev/null 2>&1; then
+    network_ready=1
+    break
+  fi
+  sleep 1
+done
+[[ "$network_ready" == 1 ]] || {
+  echo "ERROR: emulator network/DNS did not become ready for the official version check" >&2
+  exit 1
+}
+
+"$adb" shell am start -W -n "$fixture_component" \
+  --ez dev.kartpad.android.TEST_RETRO_REWIND_VERSION_CHECK true >/dev/null
+wait_for_marker "A3 Android official version check latest=6.12.5 update_required=false"
+"$adb" shell am force-stop "$package"
+"$adb" logcat -c
 
 "$adb" shell am start -W -n "$component" >/dev/null
 wait_for_marker "A3 installer UI state=not-installed"

--- a/scripts/test-android-retro-rewind-version.sh
+++ b/scripts/test-android-retro-rewind-version.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
+# shellcheck source=android-toolchain-versions.sh
+source "$repo_root/scripts/android-toolchain-versions.sh"
+java_home="$repo_root/.android-bootstrap/jdk-$KARTPAD_ANDROID_JDK_VERSION/Contents/Home"
+classes="$repo_root/build/android-retro-rewind-version-tests"
+
+if [[ ! -x "$java_home/bin/javac" || ! -x "$java_home/bin/java" ]]; then
+  echo "ERROR: pinned Android JDK is unavailable; run scripts/bootstrap-android-host.sh" >&2
+  exit 1
+fi
+
+mkdir -p "$classes"
+find "$classes" -type f -delete
+"$java_home/bin/javac" -Werror -Xlint:all -d "$classes" \
+  "$repo_root/android/app/src/main/java/dev/kartpad/android/RetroRewindRelease.java" \
+  "$repo_root/android/app/src/main/java/dev/kartpad/android/RetroRewindVersionCheck.java" \
+  "$repo_root/android/app/src/test/java/dev/kartpad/android/RetroRewindVersionCheckTestMain.java"
+"$java_home/bin/java" -cp "$classes" \
+  dev.kartpad.android.RetroRewindVersionCheckTestMain "$@"


### PR DESCRIPTION
## Summary
- generate the official Retro Rewind version-manifest URL from the sole release profile and gate the install worker before capacity checks or archive acquisition
- add a bounded, fail-closed HTTPS/strict-UTF-8 version checker with arbitrary-precision numeric comparison and an actionable stale-KartPad UI state
- cover malformed manifests, redirects, transport faults, cancellation, oversized input, and current/newer releases; prove the official feed through both host and wiped Android TLS stacks

## Verification
- `scripts/test-android-retro-rewind-version.sh`
- `scripts/test-android-retro-rewind-version.sh --live`
- `scripts/test-android-retro-rewind-installer-ui.sh` (wiped API 36 ARM64 AVD)
- all eight Android A3 source contract runners
- source-only release Kotlin/Java compile and API 28 lint
- private game-runtime debug/release source compile
- strict APK audit (`391f183e6fd4aebb540ad561c6fef436a4bf9cfe1857f205e7480e3e911389e2`)
- 22 builder tests, SunPad snapshot, repository safety, shell syntax/lint, and diff checks

## Limits
- today's official feed matches the pinned `6.12.5`; the newer-version branch is fault-fixture tested rather than observable against the current live feed
- no production archive bytes were requested or downloaded
- the normal dual-mode chooser/installed fallback, production archive and fault execution, gameplay/mode switching, and physical hardware acceptance remain open
- full source verification still stops at the pre-existing ignored `ref/upstream/rr-pulsar` pin mismatch documented in the evidence
