### PR TITLE
Test Android extraction storage exhaustion

### DIFF
--- a/android/app/src/debug/java/dev/kartpad/android/RetroRewindEnospcDeviceFixture.java
+++ b/android/app/src/debug/java/dev/kartpad/android/RetroRewindEnospcDeviceFixture.java
@@ -1,0 +1,205 @@
+package dev.kartpad.android;
+
+import android.content.Context;
+import android.util.Log;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+/** Drives the real extraction pipeline against a bounded ENOSPC filesystem. */
+final class RetroRewindEnospcDeviceFixture {
+    private static final String TAG = "KartPadFixture";
+    private static final String ARCHIVE_NAME = "RetroRewindEnospcFixture.zip";
+    private static final String CURRENT_PATH = "fixture/current.bin";
+    private static final byte[] CURRENT_CONTENT =
+            "preserve-this-install".getBytes(StandardCharsets.UTF_8);
+
+    private RetroRewindEnospcDeviceFixture() {}
+
+    static void prepare(Context context) {
+        try {
+            System.loadLibrary("main");
+            Path archive = context.getCacheDir().toPath().resolve("current-fixture.zip");
+            try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(archive))) {
+                addDirectory(zip, RetroRewindRelease.ROOT + "/");
+                addFile(zip, RetroRewindRelease.ROOT + "/version.txt",
+                        (RetroRewindRelease.VERSION + "\n").getBytes(StandardCharsets.UTF_8));
+                addDirectory(zip, RetroRewindRelease.ROOT + "/fixture/");
+                addFile(zip, RetroRewindRelease.ROOT + "/" + CURRENT_PATH, CURRENT_CONTENT);
+            }
+            RetroRewindInstallValidator.Contract contract = currentContract();
+            RetroRewindInstallPipeline.Result result = install(
+                    context, archive, "enospc-current", contract, new AtomicLong());
+            require(result.isInstalled(), "existing install setup failed: " + result.error);
+            require(validateInstalled(context, contract).isValid(),
+                    "existing install setup did not validate");
+            Files.deleteIfExists(archive);
+            Log.i(TAG, "A3 ENOSPC fixture prepared existing=valid");
+        } catch (Exception error) {
+            Log.e(TAG, "A3 ENOSPC fixture preparation failed", error);
+        }
+    }
+
+    static void run(
+            Context context,
+            long archiveBytes,
+            String archiveSha256,
+            long payloadBytes,
+            String payloadSha256) {
+        try {
+            System.loadLibrary("main");
+            require(archiveBytes > 0 && payloadBytes > 0,
+                    "ENOSPC fixture sizes are invalid");
+            require(isLowercaseSha256(archiveSha256) && isLowercaseSha256(payloadSha256),
+                    "ENOSPC fixture digest is invalid");
+            RetroRewindInstallValidator.Contract current = currentContract();
+            require(validateInstalled(context, current).isValid(),
+                    "existing install was not valid before ENOSPC extraction");
+
+            Path archive = context.getCacheDir().toPath().resolve(ARCHIVE_NAME);
+            require(Files.size(archive) == archiveBytes, "ENOSPC archive size changed");
+            RetroRewindInstallValidator.Contract replacement =
+                    new RetroRewindInstallValidator.Contract(
+                            RetroRewindRelease.VERSION,
+                            RetroRewindRelease.ROOT,
+                            Collections.singletonList(
+                                    new RetroRewindInstallValidator.ArtifactRequirement(
+                                            "fixture/large.bin", payloadBytes, payloadSha256)));
+            AtomicLong extractedBytes = new AtomicLong();
+            RetroRewindInstallPipeline.Result result = RetroRewindInstallPipeline.install(
+                    context.getFilesDir(),
+                    archive,
+                    "enospc-replacement",
+                    () -> false,
+                    (completed, total) -> extractedBytes.set(completed),
+                    path -> RetroRewindArchiveDownload.verifyFile(
+                            path, archiveBytes, archiveSha256),
+                    RetroRewindArchiveExtractor::extract,
+                    replacement);
+            require(result.error == RetroRewindInstallPipeline.Error.EXTRACTION_FAILURE,
+                    "ENOSPC did not fail extraction: " + result.error);
+            require(result.extractionError == RetroRewindArchiveExtractor.Error.IO_FAILURE,
+                    "ENOSPC did not report native IO failure: " + result.extractionError);
+            require(extractedBytes.get() > 0 && extractedBytes.get() < payloadBytes,
+                    "ENOSPC did not interrupt an active extraction");
+            require(validateInstalled(context, current).isValid(),
+                    "ENOSPC changed the existing valid install");
+            require(!Files.exists(RetroRewindInstallStorage.supportRoot(context.getFilesDir())
+                            .resolve("RetroRewind.import-enospc-replacement")),
+                    "ENOSPC left staging behind");
+            Log.i(TAG, "A3 ENOSPC extraction passed existing=preserved " +
+                    "error=IO_FAILURE extracted=" + extractedBytes.get() +
+                    " selected=" + payloadBytes);
+        } catch (Exception error) {
+            Log.e(TAG, "A3 ENOSPC extraction failed", error);
+        }
+    }
+
+    static String archiveName() {
+        return ARCHIVE_NAME;
+    }
+
+    private static RetroRewindInstallPipeline.Result install(
+            Context context,
+            Path archive,
+            String token,
+            RetroRewindInstallValidator.Contract contract,
+            AtomicLong extractedBytes) throws IOException {
+        long archiveBytes = Files.size(archive);
+        String archiveSha256 = sha256(archive);
+        return RetroRewindInstallPipeline.install(
+                context.getFilesDir(),
+                archive,
+                token,
+                () -> false,
+                (completed, total) -> extractedBytes.set(completed),
+                path -> RetroRewindArchiveDownload.verifyFile(
+                        path, archiveBytes, archiveSha256),
+                RetroRewindArchiveExtractor::extract,
+                contract);
+    }
+
+    private static RetroRewindInstallValidator.Contract currentContract() {
+        return new RetroRewindInstallValidator.Contract(
+                RetroRewindRelease.VERSION,
+                RetroRewindRelease.ROOT,
+                Collections.singletonList(
+                        new RetroRewindInstallValidator.ArtifactRequirement(
+                                CURRENT_PATH,
+                                CURRENT_CONTENT.length,
+                                sha256(CURRENT_CONTENT))));
+    }
+
+    private static RetroRewindInstallValidator.Result validateInstalled(
+            Context context, RetroRewindInstallValidator.Contract contract) {
+        return RetroRewindInstallValidator.validate(
+                RetroRewindInstallStorage.installedRoot(context.getFilesDir())
+                        .resolve(RetroRewindRelease.ROOT),
+                contract);
+    }
+
+    private static void addDirectory(ZipOutputStream zip, String name) throws IOException {
+        zip.putNextEntry(new ZipEntry(name));
+        zip.closeEntry();
+    }
+
+    private static void addFile(ZipOutputStream zip, String name, byte[] content)
+            throws IOException {
+        zip.putNextEntry(new ZipEntry(name));
+        zip.write(content);
+        zip.closeEntry();
+    }
+
+    private static String sha256(Path path) throws IOException {
+        MessageDigest digest = sha256Digest();
+        try (var input = Files.newInputStream(path)) {
+            byte[] buffer = new byte[16 * 1024];
+            int count;
+            while ((count = input.read(buffer)) != -1) {
+                digest.update(buffer, 0, count);
+            }
+        }
+        return hex(digest.digest());
+    }
+
+    private static String sha256(byte[] bytes) {
+        return hex(sha256Digest().digest(bytes));
+    }
+
+    private static MessageDigest sha256Digest() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException error) {
+            throw new AssertionError("Android runtime has no SHA-256", error);
+        }
+    }
+
+    private static boolean isLowercaseSha256(String value) {
+        return value != null && value.matches("[0-9a-f]{64}");
+    }
+
+    private static String hex(byte[] bytes) {
+        char[] digits = "0123456789abcdef".toCharArray();
+        char[] output = new char[bytes.length * 2];
+        for (int index = 0; index < bytes.length; index++) {
+            int value = bytes[index] & 0xff;
+            output[index * 2] = digits[value >>> 4];
+            output[index * 2 + 1] = digits[value & 0x0f];
+        }
+        return new String(output);
+    }
+
+    private static void require(boolean condition, String message) {
+        if (!condition) {
+            throw new IllegalStateException(message);
+        }
+    }
+}

