### PR TITLE
Test Android low-space preflight on-device

### DIFF
--- a/android/app/src/debug/java/dev/kartpad/android/RetroRewindWorkerFixtureActivity.kt
+++ b/android/app/src/debug/java/dev/kartpad/android/RetroRewindWorkerFixtureActivity.kt
@@ -23,6 +23,22 @@ internal class RetroRewindWorkerFixtureActivity : Activity() {
             }
             return
         }
+        if (intent.getBooleanExtra(EXTRA_SPACE_PROBE, false)) {
+            if (savedInstanceState == null) {
+                Thread {
+                    val result = RetroRewindSpaceProbe.check(filesDir, cacheDir)
+                    Log.i(
+                        LOG_TAG,
+                        "A3 Android space probe error=${result.error} " +
+                            "required_files=${result.requiredFilesBytes} " +
+                            "available_files=${result.availableFilesBytes} " +
+                            "required_cache=${result.requiredCacheBytes} " +
+                            "available_cache=${result.availableCacheBytes}",
+                    )
+                }.start()
+            }
+            return
+        }
         if (intent.getBooleanExtra(EXTRA_INIT_ONLY, false)) {
             Log.i(LOG_TAG, "A3 worker initializer activity created")
             return
@@ -147,5 +163,7 @@ internal class RetroRewindWorkerFixtureActivity : Activity() {
             "dev.kartpad.android.TEST_RETRO_REWIND_VERSION_CHECK"
         const val EXTRA_PIPELINE =
             "dev.kartpad.android.TEST_RETRO_REWIND_PIPELINE"
+        const val EXTRA_SPACE_PROBE =
+            "dev.kartpad.android.TEST_RETRO_REWIND_SPACE_PROBE"
     }
 }

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -934,6 +934,12 @@ failure retains the previously validated install and cleans staging, and a
 valid replacement survives a recreated single-rollback process-death state;
 recovery restores it and removes stale staging with no transient directories. This is
 synthetic fault evidence, not a production-size install or gameplay result.
+The production same-store capacity probe now also rejects a real controlled
+deficit on a wiped API 36 ARM64 AVD. With 4,186,030,080 bytes available against
+the profile-derived 4,327,477,355-byte requirement, it reports
+`INSUFFICIENT_SHARED_STORE` and creates no archive state. The bounded filler is
+removed during cleanup. Mid-transfer/mid-extraction `ENOSPC` remains distinct
+and unproven.
 Do not begin the touch-UI port until A2's controller-driven Original-mode proof
 passes. Physical Android hardware remains authoritative for vendor Vulkan and
 controller behavior; Retro Rewind installation and touch parity follow from

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -279,6 +279,15 @@ not block offline Retro Rewind support.
    production-size install, real full-disk behavior, gameplay/mode routing, or
    physical acceptance. Evidence:
    `docs/artifacts/2026-09-04/android/a3-device-install-faults.md`.
+   The production Android space probe now has a real controlled low-capacity
+   execution on a wiped API 36 ARM64 AVD. A safety-capped 1,121 MiB filler
+   reduced the shared app store to 4,186,030,080 available bytes, below the
+   profile-derived 4,327,477,355-byte requirement. The probe returned
+   `INSUFFICIENT_SHARED_STORE`, no archive cache state appeared, the filler was
+   removed, and the emulator stopped. This proves preflight refusal before
+   acquisition, not mid-transfer/mid-extraction `ENOSPC` or a production-size
+   install. Evidence:
+   `docs/artifacts/2026-09-04/android/a3-device-low-space.md`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2547,3 +2547,32 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   mode routing/gameplay, and physical hardware remain open. No production
   archive, private data, APK, or AAB was downloaded or published. Evidence:
   `docs/artifacts/2026-09-04/android/a3-device-install-faults.md`.
