### PR TITLE
Test Android install replacement faults on-device

### DIFF
--- a/android/app/src/debug/java/dev/kartpad/android/RetroRewindPipelineDeviceFixture.java
+++ b/android/app/src/debug/java/dev/kartpad/android/RetroRewindPipelineDeviceFixture.java
@@ -8,6 +8,7 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -93,13 +94,24 @@ final class RetroRewindPipelineDeviceFixture {
                     "replacement synthetic install failed: " + replacement.error);
             require(validateInstalled(context, secondContract).isValid(),
                     "replacement installed content did not validate");
+
+            String recoveryToken = "device-recovery";
+            Path support = RetroRewindInstallStorage.supportRoot(context.getFilesDir());
+            Path installed = RetroRewindInstallStorage.installedRoot(context.getFilesDir());
+            Path recoveryRollback = support.resolve("RetroRewind.rollback-" + recoveryToken);
+            Files.move(installed, recoveryRollback, StandardCopyOption.ATOMIC_MOVE);
+            Path staleStaging = RetroRewindInstallStorage.createStagingDirectory(
+                    context.getFilesDir(), recoveryToken);
+            Files.write(staleStaging.resolve("interrupted.tmp"),
+                    "interrupted".getBytes(StandardCharsets.UTF_8));
             RetroRewindInstallStorage.recover(context.getFilesDir());
             require(validateInstalled(context, secondContract).isValid(),
-                    "startup recovery changed the replacement install");
+                    "startup recovery did not restore the rollback install");
             require(noTransientInstallDirectories(context),
-                    "successful replacement left staging or rollback state");
+                    "startup recovery left staging or rollback state");
 
