### PR TITLE
Fix Android Retro Rewind production install

### DIFF
--- a/android/app/src/debug/java/dev/kartpad/android/RetroRewindPipelineDeviceFixture.java
+++ b/android/app/src/debug/java/dev/kartpad/android/RetroRewindPipelineDeviceFixture.java
@@ -29,7 +29,8 @@ final class RetroRewindPipelineDeviceFixture {
         Path fixtureRoot = context.getCacheDir().toPath()
                 .resolve("RetroRewindPipelineDeviceFixture");
         try {
-            System.loadLibrary("main");
+            // Deliberately do not preload JNI here. This fixture starts in a
+            // non-SDL process and proves the extractor owns its cold load.
             deleteTree(fixtureRoot);
             Files.createDirectories(fixtureRoot);
             RetroRewindInstallStorage.recover(context.getFilesDir());

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindArchiveDownload.java
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindArchiveDownload.java
@@ -136,6 +136,25 @@ final class RetroRewindArchiveDownload {
                 ".RetroRewind-" + RetroRewindRelease.VERSION + ".part");
     }
 
+    /** Bytes already occupying the cache that the next transfer can reuse or replace in place. */
+    static long reusableBytes(Path cacheDirectory) {
+        Path archive = archivePath(cacheDirectory);
+        if (verifyFile(archive, RetroRewindRelease.ARCHIVE_BYTES,
+                RetroRewindRelease.ARCHIVE_SHA256) == Error.NONE) {
+            return RetroRewindRelease.ARCHIVE_BYTES;
+        }
+        Path partial = partialPath(cacheDirectory);
+        try {
+            if (!Files.isRegularFile(partial, LinkOption.NOFOLLOW_LINKS)) {
+                return 0;
+            }
+            long bytes = Files.size(partial);
+            return bytes >= 0 && bytes <= RetroRewindRelease.ARCHIVE_BYTES ? bytes : 0;
+        } catch (IOException | SecurityException exception) {
+            return 0;
+        }
+    }
+
     private static Result downloadPinned(
             Path partial, long resumeOffset, Cancellation cancellation, Progress progress) {
         URL initial;

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindArchiveExtractor.java
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindArchiveExtractor.java
@@ -9,6 +9,23 @@ import java.nio.file.Path;
 final class RetroRewindArchiveExtractor {
     private static final int MAXIMUM_ENTRIES = 10_000;
 
+    /**
+     * Loads the JNI owner only when extraction is actually requested.
+     *
+     * Keeping this lazy lets host-side policy tests use the Java result types,
+     * while ensuring a cold WorkManager process does not depend on an SDL
+     * Activity having loaded the library first.
+     */
+    private static final class NativeLibrary {
+        static {
+            System.loadLibrary("main");
+        }
+
+        private NativeLibrary() {}
+
+        static void ensureLoaded() {}
+    }
+
     interface Cancellation {
         boolean isCancelled();
     }
@@ -65,6 +82,7 @@ final class RetroRewindArchiveExtractor {
             throw new IOException("Retro Rewind extraction destination is not empty");
         }
 
+        NativeLibrary.ensureLoaded();
         long[] counts = new long[3];
         int code = nativeExtract(
                 archive.toAbsolutePath().toString(),

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindSpacePreflight.java
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindSpacePreflight.java
@@ -46,14 +46,33 @@ final class RetroRewindSpacePreflight {
             boolean sameStore,
             long archiveBytes,
             long maximumExpandedBytes) {
+        return evaluate(
+                availableFilesBytes,
+                availableCacheBytes,
+                sameStore,
+                archiveBytes,
+                maximumExpandedBytes,
+                0);
+    }
+
+    static Result evaluate(
+            long availableFilesBytes,
+            long availableCacheBytes,
+            boolean sameStore,
+            long archiveBytes,
+            long maximumExpandedBytes,
+            long reusableArchiveBytes) {
         if (availableFilesBytes < 0 || availableCacheBytes < 0 ||
-                archiveBytes < 0 || maximumExpandedBytes < 0) {
+                archiveBytes < 0 || maximumExpandedBytes < 0 ||
+                reusableArchiveBytes < 0 || reusableArchiveBytes > archiveBytes) {
             return result(Error.INVALID_REQUIREMENT, 0, 0,
                     availableFilesBytes, availableCacheBytes);
         }
 
+        long remainingArchiveBytes = archiveBytes - reusableArchiveBytes;
+
         if (sameStore) {
-            long required = checkedAdd(archiveBytes, maximumExpandedBytes);
+            long required = checkedAdd(remainingArchiveBytes, maximumExpandedBytes);
             required = checkedAdd(required, RESERVE_BYTES);
             if (required < 0) {
                 return result(Error.INVALID_REQUIREMENT, 0, 0,
@@ -66,7 +85,7 @@ final class RetroRewindSpacePreflight {
         }
 
         long requiredFiles = checkedAdd(maximumExpandedBytes, RESERVE_BYTES);
-        long requiredCache = checkedAdd(archiveBytes, RESERVE_BYTES);
+        long requiredCache = checkedAdd(remainingArchiveBytes, RESERVE_BYTES);
         if (requiredFiles < 0 || requiredCache < 0) {
             return result(Error.INVALID_REQUIREMENT, 0, 0,
                     availableFilesBytes, availableCacheBytes);

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindSpaceProbe.kt
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindSpaceProbe.kt
@@ -17,6 +17,7 @@ internal object RetroRewindSpaceProbe {
                 sameStore,
                 RetroRewindRelease.ARCHIVE_BYTES,
                 RetroRewindRelease.MAXIMUM_EXPANDED_BYTES,
+                RetroRewindArchiveDownload.reusableBytes(cacheDirectory.toPath()),
             )
         } catch (_: ErrnoException) {
             RetroRewindSpacePreflight.probeFailed()

--- a/android/app/src/test/java/dev/kartpad/android/RetroRewindArchiveDownloadTestMain.java
+++ b/android/app/src/test/java/dev/kartpad/android/RetroRewindArchiveDownloadTestMain.java
@@ -29,6 +29,11 @@ public final class RetroRewindArchiveDownloadTestMain {
                             directory.resolve(".RetroRewind-" +
                                     RetroRewindRelease.VERSION + ".part")),
                     "partial path is not stable and version-scoped");
+            Path releasePartial = RetroRewindArchiveDownload.partialPath(directory);
+            Files.write(releasePartial, new byte[321]);
+            expect(RetroRewindArchiveDownload.reusableBytes(directory) == 321,
+                    "safe partial bytes were not credited for preflight");
+            Files.delete(releasePartial);
 
             long[] progress = {0, 0};
             expectError(RetroRewindArchiveDownload.transfer(

--- a/android/app/src/test/java/dev/kartpad/android/RetroRewindSpacePreflightTestMain.java
+++ b/android/app/src/test/java/dev/kartpad/android/RetroRewindSpacePreflightTestMain.java
@@ -22,6 +22,18 @@ public final class RetroRewindSpacePreflightTestMain {
                         true, archive, expanded),
                 RetroRewindSpacePreflight.Error.INSUFFICIENT_SHARED_STORE);
 
+        var sharedCached = RetroRewindSpacePreflight.evaluate(
+                expanded + reserve, 0, true, archive, expanded, archive);
+        expect(sharedCached.isReady(), "cached archive was charged twice");
+        expect(sharedCached.requiredFilesBytes == expanded + reserve,
+                "cached shared-store requirement is incorrect");
+
+        var sharedPartial = RetroRewindSpacePreflight.evaluate(
+                500 + expanded + reserve, 0, true, archive, expanded, 500);
+        expect(sharedPartial.isReady(), "partial archive credit was rejected");
+        expect(sharedPartial.requiredFilesBytes == 500 + expanded + reserve,
+                "partial shared-store requirement is incorrect");
+
         var separateReady = RetroRewindSpacePreflight.evaluate(
                 expanded + reserve, archive + reserve, false, archive, expanded);
         expect(separateReady.isReady(), "exact separate-store capacity was rejected");
@@ -51,6 +63,11 @@ public final class RetroRewindSpacePreflightTestMain {
                         -1, 0, true, archive, expanded),
                 RetroRewindSpacePreflight.Error.INVALID_REQUIREMENT);
         expectError(
+                RetroRewindSpacePreflight.evaluate(
+                        Long.MAX_VALUE, Long.MAX_VALUE, true,
+                        archive, expanded, archive + 1),
+                RetroRewindSpacePreflight.Error.INVALID_REQUIREMENT);
+        expectError(
                 RetroRewindSpacePreflight.probeFailed(),
                 RetroRewindSpacePreflight.Error.PROBE_FAILED);
 
@@ -61,6 +78,13 @@ public final class RetroRewindSpacePreflightTestMain {
         expect(production.isReady(), "production requirements overflowed");
         expect(production.requiredFilesBytes == 4_327_477_355L,
                 "production shared-store requirement drifted");
+        var productionCached = RetroRewindSpacePreflight.evaluate(
+                Long.MAX_VALUE, Long.MAX_VALUE, true,
+                RetroRewindRelease.ARCHIVE_BYTES,
+                RetroRewindRelease.MAXIMUM_EXPANDED_BYTES,
+                RetroRewindRelease.ARCHIVE_BYTES);
+        expect(productionCached.requiredFilesBytes == 2_468_435_456L,
+                "production cached-archive requirement drifted");
     }
 
     private static void expectError(

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -947,6 +947,17 @@ reported `IO_FAILURE`. The pipeline removed partial staging and preserved the
 previous validated install. The loop image and temporary AVD were deleted.
 This closes the synthetic emulator full-disk fault, not production-size peak
 space or the official archive.
+
+The official production-size installer now also passes on a wiped API 36 ARM64
+emulator. It downloaded and exactly verified the pinned 1,859,041,899-byte
+archive, exposed and fixed a missing cold-worker JNI load plus cached-archive
+space double-counting on Retry, then reused the verified archive, activated
+2,110,038,016 bytes, and removed the cache. A force-stop/airplane-mode relaunch
+revalidated the installed 6.12.5 pack offline. This closes official pack
+installation on the emulator, not Retro Rewind gameplay, mode switching, or
+physical-device acceptance. Evidence is in
+`docs/artifacts/2026-09-04/android/a3-production-install.md`.
+
 Do not begin the touch-UI port until A2's controller-driven Original-mode proof
 passes. Physical Android hardware remains authoritative for vendor Vulkan and
 controller behavior; Retro Rewind installation and touch parity follow from

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -297,6 +297,15 @@ not block offline Retro Rewind support.
    46 GiB. This closes the synthetic emulator fault, not the official
    production-size install. Evidence:
    `docs/artifacts/2026-09-04/android/a3-device-enospc.md`.
+   The official production-size installer now passes on a wiped API 36 ARM64
+   emulator. Its real 1,859,041,899-byte download matched the pinned digest.
+   Execution exposed a missing cold-worker JNI load and cached-archive space
+   double-counting on Retry; both are fixed with direct host/device regression
+   coverage. The patched retry reused the archive, activated 2,110,038,016
+   bytes, removed the cache, and revalidated version 6.12.5 after force-stop in
+   airplane mode. Gameplay/mode switching and physical acceptance remain open.
+   Evidence:
+   `docs/artifacts/2026-09-04/android/a3-production-install.md`.
 2. Collect the first physical Apple TV report against `v0.4.0` using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2612,3 +2612,29 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   physical hardware remain open. No production archive, private data, APK, or
   AAB was downloaded or published. Evidence:
   `docs/artifacts/2026-09-04/android/a3-device-enospc.md`.
+
+## 2026-09-04 — Android A3 official production install
+
+- Drove the release-owned installer on a wiped API 36 ARM64 AVD through the
+  real official Retro Rewind 6.12.5 transfer. All 1,859,041,899 bytes arrived
+  and matched the profile-pinned SHA-256.
+- The first run reached native extraction and failed because the cold
+  WorkManager process had not loaded `libmain.so`. The extractor now owns a
+  lazy JNI load; the non-SDL device pipeline fixture no longer preloads it and
+  passes from a cold process.
+- Retry then correctly exposed that preflight charged a verified cached
+  archive twice. The pure capacity evaluator now accepts bounded reusable
+  bytes; Android credits only a verified final archive or a safe regular
+  partial that the downloader can reuse/replace, while retaining the 2.2 GB
+  expansion ceiling and 256 MiB reserve.
+- The patched APK reused the verified cache, completed native extraction and
+  atomic activation, removed the archive, and reported 2,110,038,016 installed
+  bytes. The pinned `Code.pul` and XML size/hash checks pass.
+- Force-stop plus airplane mode still produced `Retro Rewind is ready` after a
+  cold validation. Focused host tests, debug build, and strict APK audit pass;
+  the current source-only APK SHA-256 is
+  `fca7cf95024310b40471b2b750e6571b1fb94fb31faa03abfd8af3bf9424358d`.
+- Classification: **Pass for official production-size installation and
+  offline pack revalidation on the ARM64 emulator.** Gameplay/mode switching,
+  physical acceptance, and publishing remain open. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-production-install.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -440,6 +440,19 @@ space to 46 GiB. This closes the synthetic emulator full-disk fault, not the
 official production-size install. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-device-enospc.md`](artifacts/2026-09-04/android/a3-device-enospc.md).
 
+The official production-size A3 installer now passes on a wiped API 36 ARM64
+emulator. The foreground worker downloaded and exactly verified the pinned
+1,859,041,899-byte Retro Rewind 6.12.5 archive, then exposed and fixed two real
+recovery defects: a cold worker had not loaded the JNI extractor, and Retry
+double-counted an already cached archive during free-space preflight. The
+patched worker reused the verified cache, natively extracted and atomically
+activated 2,110,038,016 bytes, removed the archive, and validated the pinned
+`Code.pul` and XML. After force-stop and airplane mode, a cold launch again
+reported the installed pack ready. This closes official installation and
+offline installed-content revalidation on the emulator, not Retro Rewind
+gameplay/mode switching or physical hardware. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-production-install.md`](artifacts/2026-09-04/android/a3-production-install.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-04/android/a3-production-install.md
+++ b/docs/artifacts/2026-09-04/android/a3-production-install.md
@@ -1,0 +1,66 @@
+# Android A3 official production install
+
+Date: 2026-09-04
+
+Branch: `codex/android-a3-production-install`
+
+Baseline: `6756442`
+
+## Falsifiable subgoal
+
+On a freshly wiped API 36 ARM64 emulator, drive the release-owned installer
+through the official Retro Rewind 6.12.5 download, exact verification, native
+extraction, activation, cache cleanup, process restart, and offline installed-
+content validation. Treat emulator execution as emulator evidence only.
+
+## Result
+
+- The wiped emulator exposed 5,258,480 KiB of app-store space, exceeding the
+  profile-derived 4,327,477,355-byte initial requirement. Its network was
+  Android-validated before the production control was activated.
+- The real foreground worker downloaded all 1,859,041,899 bytes from the
+  profile-generated official HTTPS URL. The resulting archive matched SHA-256
+  `d8f7c61636ef76f8a451f4071ec5bbdcfea9d5f2500cfc6c245431f04580f9d9`.
+- The first production run exposed a cold-worker defect: native extraction
+  threw `UnsatisfiedLinkError` because no SDL activity had loaded `libmain.so`.
+  The extractor now owns a lazy, process-idempotent JNI load. The existing
+  non-SDL device pipeline fixture deliberately omits manual loading and passes
+  from a cold process.
+- The preserved verified archive then exposed a second recovery defect:
+  preflight charged the already-occupied archive a second time and rejected
+  Retry. Capacity evaluation now accepts bounded reusable archive bytes and
+  requires only the remaining transfer bytes plus the unchanged expansion cap
+  and 256 MiB reserve. Host boundary tests cover full and partial cache credit.
+- Installing the patched APK with `-r` preserved the verified cache. Retry
+  reused it, entered JNI extraction, atomically activated 2,110,038,016 bytes
+  of content, and displayed `Retro Rewind is ready` only after the production
+  validator passed.
+- The archive was deleted after success. `Code.pul` is exactly 1,723,600 bytes
+  at SHA-256
+  `622485319fd01746c705e5c1b08b2551e36368d8abd70138ee843dc8a0a0a293`;
+  `RetroRewind6.xml` matches
+  `faf88234f81e16a85403d2a86d25e2ef4b261aedb553a312b532e60a11b28200`.
+- After force-stop and airplane mode, a cold installer launch revalidated the
+  installed pack and again reported version 6.12.5 ready without network
+  access.
+
+## Verification
+
+- Focused archive-download, space, installation-pipeline, and worker-policy
+  host tests pass.
+- Source-only debug assemble and strict APK/privacy audit pass. The patched APK
+  is SHA-256
+  `fca7cf95024310b40471b2b750e6571b1fb94fb31faa03abfd8af3bf9424358d`.
+- The cold non-SDL device pipeline emitted
+  `A3 device install faults passed existing=preserved replacement=valid
+  recovery=restored` before the production retry.
+- The production UI ended at `Retro Rewind is ready`; an offline cold relaunch
+  ended at the same validated state. No WorkManager, application-runtime, or
+  installer error remained after the patched retry.
+
+## Classification
+
+**Pass for the official production-size Retro Rewind 6.12.5 installation and
+offline revalidation on an API 36 ARM64 emulator.** This is not Retro Rewind
+gameplay, Original/Retro mode switching, physical-device acceptance, or public
+release authorization. No APK/AAB or private game data was published.


### PR DESCRIPTION
## Summary
- load the native Retro Rewind extractor from a cold foreground-worker process
- credit verified/reusable cached archive bytes during retry preflight
- prove the official 1.86 GB install and offline revalidation on API 36 ARM64

## Verification
- all eight A3 source contract runners
- cold non-SDL JNI device pipeline fixture
- official 1,859,041,899-byte archive size/SHA-256 verification
- production retry, native extraction, activation, cache cleanup, and offline cold revalidation
- source-only debug/release compile, API-28 lint, strict APK audit
- private game-runtime Kotlin/Java compile
- builder, SunPad snapshot, repository safety, and diff checks

## Classification
Emulator-only official installer acceptance. Retro Rewind gameplay/mode switching and physical-device acceptance remain open. No APK/AAB was published.