--- a/android/app/src/debug/java/dev/kartpad/android/RetroRewindWorkerFixtureActivity.kt
+++ b/android/app/src/debug/java/dev/kartpad/android/RetroRewindWorkerFixtureActivity.kt
@@ -39,6 +39,32 @@ internal class RetroRewindWorkerFixtureActivity : Activity() {
             }
             return
         }
+        if (intent.getBooleanExtra(EXTRA_ENOSPC_PREPARE, false)) {
+            if (savedInstanceState == null) {
+                Thread {
+                    RetroRewindEnospcDeviceFixture.prepare(applicationContext)
+                }.start()
+            }
+            return
+        }
+        if (intent.getBooleanExtra(EXTRA_ENOSPC_RUN, false)) {
+            if (savedInstanceState == null) {
+                val archiveBytes = intent.getLongExtra(EXTRA_ARCHIVE_BYTES, -1)
+                val archiveSha256 = intent.getStringExtra(EXTRA_ARCHIVE_SHA256)
+                val payloadBytes = intent.getLongExtra(EXTRA_PAYLOAD_BYTES, -1)
+                val payloadSha256 = intent.getStringExtra(EXTRA_PAYLOAD_SHA256)
+                Thread {
+                    RetroRewindEnospcDeviceFixture.run(
+                        applicationContext,
+                        archiveBytes,
+                        archiveSha256,
+                        payloadBytes,
+                        payloadSha256,
+                    )
+                }.start()
+            }
+            return
+        }
         if (intent.getBooleanExtra(EXTRA_INIT_ONLY, false)) {
             Log.i(LOG_TAG, "A3 worker initializer activity created")
             return
@@ -165,5 +191,17 @@ internal class RetroRewindWorkerFixtureActivity : Activity() {
             "dev.kartpad.android.TEST_RETRO_REWIND_PIPELINE"
         const val EXTRA_SPACE_PROBE =
             "dev.kartpad.android.TEST_RETRO_REWIND_SPACE_PROBE"
+        const val EXTRA_ENOSPC_PREPARE =
+            "dev.kartpad.android.TEST_RETRO_REWIND_ENOSPC_PREPARE"
+        const val EXTRA_ENOSPC_RUN =
+            "dev.kartpad.android.TEST_RETRO_REWIND_ENOSPC_RUN"
+        const val EXTRA_ARCHIVE_BYTES =
+            "dev.kartpad.android.TEST_RETRO_REWIND_ARCHIVE_BYTES"
+        const val EXTRA_ARCHIVE_SHA256 =
+            "dev.kartpad.android.TEST_RETRO_REWIND_ARCHIVE_SHA256"
+        const val EXTRA_PAYLOAD_BYTES =
+            "dev.kartpad.android.TEST_RETRO_REWIND_PAYLOAD_BYTES"
+        const val EXTRA_PAYLOAD_SHA256 =
+            "dev.kartpad.android.TEST_RETRO_REWIND_PAYLOAD_SHA256"
     }
 }

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -940,6 +940,13 @@ the profile-derived 4,327,477,355-byte requirement, it reports
 `INSUFFICIENT_SHARED_STORE` and creates no archive state. The bounded filler is
 removed during cleanup. Mid-transfer/mid-extraction `ENOSPC` remains distinct
 and unproven.