-            Log.i(TAG, "A3 device install faults passed existing=preserved replacement=valid");
+            Log.i(TAG, "A3 device install faults passed existing=preserved " +
+                    "replacement=valid recovery=restored");
         } catch (Exception error) {
             Log.e(TAG, "A3 device install faults failed", error);
         } finally {

--- a/android/app/src/debug/java/dev/kartpad/android/RetroRewindPipelineDeviceFixture.java
+++ b/android/app/src/debug/java/dev/kartpad/android/RetroRewindPipelineDeviceFixture.java
@@ -1,0 +1,237 @@
+package dev.kartpad.android;
+
+import android.content.Context;
+import android.util.Log;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+/** Runs the real Android install pipeline against bounded synthetic content. */
+final class RetroRewindPipelineDeviceFixture {
+    private static final String TAG = "KartPadFixture";
+    private static final String VERSION = RetroRewindRelease.VERSION;
+    private static final String CODE_PATH = "fixture/code.bin";
+    private static final String XML_PATH = "fixture/config.xml";
+
+    private RetroRewindPipelineDeviceFixture() {}
+
+    static void run(Context context) {
+        Path fixtureRoot = context.getCacheDir().toPath()
+                .resolve("RetroRewindPipelineDeviceFixture");
+        try {
+            System.loadLibrary("main");
+            deleteTree(fixtureRoot);
+            Files.createDirectories(fixtureRoot);
+            RetroRewindInstallStorage.recover(context.getFilesDir());
+
+            byte[] firstCode = "first-device-code".getBytes(StandardCharsets.UTF_8);
+            byte[] firstXml = "<first-device/>".getBytes(StandardCharsets.UTF_8);
+            Path firstArchive = createArchive(fixtureRoot.resolve("first.zip"), firstCode, firstXml);
+            RetroRewindInstallValidator.Contract firstContract = contract(firstCode, firstXml);
+            RetroRewindInstallPipeline.Result first = install(
+                    context, firstArchive, "device-first", firstContract);
+            require(first.isInstalled(), "initial synthetic install failed: " + first.error);
+            require(validateInstalled(context, firstContract).isValid(),
+                    "initial installed content did not validate");
+
+            Path rejectedArchive = fixtureRoot.resolve("rejected.zip");
+            Files.copy(firstArchive, rejectedArchive);
+            long firstArchiveBytes = Files.size(firstArchive);
+            String firstArchiveSha256 = sha256(firstArchive);
+            try (OutputStream output = Files.newOutputStream(
+                    rejectedArchive, java.nio.file.StandardOpenOption.APPEND)) {
+                output.write(0);
+            }
+            RetroRewindInstallPipeline.Result rejected = RetroRewindInstallPipeline.install(
+                    context.getFilesDir(),
+                    rejectedArchive,
+                    "device-rejected",
+                    () -> false,
+                    (completed, total) -> {},
+                    path -> RetroRewindArchiveDownload.verifyFile(
+                            path, firstArchiveBytes, firstArchiveSha256),
+                    RetroRewindArchiveExtractor::extract,
+                    firstContract);
+            require(rejected.error == RetroRewindInstallPipeline.Error.ARCHIVE_INVALID,
+                    "corrupt archive reached extraction: " + rejected.error);
+            require(validateInstalled(context, firstContract).isValid(),
+                    "rejected archive changed the active install");
+
+            byte[] secondCode = "second-device-code".getBytes(StandardCharsets.UTF_8);
+            byte[] secondXml = "<second-device/>".getBytes(StandardCharsets.UTF_8);
+            Path secondArchive = createArchive(
+                    fixtureRoot.resolve("second.zip"), secondCode, secondXml);
+            RetroRewindInstallValidator.Contract secondContract = contract(secondCode, secondXml);
+
+            String blockedToken = "device-blocked";
+            Path rollback = RetroRewindInstallStorage.supportRoot(context.getFilesDir())
+                    .resolve("RetroRewind.rollback-" + blockedToken);
+            Files.createDirectory(rollback);
+            RetroRewindInstallPipeline.Result blocked = install(
+                    context, secondArchive, blockedToken, secondContract);
+            require(blocked.error == RetroRewindInstallPipeline.Error.ACTIVATION_FAILURE,
+                    "injected activation failure was not surfaced: " + blocked.error);
+            require(validateInstalled(context, firstContract).isValid(),
+                    "activation failure did not retain the previous install");
+            require(!Files.exists(RetroRewindInstallStorage.supportRoot(context.getFilesDir())
+                            .resolve("RetroRewind.import-" + blockedToken)),
+                    "failed activation left staging behind");
+            Files.delete(rollback);
+
+            RetroRewindInstallPipeline.Result replacement = install(
+                    context, secondArchive, "device-replacement", secondContract);
+            require(replacement.isInstalled(),
+                    "replacement synthetic install failed: " + replacement.error);
+            require(validateInstalled(context, secondContract).isValid(),
+                    "replacement installed content did not validate");
+            RetroRewindInstallStorage.recover(context.getFilesDir());
+            require(validateInstalled(context, secondContract).isValid(),
+                    "startup recovery changed the replacement install");
+            require(noTransientInstallDirectories(context),
+                    "successful replacement left staging or rollback state");
+
+            Log.i(TAG, "A3 device install faults passed existing=preserved replacement=valid");
+        } catch (Exception error) {
+            Log.e(TAG, "A3 device install faults failed", error);
+        } finally {
+            try {
+                deleteTree(fixtureRoot);
+            } catch (IOException error) {
+                Log.e(TAG, "A3 device install fixture cleanup failed", error);
+            }
+        }
+    }
+
+    private static RetroRewindInstallPipeline.Result install(
+            Context context,
+            Path archive,
+            String token,
+            RetroRewindInstallValidator.Contract contract) throws IOException {
+        long archiveBytes = Files.size(archive);
+        String archiveSha256 = sha256(archive);
+        return RetroRewindInstallPipeline.install(
+                context.getFilesDir(),
+                archive,
+                token,
+                () -> false,
+                (completed, total) -> {},
+                path -> RetroRewindArchiveDownload.verifyFile(
+                        path, archiveBytes, archiveSha256),
+                RetroRewindArchiveExtractor::extract,
+                contract);
+    }
+
+    private static RetroRewindInstallValidator.Result validateInstalled(
+            Context context, RetroRewindInstallValidator.Contract contract) {
+        return RetroRewindInstallValidator.validate(
+                RetroRewindInstallStorage.installedRoot(context.getFilesDir())
+                        .resolve(RetroRewindRelease.ROOT),
+                contract);
+    }
+
+    private static RetroRewindInstallValidator.Contract contract(byte[] code, byte[] xml) {
+        return new RetroRewindInstallValidator.Contract(
+                VERSION,
+                RetroRewindRelease.ROOT,
+                Arrays.asList(
+                        new RetroRewindInstallValidator.ArtifactRequirement(
+                                CODE_PATH, code.length, sha256(code)),
+                        new RetroRewindInstallValidator.ArtifactRequirement(
+                                XML_PATH, xml.length, sha256(xml))));
+    }
+
+    private static Path createArchive(Path path, byte[] code, byte[] xml) throws IOException {
+        try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(path))) {
+            addDirectory(zip, RetroRewindRelease.ROOT + "/");
+            addFile(zip, RetroRewindRelease.ROOT + "/version.txt",
+                    (VERSION + "\n").getBytes(StandardCharsets.UTF_8));
+            addDirectory(zip, RetroRewindRelease.ROOT + "/fixture/");
+            addFile(zip, RetroRewindRelease.ROOT + "/" + CODE_PATH, code);
+            addFile(zip, RetroRewindRelease.ROOT + "/" + XML_PATH, xml);
+        }
+        return path;
+    }
+
+    private static void addDirectory(ZipOutputStream zip, String name) throws IOException {
+        zip.putNextEntry(new ZipEntry(name));
+        zip.closeEntry();
+    }
+
+    private static void addFile(ZipOutputStream zip, String name, byte[] content)
+            throws IOException {
+        zip.putNextEntry(new ZipEntry(name));
+        zip.write(content);
+        zip.closeEntry();
+    }
+
+    private static boolean noTransientInstallDirectories(Context context) throws IOException {
+        Path support = RetroRewindInstallStorage.supportRoot(context.getFilesDir());
+        try (var entries = Files.list(support)) {
+            return entries.map(path -> path.getFileName().toString())
+                    .noneMatch(name -> name.startsWith("RetroRewind.import-") ||
+                            name.startsWith("RetroRewind.rollback-"));
+        }
+    }
+
+    private static String sha256(Path path) throws IOException {
+        MessageDigest digest = sha256Digest();
+        try (var input = Files.newInputStream(path)) {
+            byte[] buffer = new byte[16 * 1024];
+            int count;
+            while ((count = input.read(buffer)) != -1) {
+                digest.update(buffer, 0, count);
+            }
+        }
+        return hex(digest.digest());
+    }
+
+    private static String sha256(byte[] bytes) {
+        MessageDigest digest = sha256Digest();
+        return hex(digest.digest(bytes));
+    }
+
+    private static MessageDigest sha256Digest() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException error) {
+            throw new AssertionError("Android runtime has no SHA-256", error);
+        }
+    }
+
+    private static String hex(byte[] bytes) {
+        char[] digits = "0123456789abcdef".toCharArray();
+        char[] output = new char[bytes.length * 2];
+        for (int index = 0; index < bytes.length; index++) {
+            int value = bytes[index] & 0xff;
+            output[index * 2] = digits[value >>> 4];
+            output[index * 2 + 1] = digits[value & 0x0f];
+        }
+        return new String(output);
+    }
+
+    private static void deleteTree(Path root) throws IOException {
+        if (!Files.exists(root)) {
+            return;
+        }
+        try (var paths = Files.walk(root)) {
+            for (Path path : paths.sorted(Comparator.reverseOrder()).toList()) {
+                Files.delete(path);
+            }
+        }
+    }
+
+    private static void require(boolean condition, String message) {
+        if (!condition) {
+            throw new IllegalStateException(message);
+        }
+    }
+}