+
+## 2026-09-04 — Android A3 real low-space preflight
+
+- Added a debug-only route to run the production `RetroRewindSpaceProbe`
+  against real Android `filesDir`/`cacheDir`, plus a wiped-AVD harness whose
+  byte requirement comes from the sole Retro Rewind profile.
+- The harness refuses an existing device, caps guest filling at 2 GiB, requires
+  8 GiB of host reserve, and deletes only its explicit disposable filler. The
+  first ShellCheck pass rejected an ambiguous compound assertion; an explicit
+  conditional fixed it before any low-space run began.
+- A wiped API 36 / 4 KiB ARM64 AVD used a controlled 1,121 MiB filler. The
+  production probe observed 4,186,030,080 bytes available against the exact
+  4,327,477,355-byte same-store requirement and returned
+  `INSUFFICIENT_SHARED_STORE`. The harness confirmed zero archive bytes/cache
+  state, deleted the filler, and stopped the emulator.
+- Android's image has no usable `fstrim`; the dedicated sparse AVD image keeps
+  allocated blocks for reuse. Host free space remains 44 GiB. Debug assemble,
+  strict APK/privacy audit, eight A3 source runners, release compile/API-28
+  lint, SunPad snapshot, repository safety, shell lint/syntax, and diff checks
+  pass. Source verification validates 446 hunks and every other pin before the
+  unchanged ignored `rr-pulsar` mismatch; it was not mutated. The exact
+  source-only APK is 33,843,921 bytes at SHA-256
+  `dda33041fd82e4db874562313dad5bdd583d9d164199d87dad55acc287779e7d`.
+- Classification: **Pass for real Android same-store preflight refusal under a
+  controlled byte deficit before archive acquisition.** Mid-transfer or
+  mid-extraction `ENOSPC`, the official production-size install, gameplay, and
+  physical hardware remain open. No production archive, private data, APK, or
+  AAB was downloaded or published. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-device-low-space.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -421,6 +421,15 @@ archive, real storage exhaustion, normal mode routing/gameplay, or physical
 hardware. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-device-install-faults.md`](artifacts/2026-09-04/android/a3-device-install-faults.md).
 
+Android's production same-store space probe now also has a real low-capacity
+execution on a wiped API 36 ARM64 AVD. A guarded 1,121 MiB disposable filler
+reduced available app storage to 4,186,030,080 bytes; the probe rejected that
+against the exact profile-derived 4,327,477,355-byte requirement and the
+harness confirmed zero archive cache state. The filler was removed and the
+emulator stopped. This closes the on-device preflight deficit case, not
+mid-transfer/mid-extraction `ENOSPC` or the production-size install. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-device-low-space.md`](artifacts/2026-09-04/android/a3-device-low-space.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-04/android/a3-device-low-space.md
+++ b/docs/artifacts/2026-09-04/android/a3-device-low-space.md
@@ -1,0 +1,64 @@
+# Android A3 real low-space preflight
+
+Date: 2026-09-04
+
+Branch: `codex/android-a3-device-low-space`
+
+Baseline: `f58bd90529eb35dd3bd2a69f497c468bfc506d95`
+
+## Falsifiable subgoal
+
+Exercise KartPad's production Retro Rewind space probe against a genuinely
+low-space Android app store before any archive acquisition. The requirement
+must be derived from the sole profile, the disposable fill must be bounded by
+host and guest safety guards, and the probe must report a real byte deficit
+while leaving no archive state.
+
+## Result
+
+- Added a debug-only activity route that invokes the production
+  `RetroRewindSpaceProbe` against the app's real `filesDir` and `cacheDir` and
+  logs only bounded capacity/result values.
+- Added a wiped-AVD harness that derives the current same-store requirement
+  from `mkwii-rmcp01-rev0.json`, caps its filler at 2 GiB, refuses to proceed
+  without 8 GiB of host reserve, and removes one explicit guest filler during
+  cleanup.
+- The API 36 ARM64 AVD began above the required threshold. A controlled 1,121
+  MiB filler reduced available `/data` capacity to 4,186,030,080 bytes.
+- The real production probe reported `INSUFFICIENT_SHARED_STORE` against the
+  exact profile-derived 4,327,477,355-byte requirement. The harness verified
+  `available < required` and found no `.zip` or `.part` acquisition state in
+  app cache.
+- The filler was deleted and the emulator shut down. The Android image does
+  not expose a usable `fstrim` command, so its dedicated sparse host image
+  retains allocated blocks for reuse; the host still has 44 GiB available.
+
+## Verification
+
+- `scripts/test-android-retro-rewind-low-space.sh`: pass.
+- Final marker:
+  `Android Retro Rewind low-space preflight passed: avd=KartPad_API_36_ARM64
+  api=36 abi=arm64-v8a page_size=4096 required=4327477355
+  available=4186030080 filler_mib=1121 archive_bytes=0`.
+- Debug assemble and strict APK/privacy audit pass. The exact source-only APK
+  is 33,843,921 bytes at SHA-256
+  `dda33041fd82e4db874562313dad5bdd583d9d164199d87dad55acc287779e7d`.
+- Shell syntax, ShellCheck with repository source resolution, and diff checks
+  pass. No ADB target remains after cleanup.
+- All eight A3 source contract runners, release Kotlin/Java compilation,
+  API-28 lint, SunPad snapshot, and repository safety pass. Source verification
+  validates 446 patch hunks and the WiiCompiled, SunPad, and WheelWizard pins,
+  then stops at the unchanged ignored `rr-pulsar` mismatch (local
+  `b566a5d...`, pinned `29e76d4...`); this work does not mutate that checkout.
+
+The first ShellCheck pass rejected an ambiguous `A && B || fail` assertion.
+The final harness uses an explicit conditional; no low-space run had begun
+before that correction.
+
+## Classification
+
+**Pass for the production Android same-store preflight under a real controlled
+byte deficit before archive acquisition.** This is not mid-download or
+mid-extraction `ENOSPC`, does not execute the 1.86 GB official archive, and
+does not satisfy gameplay or physical-hardware A3 rows. No production archive,
+private data, device identifier, APK, or AAB was downloaded or published.

--- a/scripts/test-android-retro-rewind-low-space.sh
+++ b/scripts/test-android-retro-rewind-low-space.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+# shellcheck source=android-toolchain-versions.sh
+source "$repo_root/scripts/android-toolchain-versions.sh"
+sdk_root="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/Library/Android/sdk}}"
+adb="$sdk_root/platform-tools/adb"
+emulator="$sdk_root/emulator/emulator"
+avd="$KARTPAD_ANDROID_PHONE_AVD"
+package="dev.kartpad.android"
+filler="/data/local/tmp/kartpad-low-space.fill"
+
+if "$adb" devices | sed -n '2,$p' | grep -q '[[:space:]]device$'; then
+  echo "ERROR: an Android device/emulator is already connected; preserve the one-emulator rule" >&2
+  exit 1
+fi
+
+"$repo_root/scripts/build-android-fixture.sh"
+"$repo_root/scripts/audit-android-package.sh"
+emulator_log="$repo_root/.android-bootstrap/emulator-$avd-low-space.raw.log"
+"$emulator" "@$avd" -no-window -no-audio -no-boot-anim -no-snapshot \
+  -gpu auto -wipe-data >"$emulator_log" 2>&1 &
+emulator_pid=$!
+cleanup() {
+  "$adb" shell rm -f "$filler" >/dev/null 2>&1 || true
+  "$adb" emu kill >/dev/null 2>&1 || true
+  wait "$emulator_pid" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+"$adb" wait-for-device
+booted=0
+for _ in {1..60}; do
+  if [[ "$("$adb" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" == "1" ]]; then
+    booted=1
+    break
+  fi
+  sleep 2
+done
+[[ "$booted" == 1 ]] || { echo "ERROR: emulator did not finish booting" >&2; exit 1; }
+
+abi="$("$adb" shell getprop ro.product.cpu.abi | tr -d '\r')"
+page_size="$("$adb" shell getconf PAGE_SIZE | tr -d '\r')"
+[[ "$abi" == "arm64-v8a" ]] || { echo "ERROR: unexpected device ABI: $abi" >&2; exit 1; }
+[[ "$page_size" == "4096" ]] || { echo "ERROR: unexpected page size: $page_size" >&2; exit 1; }
+
+apk="$repo_root/android/app/build/outputs/apk/debug/app-debug.apk"
+"$adb" install -r "$apk" >/dev/null
+
+required_bytes="$(python3 - "$repo_root/builder/profiles/mkwii-rmcp01-rev0.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as stream:
+    retro = json.load(stream)["retroRewind"]
+print(retro["archive"]["bytes"] + retro["archive"]["maximumExpandedBytes"] + 256 * 1024 * 1024)
+PY
+)"
+available_kib="$("$adb" shell df -k /data | awk 'NR == 2 {print $4}' | tr -d '\r')"
+[[ "$available_kib" =~ ^[0-9]+$ ]] || {
+  echo "ERROR: could not read disposable AVD free space" >&2
+  exit 1
+}
+available_bytes=$((available_kib * 1024))
+target_bytes=$((required_bytes - 128 * 1024 * 1024))
+fill_bytes=$((available_bytes - target_bytes))
+if (( fill_bytes <= 0 )); then
+  echo "ERROR: wiped AVD is already below the controlled low-space target" >&2
+  exit 1
+fi
+maximum_fill_bytes=$((2 * 1024 * 1024 * 1024))
+if (( fill_bytes > maximum_fill_bytes )); then
+  echo "ERROR: controlled filler would exceed the 2 GiB safety cap" >&2
+  exit 1
+fi
+host_available_kib="$(df -Pk "$repo_root" | awk 'NR == 2 {print $4}')"
+host_reserve_bytes=$((8 * 1024 * 1024 * 1024))
+if (( host_available_kib * 1024 < fill_bytes + host_reserve_bytes )); then
+  echo "ERROR: host lacks the required 8 GiB reserve for the disposable filler" >&2
+  exit 1
+fi
+
+fill_mib=$(((fill_bytes + 1024 * 1024 - 1) / (1024 * 1024)))
+"$adb" shell dd if=/dev/zero of="$filler" bs=1048576 count="$fill_mib" \
+  >/dev/null 2>&1
+
+"$adb" logcat -c
+"$adb" shell am start -W \
+  -n "$package/.RetroRewindWorkerFixtureActivity" \
+  --ez dev.kartpad.android.TEST_RETRO_REWIND_SPACE_PROBE true >/dev/null
+
+marker=""
+for _ in {1..30}; do
+  marker="$("$adb" logcat -d -v raw KartPadFixture:I AndroidRuntime:E '*:S' |
+    grep -F 'A3 Android space probe error=' | tail -1 || true)"
+  [[ -n "$marker" ]] && break
+  sleep 1
+done
+[[ "$marker" == *"error=INSUFFICIENT_SHARED_STORE"* ]] || {
+  echo "ERROR: production space probe did not reject the controlled low-space store" >&2
+  printf '%s\n' "$marker" >&2
+  exit 1
+}
+
+reported_required="$(printf '%s\n' "$marker" |
+  sed -n 's/.*required_files=\([0-9][0-9]*\).*/\1/p')"
+reported_available="$(printf '%s\n' "$marker" |
+  sed -n 's/.*available_files=\([0-9][0-9]*\).*/\1/p')"
+[[ "$reported_required" == "$required_bytes" ]] || {
+  echo "ERROR: Android requirement $reported_required != profile requirement $required_bytes" >&2
+  exit 1
+}
+if [[ ! "$reported_available" =~ ^[0-9]+$ ]] ||
+    (( reported_available >= reported_required )); then
+  echo "ERROR: Android low-space result did not report a real deficit" >&2
+  exit 1
+fi
+
+if "$adb" shell run-as "$package" ls cache 2>/dev/null |
+    grep -Eq 'RetroRewind.*\.(zip|part)$'; then
+  echo "ERROR: low-space probe unexpectedly left archive acquisition state" >&2
+  exit 1
+fi
+
+echo "Android Retro Rewind low-space preflight passed: avd=$avd api=36 abi=$abi page_size=$page_size required=$reported_required available=$reported_available filler_mib=$fill_mib archive_bytes=0"