+The after-preflight storage-exhaustion path now has real Android execution as
+well. On a temporary API 36 AVD, a 512 MiB app-private ext4 mount accepted
+117,440,519 bytes of a validated 402,653,184-byte synthetic payload before JNI
+reported `IO_FAILURE`. The pipeline removed partial staging and preserved the
+previous validated install. The loop image and temporary AVD were deleted.
+This closes the synthetic emulator full-disk fault, not production-size peak
+space or the official archive.
 Do not begin the touch-UI port until A2's controller-driven Original-mode proof
 passes. Physical Android hardware remains authoritative for vendor Vulkan and
 controller behavior; Retro Rewind installation and touch parity follow from

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -288,6 +288,15 @@ not block offline Retro Rewind support.
    acquisition, not mid-transfer/mid-extraction `ENOSPC` or a production-size
    install. Evidence:
    `docs/artifacts/2026-09-04/android/a3-device-low-space.md`.
+   The after-preflight full-disk fault now executes through the real Android
+   pipeline on a temporary API 36 ARM64 AVD. A 512 MiB app-private ext4 mount
+   accepted 117,440,519 bytes of a validated 402,653,184-byte synthetic file
+   before JNI returned `IO_FAILURE`; exact staging was removed and the prior
+   validated install remained intact. Cleanup deleted the loop image, host
+   fixtures, emulator, and exact temporary AVD, returning host free space to
+   46 GiB. This closes the synthetic emulator fault, not the official
+   production-size install. Evidence:
+   `docs/artifacts/2026-09-04/android/a3-device-enospc.md`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2576,3 +2576,39 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   physical hardware remain open. No production archive, private data, APK, or
   AAB was downloaded or published. Evidence:
   `docs/artifacts/2026-09-04/android/a3-device-low-space.md`.