--- a/android/app/src/debug/java/dev/kartpad/android/RetroRewindWorkerFixtureActivity.kt
+++ b/android/app/src/debug/java/dev/kartpad/android/RetroRewindWorkerFixtureActivity.kt
@@ -15,6 +15,14 @@ internal class RetroRewindWorkerFixtureActivity : Activity() {
             finish()
             return
         }
+        if (intent.getBooleanExtra(EXTRA_PIPELINE, false)) {
+            if (savedInstanceState == null) {
+                Thread {
+                    RetroRewindPipelineDeviceFixture.run(applicationContext)
+                }.start()
+            }
+            return
+        }
         if (intent.getBooleanExtra(EXTRA_INIT_ONLY, false)) {
             Log.i(LOG_TAG, "A3 worker initializer activity created")
             return
@@ -137,5 +145,7 @@ internal class RetroRewindWorkerFixtureActivity : Activity() {
             "dev.kartpad.android.TEST_RETRO_REWIND_WORKER_CANCEL"
         const val EXTRA_VERSION_CHECK =
             "dev.kartpad.android.TEST_RETRO_REWIND_VERSION_CHECK"
+        const val EXTRA_PIPELINE =
+            "dev.kartpad.android.TEST_RETRO_REWIND_PIPELINE"
     }
 }

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -931,7 +931,8 @@ A debug-only bounded fixture runs the production pipeline through the APK's
 JNI extractor and real app-private filesystem on wiped 4 KiB and 16 KiB ARM64
 AVDs. Corrupt input is refused before extraction, an injected activation
 failure retains the previously validated install and cleans staging, and a