### PR DESCRIPTION
## Summary
- add a debug-only route that runs the production Retro Rewind space probe against real Android `filesDir`/`cacheDir`
- add a guarded wiped-AVD harness that derives the exact requirement from the sole profile, caps guest filling at 2 GiB, and retains 8 GiB of host reserve
- prove a genuine shared-store deficit is rejected before acquisition and leaves no archive cache state

## Verification
- `scripts/test-android-retro-rewind-low-space.sh`
  - API 36 / ARM64 / 4 KiB
  - required: `4327477355`
  - available: `4186030080`
  - controlled filler: `1121 MiB`
  - result: `INSUFFICIENT_SHARED_STORE`
  - archive bytes/state: `0`
- all eight Android A3 source contract runners
- source-only release Kotlin/Java compile and API-28 lint
- source-only debug assemble and strict APK/privacy audit
- SunPad snapshot, repository safety, shell syntax/lint, and diff checks
- source-only APK: `dda33041fd82e4db874562313dad5bdd583d9d164199d87dad55acc287779e7d`

## Limits
- proves real low-space preflight refusal, not mid-download or mid-extraction `ENOSPC`
- does not download the official 1.86 GB archive or prove gameplay/physical hardware
- the guest filler is deleted; the dedicated AVD sparse image retains allocated blocks for reuse because that image exposes no usable `fstrim`; host free space remains 44 GiB
- source verification still stops at the documented pre-existing ignored `ref/upstream/rr-pulsar` mismatch after all 446 hunks and other pins pass