+
+## 2026-09-04 — Android A3 mid-extraction ENOSPC
+
+- Added a debug-only two-phase fixture that installs a valid existing pack,
+  then runs a separately verified synthetic replacement through the production
+  JNI extraction/validation/activation pipeline after the backing filesystem
+  is deliberately constrained.
+- The guarded harness creates an exact temporary API 36 AVD, mounts a 512 MiB
+  ext4 loop image at app-private `KartPad`, derives ownership/SELinux context
+  from the installed package, and proves app access. The replacement archive
+  is created first, and an 8 GiB host reserve remains mandatory.
+- A 368,544 KiB filler left insufficient expansion capacity. JNI wrote
+  117,440,519 bytes of a validated 402,653,184-byte payload before
+  `IO_FAILURE`; the pipeline reported extraction failure, deleted partial
+  staging, and the prior installed pack still passed exact validation.
+- An attempted smaller emulator data partition was ignored by the system image
+  and the unchanged 6 GiB partition was observed before stopping it; no 5 GiB
+  fill was attempted. The bounded loop mount replaced that disproportionate
+  route. One manual cleanup used an unset SDK variable, then deleted the exact
+  temporary AVD with the resolved pinned path before the automated run.
+- Cleanup unmounted/deleted the loop image, stopped the emulator, deleted the
+  temporary AVD and host fixtures, and left no ADB target. Host free space
+  returned to 46 GiB. Debug assemble/package audit pass; the exact source-only
+  APK is 33,843,921 bytes at SHA-256
+  `120eb052dbe10d3967ff8a58ea3032526d5d1d2982e580ccdf92092d30b49e1a`.
+- All eight A3 source contracts, source-only release compile/API-28 lint,
+  private game-runtime debug Kotlin/Java compile, SunPad snapshot, repository
+  safety, shell, and diff checks pass. Source verification validates 446 hunks
+  and every other pin before the unchanged ignored `rr-pulsar` mismatch; it
+  was not mutated.
+- Classification: **Pass for real Android mid-extraction ENOSPC with measured
+  JNI progress, partial-staging cleanup, and preservation of a previous valid
+  install.** Production-size archive/peak-space, gameplay/mode switching, and
+  physical hardware remain open. No production archive, private data, APK, or
+  AAB was downloaded or published. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-device-enospc.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -430,6 +430,16 @@ emulator stopped. This closes the on-device preflight deficit case, not
 mid-transfer/mid-extraction `ENOSPC` or the production-size install. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-device-low-space.md`](artifacts/2026-09-04/android/a3-device-low-space.md).
 
+The real Android installation pipeline now also survives storage exhaustion
+after preflight. A temporary API 36 AVD mounted a 512 MiB ext4 filesystem at
+the app-private support root; the JNI extractor wrote 117,440,519 bytes of a
+validated 402,653,184-byte synthetic payload before native `IO_FAILURE`. The
+pipeline removed partial staging and the previous validated install remained
+unchanged. The loop image and temporary AVD were deleted, returning host free
+space to 46 GiB. This closes the synthetic emulator full-disk fault, not the
+official production-size install. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-device-enospc.md`](artifacts/2026-09-04/android/a3-device-enospc.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-04/android/a3-device-enospc.md
+++ b/docs/artifacts/2026-09-04/android/a3-device-enospc.md
@@ -1,0 +1,77 @@
+# Android A3 mid-extraction ENOSPC
+
+Date: 2026-09-04
+
+Branch: `codex/android-a3-device-enospc`
+
+Baseline: `33f6f94`
+
+## Falsifiable subgoal
+
+Prove the real Android JNI extraction/installation pipeline preserves an
+existing validated Retro Rewind pack when storage becomes exhausted after
+preflight. Use a bounded temporary filesystem and synthetic content, require
+measured extraction progress before native `IO_FAILURE`, remove partial
+staging, and reclaim every temporary emulator/storage artifact afterward.
+
+## Result
+
+- Added a debug-only two-phase device fixture. Preparation installs and
+  validates a small existing pack through the production pipeline before the
+  test filesystem is filled. Execution verifies a host-created synthetic ZIP,
+  invokes the production JNI extractor, and revalidates the existing pack
+  after failure.
+- Added a guarded harness that creates its own temporary API 36 ARM64 AVD and a
+  512 MiB ext4 loop filesystem mounted at the app-private KartPad support root.
+  Ownership and SELinux context are derived from the installed package, and
+  app access is proven before the fixture runs.
+- The harness creates the replacement ZIP before applying a 368,544 KiB
+  filler. The archive is only 391,907 bytes but declares and hashes a
+  402,653,184-byte synthetic file, so extraction—not archive creation—must
+  encounter the bounded filesystem limit.
+- JNI extraction made 117,440,519 bytes of measured progress, then returned
+  `IO_FAILURE`. The pipeline classified `EXTRACTION_FAILURE`, removed its exact
+  partial staging directory, and the previous installed pack still passed its
+  byte/hash contract.
+- Cleanup force-stopped the app, unmounted the loop filesystem, deleted the
+  loop image/archive, stopped the emulator, deleted the exact temporary AVD,
+  and removed host fixtures. No ADB target or temporary AVD remains; host free
+  space returned to 46 GiB.
+
+## Verification
+
+- `scripts/test-android-retro-rewind-enospc.sh`: pass.
+- Final marker:
+  `Android Retro Rewind ENOSPC extraction passed:
+  avd=KartPad_API_36_ENOSPC api=36 abi=arm64-v8a filesystem_mib=512
+  filler_kib=368544 payload_bytes=402653184 extracted_bytes=117440519
+  existing=preserved staging=clean archive=synthetic`.
+- Debug assemble and strict APK/privacy audit pass. The exact source-only APK
+  is 33,843,921 bytes at SHA-256
+  `120eb052dbe10d3967ff8a58ea3032526d5d1d2982e580ccdf92092d30b49e1a`.
+- All eight A3 source contracts, source-only release compile, API-28 lint,
+  private game-runtime debug Kotlin/Java compile, SunPad snapshot, repository
+  safety, shell lint/syntax, and diff checks pass. Source verification validates
+  446 patch hunks and the WiiCompiled, SunPad, and WheelWizard pins, then stops
+  at the unchanged ignored `rr-pulsar` mismatch (local `b566a5d...`, pinned
+  `29e76d4...`); this work does not mutate that checkout.
+
+Discovery rejected two disproportionate alternatives before the passing run:
+the emulator ignored a smaller partition request for its existing 6 GiB data
+image, while filling that entire image would have required roughly 5 GiB. A
+temporary 512 MiB loop filesystem reduced the bounded write budget and was
+fully deleted after the run. One manual AVD cleanup initially used an unset SDK
+variable; the exact named AVD was then deleted with the resolved pinned SDK
+path before the automated test began. The emulator had also normalized one
+pinned AVD config from `key=value` to `key = value`; restoring only that
+mechanical formatting returned `check-android-host.sh` to green without
+changing its image or userdata.
+
+## Classification
+
+**Pass for real Android mid-extraction storage exhaustion with measured JNI
+progress, exact staging cleanup, and preservation of a previous validated
+install.** This closes the synthetic emulator form of A3's full-disk fault; it
+does not execute the official 1.86 GB archive, prove production-size peak
+space, gameplay, mode switching, or physical hardware. No production archive,
+private data, device identifier, APK, or AAB was downloaded or published.

--- a/scripts/test-android-retro-rewind-enospc.sh
+++ b/scripts/test-android-retro-rewind-enospc.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+# shellcheck source=android-toolchain-versions.sh
+source "$repo_root/scripts/android-toolchain-versions.sh"
+sdk_root="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/Library/Android/sdk}}"
+adb="$sdk_root/platform-tools/adb"
+emulator="$sdk_root/emulator/emulator"
+avdmanager="$sdk_root/cmdline-tools/$KARTPAD_ANDROID_CMDLINE_TOOLS_REVISION/bin/avdmanager"
+temporary_avd="KartPad_API_36_ENOSPC"
+package="dev.kartpad.android"
+component="$package/.RetroRewindWorkerFixtureActivity"
+mountpoint="/data/user/0/$package/files/KartPad"
+image="/data/local/tmp/kartpad-enospc.img"
+pushed_archive="/data/local/tmp/RetroRewindEnospcFixture.zip"
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/kartpad-android-enospc.XXXXXX")"
+host_archive="$test_root/RetroRewindEnospcFixture.zip"
+metadata="$test_root/metadata"
+emulator_pid=""
+avd_created=0
+
+cleanup() {
+  "$adb" shell am force-stop "$package" >/dev/null 2>&1 || true
+  "$adb" shell umount "$mountpoint" >/dev/null 2>&1 || true
+  "$adb" shell rm -f "$image" "$pushed_archive" >/dev/null 2>&1 || true
+  "$adb" emu kill >/dev/null 2>&1 || true
+  if [[ -n "$emulator_pid" ]]; then
+    wait "$emulator_pid" 2>/dev/null || true
+  fi
+  if [[ "$avd_created" == 1 ]]; then
+    "$avdmanager" delete avd --name "$temporary_avd" >/dev/null 2>&1 || true
+  fi
+  find "$test_root" -depth -delete
+}
+trap cleanup EXIT
+
+if "$adb" devices | sed -n '2,$p' | grep -q '[[:space:]]device$'; then
+  echo "ERROR: an Android device/emulator is already connected; preserve the one-emulator rule" >&2
+  exit 1
+fi
+if [[ -e "$HOME/.android/avd/$temporary_avd.ini" ||
+      -d "$HOME/.android/avd/$temporary_avd.avd" ]]; then
+  echo "ERROR: temporary AVD already exists: $temporary_avd" >&2
+  exit 1
+fi
+host_available_kib="$(df -Pk "$repo_root" | awk 'NR == 2 {print $4}')"
+if (( host_available_kib * 1024 < 8 * 1024 * 1024 * 1024 )); then
+  echo "ERROR: host lacks the required 8 GiB reserve" >&2
+  exit 1
+fi
+
+python3 - "$repo_root/builder/profiles/mkwii-rmcp01-rev0.json" \
+  "$host_archive" "$metadata" <<'PY'
+import hashlib
+import json
+from pathlib import Path
+import sys
+import zipfile
+
+profile_path, archive_path, metadata_path = map(Path, sys.argv[1:])
+with profile_path.open(encoding="utf-8") as stream:
+    retro = json.load(stream)["retroRewind"]
+payload_bytes = 384 * 1024 * 1024
+chunk = bytes(1024 * 1024)
+payload_digest = hashlib.sha256()
+with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED, allowZip64=True) as archive:
+    root = retro["root"]
+    archive.writestr(f"{root}/", b"")
+    archive.writestr(f"{root}/version.txt", f"{retro['version']}\n".encode())
+    archive.writestr(f"{root}/fixture/", b"")
+    with archive.open(f"{root}/fixture/large.bin", "w", force_zip64=True) as output:
+        for _ in range(payload_bytes // len(chunk)):
+            output.write(chunk)
+            payload_digest.update(chunk)
+archive_data = archive_path.read_bytes()
+metadata_path.write_text(
+    "\n".join((
+        str(len(archive_data)),
+        hashlib.sha256(archive_data).hexdigest(),
+        str(payload_bytes),
+        payload_digest.hexdigest(),
+    )) + "\n",
+    encoding="utf-8",
+)
+PY
+archive_bytes="$(sed -n '1p' "$metadata")"
+archive_sha256="$(sed -n '2p' "$metadata")"
+payload_bytes="$(sed -n '3p' "$metadata")"
+payload_sha256="$(sed -n '4p' "$metadata")"
+
+"$repo_root/scripts/build-android-fixture.sh"
+"$repo_root/scripts/audit-android-package.sh"
+export JAVA_HOME="$repo_root/.android-bootstrap/jdk-$KARTPAD_ANDROID_JDK_VERSION/Contents/Home"
+printf 'no\n' | "$avdmanager" create avd --force --name "$temporary_avd" \
+  --package "$KARTPAD_ANDROID_PHONE_IMAGE" --device pixel_7 >/dev/null
+avd_created=1
+emulator_log="$repo_root/.android-bootstrap/emulator-$temporary_avd.raw.log"
+"$emulator" "@$temporary_avd" -no-window -no-audio -no-boot-anim -no-snapshot \
+  -gpu auto -wipe-data >"$emulator_log" 2>&1 &
+emulator_pid=$!
+
+"$adb" wait-for-device
+booted=0
+for _ in {1..60}; do
+  if [[ "$("$adb" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" == "1" ]]; then
+    booted=1
+    break
+  fi
+  sleep 2
+done
+[[ "$booted" == 1 ]] || { echo "ERROR: emulator did not finish booting" >&2; exit 1; }
+"$adb" root >/dev/null
+"$adb" wait-for-device
+
+apk="$repo_root/android/app/build/outputs/apk/debug/app-debug.apk"
+"$adb" install -r "$apk" >/dev/null
+uid="$("$adb" shell stat -c %u "/data/user/0/$package" | tr -d '\r')"
+context="$("$adb" shell ls -Zd "/data/user/0/$package/cache" |
+  awk '{print $1}' | tr -d '\r')"
+[[ "$uid" =~ ^[0-9]+$ && "$context" == u:object_r:app_data_file:* ]] || {
+  echo "ERROR: could not derive bounded app storage ownership" >&2
+  exit 1
+}
+
+"$adb" shell mkdir -p "$mountpoint"
+"$adb" shell truncate -s 536870912 "$image"
+"$adb" shell mke2fs -t ext4 -F "$image" >/dev/null
+"$adb" shell mount -o loop "$image" "$mountpoint"
+"$adb" shell chown "$uid:$uid" "$mountpoint"
+"$adb" shell chmod 700 "$mountpoint"
+"$adb" shell chcon "$context" "$mountpoint"
+"$adb" shell run-as "$package" touch files/KartPad/app-access-check
+"$adb" shell run-as "$package" rm files/KartPad/app-access-check
+
+"$adb" push "$host_archive" "$pushed_archive" >/dev/null
+"$adb" shell run-as "$package" cp "$pushed_archive" "cache/$(basename "$pushed_archive")"
+
+wait_for_marker() {
+  local expected="$1"
+  local marker=""
+  for _ in {1..60}; do
+    marker="$("$adb" logcat -d -v raw KartPadFixture:I AndroidRuntime:E '*:S' |
+      grep -F "$expected" | tail -1 || true)"
+    [[ -n "$marker" ]] && { printf '%s\n' "$marker"; return 0; }
+    sleep 1
+  done
+  echo "ERROR: fixture marker was not observed: $expected" >&2
+  "$adb" logcat -d -v brief KartPadFixture:V AndroidRuntime:E libc:F '*:S' >&2
+  return 1
+}
+
+"$adb" logcat -c
+"$adb" shell am start -W -n "$component" \
+  --ez dev.kartpad.android.TEST_RETRO_REWIND_ENOSPC_PREPARE true >/dev/null
+wait_for_marker "A3 ENOSPC fixture prepared existing=valid" >/dev/null
+"$adb" shell am force-stop "$package"
+
+available_kib="$("$adb" shell df -k "$mountpoint" | awk 'NR == 2 {print $4}' |
+  tr -d '\r')"
+[[ "$available_kib" =~ ^[0-9]+$ ]] || {
+  echo "ERROR: could not read bounded filesystem capacity" >&2
+  exit 1
+}
+target_kib=$((128 * 1024))
+fill_kib=$((available_kib - target_kib))
+if (( fill_kib <= 0 || fill_kib > 512 * 1024 )); then
+  echo "ERROR: bounded ENOSPC filler is outside its 512 MiB safety cap" >&2
+  exit 1
+fi
+"$adb" shell fallocate -l "$((fill_kib * 1024))" "$mountpoint/.enospc-fill"
+
+"$adb" logcat -c
+"$adb" shell am start -W -n "$component" \
+  --ez dev.kartpad.android.TEST_RETRO_REWIND_ENOSPC_RUN true \
+  --el dev.kartpad.android.TEST_RETRO_REWIND_ARCHIVE_BYTES "$archive_bytes" \
+  --es dev.kartpad.android.TEST_RETRO_REWIND_ARCHIVE_SHA256 "$archive_sha256" \
+  --el dev.kartpad.android.TEST_RETRO_REWIND_PAYLOAD_BYTES "$payload_bytes" \
+  --es dev.kartpad.android.TEST_RETRO_REWIND_PAYLOAD_SHA256 "$payload_sha256" \
+  >/dev/null
+marker="$(wait_for_marker "A3 ENOSPC extraction passed existing=preserved")"
+extracted="$(printf '%s\n' "$marker" |
+  sed -n 's/.*extracted=\([0-9][0-9]*\).*/\1/p')"
+[[ "$marker" == *"error=IO_FAILURE"* && "$extracted" =~ ^[0-9]+$ ]] || {
+  echo "ERROR: bounded filesystem did not produce a measured native IO failure" >&2
+  exit 1
+}
+if (( extracted <= 0 || extracted >= payload_bytes )); then
+  echo "ERROR: ENOSPC did not interrupt active extraction" >&2
+  exit 1
+fi
+
+echo "Android Retro Rewind ENOSPC extraction passed: avd=$temporary_avd api=36 abi=arm64-v8a filesystem_mib=512 filler_kib=$fill_kib payload_bytes=$payload_bytes extracted_bytes=$extracted existing=preserved staging=clean archive=synthetic"