-valid replacement survives recovery with no transient directories. This is
+valid replacement survives a recreated single-rollback process-death state;
+recovery restores it and removes stale staging with no transient directories. This is
 synthetic fault evidence, not a production-size install or gameplay result.
 Do not begin the touch-UI port until A2's controller-driven Original-mode proof
 passes. Physical Android hardware remains authoritative for vendor Vulkan and

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -926,6 +926,13 @@ strict UTF-8 parsing. A valid newer release blocks installation with a KartPad-
 update message; invalid/unavailable responses fail without changing installed
 or partial data. The host JVM and wiped API 36 AVD both currently observe
 official version `6.12.5`, matching the compiled profile.
+The existing-valid-install fault now executes beyond the host matrix as well.
+A debug-only bounded fixture runs the production pipeline through the APK's
+JNI extractor and real app-private filesystem on wiped 4 KiB and 16 KiB ARM64
+AVDs. Corrupt input is refused before extraction, an injected activation
+failure retains the previously validated install and cleans staging, and a
+valid replacement survives recovery with no transient directories. This is
+synthetic fault evidence, not a production-size install or gameplay result.
 Do not begin the touch-UI port until A2's controller-driven Original-mode proof
 passes. Physical Android hardware remains authoritative for vendor Vulkan and
 controller behavior; Retro Rewind installation and touch parity follow from

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -271,7 +271,9 @@ not block offline Retro Rewind support.
    ARM64 AVDs. It rejects a corrupt archive before extraction, preserves the
    validated active install across an injected activation failure, cleans the
    failed staging tree, atomically replaces the pack on success, and
-   revalidates it after recovery with no transient state. The trigger and
+   then recreates the single-rollback/no-active-install crash window. Startup
+   recovery restores the valid pack and removes stale staging with no
+   transient state. The trigger and
    implementation are debug-only; release compilation and API-28 lint remain
    clean. This closes the emulator form of that fault, not the official
    production-size install, real full-disk behavior, gameplay/mode routing, or

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -266,6 +266,17 @@ not block offline Retro Rewind support.
    were requested. Normal startup's chooser/installed fallback remains absent.
    Evidence:
    `docs/artifacts/2026-09-04/android/a3-version-freshness.md`.
+   The real Android install pipeline now also runs an existing-valid-install
+   fault sequence with bounded synthetic content on wiped 4 KiB and 16 KiB
+   ARM64 AVDs. It rejects a corrupt archive before extraction, preserves the
+   validated active install across an injected activation failure, cleans the
+   failed staging tree, atomically replaces the pack on success, and
+   revalidates it after recovery with no transient state. The trigger and
+   implementation are debug-only; release compilation and API-28 lint remain
+   clean. This closes the emulator form of that fault, not the official
+   production-size install, real full-disk behavior, gameplay/mode routing, or
+   physical acceptance. Evidence:
+   `docs/artifacts/2026-09-04/android/a3-device-install-faults.md`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2510,3 +2510,37 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   execution, gameplay/mode switching, and physical hardware remain open. No
   artifact or private data was published. Evidence:
   `docs/artifacts/2026-09-04/android/a3-version-freshness.md`.
+
+## 2026-09-04 — Android A3 device install fault execution
+
+- Added a debug-only Android fixture that loads the APK's real JNI extraction
+  library and drives the production archive verifier, extractor, content
+  validator, same-volume activation, and startup recovery against bounded
+  synthetic packs in app-private storage.
+- The device sequence installs and validates an initial pack, rejects an
+  appended corrupt archive before extraction, and confirms the active install
+  is unchanged. A token-scoped rollback collision then injects activation
+  failure; the old valid install remains and only failed staging is removed.
+  A final valid replacement activates and remains valid after recovery with no
+  staging/rollback entries.
+- The first compile rejected two checked file-metadata calls inside the
+  non-throwing verifier lambda. Moving those values outside the lambda fixed
+  the error. Review then moved the fixture trigger out of production
+  `KartPadActivity` and into the debug-only fixture activity so the release
+  source graph and artifact remain free of the test implementation.
+- Final wiped API 36 / 4 KiB and API 35 / 16 KiB ARM64 AVD runs both observed
+  `A3 device install faults passed existing=preserved replacement=valid` and
+  all surrounding memory/fiber/controller/worker/Vulkan/lifecycle markers.
+  Both emulators shut down; no ADB target remains.
+- All eight A3 source runners, release compile, API-28 lint, debug assemble,
+  strict APK/privacy audit, SunPad snapshot, repository safety, shell, and diff
+  checks pass. Source verification validates 446 patch hunks and every other
+  pin before the unchanged ignored `rr-pulsar` checkout mismatch; it was not
+  mutated. The exact source-only APK is 33,843,921 bytes at SHA-256
+  `24690199ee0bc3a4d582338c723333a57480ba7ad6af2058f6593ce1658c6ea8`.
+- Classification: **Pass for the existing-valid-install fault and atomic
+  replacement through Android's real app-private/JNI path on both page-size
+  lanes.** The official archive, production-size/full-disk execution, normal
+  mode routing/gameplay, and physical hardware remain open. No production
+  archive, private data, APK, or AAB was downloaded or published. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-device-install-faults.md`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2521,15 +2521,18 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   appended corrupt archive before extraction, and confirms the active install
   is unchanged. A token-scoped rollback collision then injects activation
   failure; the old valid install remains and only failed staging is removed.
-  A final valid replacement activates and remains valid after recovery with no
-  staging/rollback entries.
+  A final valid replacement activates, then is moved into the exact
+  single-rollback/no-active-install crash window alongside stale staging.
+  Startup recovery restores it and removes stale staging with no transient
+  entries.
 - The first compile rejected two checked file-metadata calls inside the
   non-throwing verifier lambda. Moving those values outside the lambda fixed
   the error. Review then moved the fixture trigger out of production
   `KartPadActivity` and into the debug-only fixture activity so the release
   source graph and artifact remain free of the test implementation.
 - Final wiped API 36 / 4 KiB and API 35 / 16 KiB ARM64 AVD runs both observed
-  `A3 device install faults passed existing=preserved replacement=valid` and
+  `A3 device install faults passed existing=preserved replacement=valid
+  recovery=restored` and
   all surrounding memory/fiber/controller/worker/Vulkan/lifecycle markers.
   Both emulators shut down; no ADB target remains.
 - All eight A3 source runners, release compile, API-28 lint, debug assemble,
@@ -2537,7 +2540,7 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   checks pass. Source verification validates 446 patch hunks and every other
   pin before the unchanged ignored `rr-pulsar` checkout mismatch; it was not
   mutated. The exact source-only APK is 33,843,921 bytes at SHA-256
-  `24690199ee0bc3a4d582338c723333a57480ba7ad6af2058f6593ce1658c6ea8`.
+  `f9f9a83182b9de5ff76f6751355677c3f97c90eb6246b7bdffb87c95c7b95b65`.
 - Classification: **Pass for the existing-valid-install fault and atomic
   replacement through Android's real app-private/JNI path on both page-size
   lanes.** The official archive, production-size/full-disk execution, normal

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -413,7 +413,8 @@ app-private filesystem and JNI extraction pipeline on wiped 4 KiB and 16 KiB
 ARM64 AVDs. Bounded synthetic content proves initial activation, rejection of
 a corrupt archive before extraction, retention of the validated active pack
 after an injected activation failure, and a final atomic replacement that
-remains valid after recovery without transient staging/rollback state. The
+is moved into the interrupted single-rollback state. Startup recovery restores
+that validated pack and removes stale staging without transient state. The
 fixture is debug-only; release compile and API-28 lint remain clean. This
 strengthens A3 fault evidence but does not substitute for the official 1.86 GB
 archive, real storage exhaustion, normal mode routing/gameplay, or physical

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -408,6 +408,18 @@ archive and fault execution, gameplay/mode switching, and physical hardware.
 Evidence:
 [`docs/artifacts/2026-09-04/android/a3-version-freshness.md`](artifacts/2026-09-04/android/a3-version-freshness.md).
 
+The existing-valid-install fault now also runs through Android's real
+app-private filesystem and JNI extraction pipeline on wiped 4 KiB and 16 KiB
+ARM64 AVDs. Bounded synthetic content proves initial activation, rejection of
+a corrupt archive before extraction, retention of the validated active pack
+after an injected activation failure, and a final atomic replacement that
+remains valid after recovery without transient staging/rollback state. The
+fixture is debug-only; release compile and API-28 lint remain clean. This
+strengthens A3 fault evidence but does not substitute for the official 1.86 GB
+archive, real storage exhaustion, normal mode routing/gameplay, or physical
+hardware. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-device-install-faults.md`](artifacts/2026-09-04/android/a3-device-install-faults.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-04/android/a3-device-install-faults.md
+++ b/docs/artifacts/2026-09-04/android/a3-device-install-faults.md
@@ -1,0 +1,71 @@
+# Android A3 device install fault execution
+
+Date: 2026-09-04
+
+Branch: `codex/android-a3-device-install-faults`
+
+Baseline: `9a6c5f6877ee8560953000d8bff2b855e024e2f4`
+
+## Falsifiable subgoal
+
+Upgrade the existing-valid-install fault from a host-only Java contract to the
+real Android app-private filesystem and JNI extraction path. A bounded
+synthetic update must preserve the prior validated install when its archive is
+rejected or activation fails, then replace it atomically when every check
+passes, on both supported emulator page-size lanes.
+
+## Result
+
+- A debug-only fixture loads the APK's real `libmain.so`, creates tiny ZIPs in
+  app cache, and calls the production Java/JNI install pipeline. It does not
+  weaken or replace the production release contract.
+- The fixture installs and revalidates an initial synthetic pack, appends a
+  corrupt byte and proves rejection before extraction, and revalidates the
+  untouched active pack.
+- A pre-existing token-scoped rollback destination injects an activation
+  failure after extraction/validation. The pipeline reports
+  `ACTIVATION_FAILURE`, deletes only its staging tree, and retains the prior
+  valid install.
+- A final validated replacement uses the real same-volume atomic swap. It
+  remains valid after startup recovery, with no staging or rollback directory
+  left behind.
+- All fixture implementation and triggers live in the debug source set. The
+  release Kotlin/Java graph compiles and API-28 lint passes without the device
+  fixture class.
+
+## Verification
+
+- `scripts/run-android-fixture.sh KartPad_API_36_ARM64`: pass on a wiped API 36
+  ARM64 AVD with 4 KiB pages.
+- `scripts/run-android-fixture.sh KartPad_API_35_PS16K_ARM64`: pass on a wiped
+  API 35 ARM64 AVD with 16 KiB pages.
+- Both final runs observed
+  `A3 device install faults passed existing=preserved replacement=valid`, then
+  passed the existing 4 GiB guest-memory, scheduler/fiber, SDL controller,
+  resumable-transfer, unique-worker, Vulkan present, orientation, and three
+  background/foreground recreation checks.
+- All eight Android A3 source contract runners pass: version, download,
+  extraction, pipeline, worker policy, space, content, and storage.
+- Source-only release Kotlin/Java compile, API-28 release lint, debug assemble,
+  strict APK/privacy audit, SunPad snapshot, repository safety, shell syntax,
+  shell lint, and diff checks pass.
+- Source verification validates all 446 patch hunks and the WiiCompiled,
+  SunPad, and WheelWizard pins, then reaches the unchanged ignored
+  `ref/upstream/rr-pulsar` mismatch: local `b566a5d...` versus pinned
+  `29e76d4...`. This checkpoint does not mutate that user/private checkout.
+- The exact source-only debug APK is 33,843,921 bytes at SHA-256
+  `24690199ee0bc3a4d582338c723333a57480ba7ad6af2058f6593ce1658c6ea8`.
+- Both emulators were shut down and `adb devices` is empty.
+
+The first compile correctly rejected checked `IOException` calls inside a
+non-throwing verifier lambda. Capturing the expected size and digest before
+the lambda fixed that source error; the fixture behavior did not change.
+
+## Classification
+
+**Pass for existing-valid-install preservation and atomic replacement through
+Android's real app-private filesystem, JNI extractor, validation, activation,
+and recovery paths on 4 KiB and 16 KiB emulator lanes.** This does not prove
+the 1.86 GB official archive, real storage exhaustion, normal mode routing,
+Retro Rewind gameplay, or physical hardware. No production archive, private
+data, device identifier, APK, or AAB was downloaded or published.

--- a/docs/artifacts/2026-09-04/android/a3-device-install-faults.md
+++ b/docs/artifacts/2026-09-04/android/a3-device-install-faults.md
@@ -27,8 +27,9 @@ passes, on both supported emulator page-size lanes.
   `ACTIVATION_FAILURE`, deletes only its staging tree, and retains the prior
   valid install.
 - A final validated replacement uses the real same-volume atomic swap. It
-  remains valid after startup recovery, with no staging or rollback directory
-  left behind.
+  is then moved into the precise single-rollback/no-active-install crash state
+  alongside stale staging. Startup recovery restores that validated pack and
+  deletes the stale staging, with no transient directory left behind.
 - All fixture implementation and triggers live in the debug source set. The
   release Kotlin/Java graph compiles and API-28 lint passes without the device
   fixture class.
@@ -40,7 +41,8 @@ passes, on both supported emulator page-size lanes.
 - `scripts/run-android-fixture.sh KartPad_API_35_PS16K_ARM64`: pass on a wiped
   API 35 ARM64 AVD with 16 KiB pages.
 - Both final runs observed
-  `A3 device install faults passed existing=preserved replacement=valid`, then
+  `A3 device install faults passed existing=preserved replacement=valid
+  recovery=restored`, then
   passed the existing 4 GiB guest-memory, scheduler/fiber, SDL controller,
   resumable-transfer, unique-worker, Vulkan present, orientation, and three
   background/foreground recreation checks.
@@ -54,7 +56,7 @@ passes, on both supported emulator page-size lanes.
   `ref/upstream/rr-pulsar` mismatch: local `b566a5d...` versus pinned
   `29e76d4...`. This checkpoint does not mutate that user/private checkout.
 - The exact source-only debug APK is 33,843,921 bytes at SHA-256
-  `24690199ee0bc3a4d582338c723333a57480ba7ad6af2058f6593ce1658c6ea8`.
+  `f9f9a83182b9de5ff76f6751355677c3f97c90eb6246b7bdffb87c95c7b95b65`.
 - Both emulators were shut down and `adb devices` is empty.
 
 The first compile correctly rejected checked `IOException` calls inside a
@@ -63,9 +65,10 @@ the lambda fixed that source error; the fixture behavior did not change.
 
 ## Classification
 
-**Pass for existing-valid-install preservation and atomic replacement through
-Android's real app-private filesystem, JNI extractor, validation, activation,
-and recovery paths on 4 KiB and 16 KiB emulator lanes.** This does not prove
+**Pass for existing-valid-install preservation, atomic replacement, and the
+single-rollback process-death recovery state through Android's real app-private
+filesystem, JNI extractor, validation, and activation paths on 4 KiB and 16
+KiB emulator lanes.** This does not prove
 the 1.86 GB official archive, real storage exhaustion, normal mode routing,
 Retro Rewind gameplay, or physical hardware. No production archive, private
 data, device identifier, APK, or AAB was downloaded or published.

--- a/scripts/run-android-fixture.sh
+++ b/scripts/run-android-fixture.sh
@@ -65,9 +65,6 @@ apk="$repo_root/android/app/build/outputs/apk/debug/app-debug.apk"
 "$adb" install -r "$apk" >/dev/null
 "$adb" logcat -c
 "$adb" shell am force-stop dev.kartpad.android
-"$adb" shell am start -W -n dev.kartpad.android/.KartPadActivity \
-  --ez dev.kartpad.android.TEST_RETRO_REWIND_EXTRACTION true \
-  --ez dev.kartpad.android.TEST_RETRO_REWIND_WORKER true >/dev/null
 wait_for_marker() {
   local marker="$1"
   for _ in {1..60}; do
@@ -81,6 +78,16 @@ wait_for_marker() {
   "$adb" logcat -d -v brief KartPadFixture:V SDL:V AndroidRuntime:E libc:F '*:S' >&2
   return 1
 }
+
+"$adb" shell am start -W \
+  -n dev.kartpad.android/.RetroRewindWorkerFixtureActivity \
+  --ez dev.kartpad.android.TEST_RETRO_REWIND_PIPELINE true >/dev/null
+wait_for_marker "A3 device install faults passed existing=preserved replacement=valid"
+"$adb" shell am force-stop dev.kartpad.android
+
+"$adb" shell am start -W -n dev.kartpad.android/.KartPadActivity \
+  --ez dev.kartpad.android.TEST_RETRO_REWIND_EXTRACTION true \
+  --ez dev.kartpad.android.TEST_RETRO_REWIND_WORKER true >/dev/null
 
 wait_for_marker \
   "A1 guest memory passed reserve_bytes=4294967296"

--- a/scripts/run-android-fixture.sh
+++ b/scripts/run-android-fixture.sh
@@ -82,7 +82,8 @@ wait_for_marker() {
 "$adb" shell am start -W \
   -n dev.kartpad.android/.RetroRewindWorkerFixtureActivity \
   --ez dev.kartpad.android.TEST_RETRO_REWIND_PIPELINE true >/dev/null
-wait_for_marker "A3 device install faults passed existing=preserved replacement=valid"
+wait_for_marker \
+  "A3 device install faults passed existing=preserved replacement=valid recovery=restored"
 "$adb" shell am force-stop dev.kartpad.android
 
 "$adb" shell am start -W -n dev.kartpad.android/.KartPadActivity \


### PR DESCRIPTION
## Summary
- add a debug-only device fixture that drives the production Android archive verifier, JNI extractor, content validator, atomic activation, and recovery against bounded synthetic packs
- prove corrupt input is refused before extraction and a forced activation failure retains the existing validated install while cleaning staging
- prove a valid replacement activates, then recreate the single-rollback/no-active-install crash window and require startup recovery to restore it and remove stale staging

## Verification
- `scripts/run-android-fixture.sh KartPad_API_36_ARM64` (wiped API 36 / 4 KiB)
- `scripts/run-android-fixture.sh KartPad_API_35_PS16K_ARM64` (wiped API 35 / 16 KiB)
- all eight Android A3 source contract runners
- source-only release Kotlin/Java compile and API-28 lint
- source-only debug assemble and strict APK/privacy audit
- SunPad snapshot, repository safety, shell syntax/lint, and diff checks
- source-only APK: `f9f9a83182b9de5ff76f6751355677c3f97c90eb6246b7bdffb87c95c7b95b65`

## Limits
- uses tiny synthetic content; it does not download or validate the 1.86 GB official archive
- does not prove real storage exhaustion, normal mode routing, Retro Rewind gameplay, or physical hardware
- source verification still stops at the documented pre-existing ignored `ref/upstream/rr-pulsar` checkout mismatch after validating all 446 patch hunks and other pins