### PR DESCRIPTION
## Summary
- add a debug-only two-phase fixture that prepares a validated existing pack, then drives a verified synthetic replacement through the production JNI extraction pipeline
- create a temporary API 36 AVD and 512 MiB app-private ext4 loop filesystem with package-derived ownership and SELinux labeling
- require measured partial extraction followed by native `IO_FAILURE`, exact staging cleanup, and preservation of the previous validated install

## Verification
- `scripts/test-android-retro-rewind-enospc.sh`
  - filesystem: `512 MiB`
  - filler: `368544 KiB`
  - synthetic payload: `402653184` bytes
  - measured bytes before ENOSPC: `117440519`
  - result: `EXTRACTION_FAILURE` / native `IO_FAILURE`
  - previous install: preserved and revalidated
  - staging: removed
- all eight Android A3 source contract runners
- source-only release Kotlin/Java compile and API-28 lint
- private game-runtime debug Kotlin/Java compile
- source-only debug assemble and strict APK/privacy audit
- SunPad snapshot, repository safety, shell syntax/lint, and diff checks
- source-only APK: `120eb052dbe10d3967ff8a58ea3032526d5d1d2982e580ccdf92092d30b49e1a`

## Cleanup and limits
- cleanup unmounts/deletes the loop image, stops the emulator, deletes the exact temporary AVD, and removes host fixtures; no ADB target remains and host free space returned to 46 GiB
- closes the synthetic emulator full-disk fault, not production-size peak storage or the official 1.86 GB archive
- does not prove gameplay, mode switching, or physical hardware
- source verification still stops at the documented ignored `ref/upstream/rr-pulsar` mismatch after all 446 hunks and other pins pass
