### PR TITLE
Link Android dual runtime and prove offline Retro boot

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -19,6 +19,13 @@ checks. None of these paths use game data or generated translated code.
 Gameplay, physical-device support, performance, and release readiness remain
 unproven. A1 is complete; A2 is the next gate.
 
+Game-runtime builds launch through `KartPadLaunchActivity`, which validates the
+pinned Retro Rewind installation before presenting side-by-side Original and
+Retro Rewind choices. Selecting an unavailable Retro install opens the
+production installer; selecting either playable mode starts the private SDL
+activity with one immutable runtime profile. Debug builds retain protected
+direct SDL-activity access for device fixtures.
+
 The first A2 build slice can privately prepare and package the complete
 29,065-function Original runtime when the ignored translated graph already
 exists. This command never copies that graph or game data into Git and does

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -9,6 +9,7 @@ val dawnAndroidRoot = providers.environmentVariable("DAWN_ANDROID_ROOT")
 val minizipAndroidRoot = providers.environmentVariable("MINIZIP_ANDROID_ROOT")
 val gameRuntimeSource = providers.gradleProperty("kartpadGameRuntimeSource").orNull
 val translatedShardManifest = providers.gradleProperty("kartpadTranslatedShardManifest").orNull
+val androidNativeTarget = providers.gradleProperty("kartpadAndroidNativeTarget").orNull
 
 android {
     namespace = "dev.kartpad.android"
@@ -44,6 +45,9 @@ android {
                     )
                 }
                 cppFlags += listOf("-std=c++20", "-fvisibility=hidden")
+                if (androidNativeTarget != null) {
+                    targets += listOf(androidNativeTarget)
+                }
             }
         }
     }

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -11,5 +11,10 @@
             android:exported="true"
             android:permission="android.permission.DUMP"
             tools:replace="android:exported" />
+        <activity
+            android:name=".KartPadActivity"
+            android:exported="true"
+            android:permission="android.permission.DUMP"
+            tools:replace="android:exported" />
     </application>
 </manifest>

--- a/android/app/src/debug/java/dev/kartpad/android/RetroRewindPipelineDeviceFixture.java
+++ b/android/app/src/debug/java/dev/kartpad/android/RetroRewindPipelineDeviceFixture.java
@@ -13,6 +13,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -236,7 +237,8 @@ final class RetroRewindPipelineDeviceFixture {
             return;
         }
         try (var paths = Files.walk(root)) {
-            for (Path path : paths.sorted(Comparator.reverseOrder()).toList()) {
+            for (Path path : paths.sorted(Comparator.reverseOrder())
+                    .collect(Collectors.toList())) {
                 Files.delete(path);
             }
         }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,8 +30,12 @@
         <activity
             android:name=".KartPadActivity"
             android:configChanges="keyboard|keyboardHidden|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode"
-            android:exported="true"
+            android:exported="false"
             android:launchMode="singleTask"
+            android:screenOrientation="sensorLandscape" />
+        <activity
+            android:name=".KartPadLaunchActivity"
+            android:exported="true"
             android:screenOrientation="sensorLandscape">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -69,14 +69,21 @@ if(KARTPAD_GAME_RUNTIME_SOURCE)
   set(MKW_KARTPAD_REPO_ROOT "${KARTPAD_REPO_ROOT}" CACHE PATH "" FORCE)
   set(MKW_TRANSLATED_COMPILE_JOBS 2 CACHE STRING "" FORCE)
   add_subdirectory("${KARTPAD_GAME_RUNTIME_SOURCE}" game-runtime)
-  target_sources(WiiCompiled PRIVATE
+  if(TARGET KartPadDual)
+    set(KARTPAD_GAME_RUNTIME_TARGET KartPadDual)
+  elseif(TARGET WiiCompiled)
+    set(KARTPAD_GAME_RUNTIME_TARGET WiiCompiled)
+  else()
+    message(FATAL_ERROR "Prepared game runtime has no Android product target")
+  endif()
+  target_sources(${KARTPAD_GAME_RUNTIME_TARGET} PRIVATE
     retro_rewind_archive_jni.cpp
     "${KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_extract.cpp"
     "${KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_path.cpp"
     "${KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_scan.cpp")
-  target_include_directories(WiiCompiled PRIVATE
+  target_include_directories(${KARTPAD_GAME_RUNTIME_TARGET} PRIVATE
     "${KARTPAD_REPO_ROOT}/runtime/include")
-  target_link_libraries(WiiCompiled PRIVATE MINIZIP::minizip)
+  target_link_libraries(${KARTPAD_GAME_RUNTIME_TARGET} PRIVATE MINIZIP::minizip)
 else()
   add_library(main SHARED
     fixture_main.cpp

--- a/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
@@ -23,6 +23,7 @@ class KartPadActivity : SDLActivity() {
             KartPadRuntimeResources.install(this)
             Os.setenv("KARTPAD_ANDROID_FILES_DIR", filesDir.absolutePath, true)
             Os.setenv("KARTPAD_ANDROID_CACHE_DIR", cacheDir.absolutePath, true)
+            configureDebugRuntimeProfile()
             configureDebugRkgInput()
             configureDebugStateTrace()
         }
@@ -39,6 +40,31 @@ class KartPadActivity : SDLActivity() {
         )
         mLayout.bringChildToFront(overlay)
         Log.i(TAG, "A0 SDLActivity shell created")
+    }
+
+    private fun configureDebugRuntimeProfile() {
+        if (!BuildConfig.DEBUG) return
+
+        when (val requested = intent.getStringExtra(DEBUG_EXTRA_RUNTIME_PROFILE)) {
+            null -> Os.unsetenv("KARTPAD_RUNTIME_PROFILE")
+            "base" -> {
+                Os.setenv("KARTPAD_RUNTIME_PROFILE", requested, true)
+                Log.i(TAG, "A3 debug runtime profile requested=base")
+            }
+            "retro_rewind" -> {
+                val installed = RetroRewindInstallValidator.validate(
+                    RetroRewindInstallStorage.installedRoot(filesDir)
+                        .resolve(RetroRewindRelease.ROOT),
+                    RetroRewindInstallValidator.productionContract(),
+                )
+                check(installed.isValid) {
+                    "Debug Retro Rewind launch requires a validated installed pack"
+                }
+                Os.setenv("KARTPAD_RUNTIME_PROFILE", requested, true)
+                Log.i(TAG, "A3 debug runtime profile requested=retro_rewind installed=valid")
+            }
+            else -> error("Unsupported debug runtime profile")
+        }
     }
 
     private fun configureDebugRkgInput() {
@@ -185,6 +211,8 @@ class KartPadActivity : SDLActivity() {
             "dev.kartpad.android.TEST_RETRO_REWIND_EXTRACTION"
         private const val DEBUG_EXTRA_RETRO_REWIND_WORKER =
             "dev.kartpad.android.TEST_RETRO_REWIND_WORKER"
+        private const val DEBUG_EXTRA_RUNTIME_PROFILE =
+            "dev.kartpad.android.TEST_RUNTIME_PROFILE"
         private const val DEBUG_RESUME_FIXTURE_SHA256 =
             "cb9d5fc3b83611af65032f73119285de4e97d4b2b9f7b2e9567443635358483a"
         private const val MIN_RKG_BYTES = 0x90L

--- a/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
@@ -23,7 +23,7 @@ class KartPadActivity : SDLActivity() {
             KartPadRuntimeResources.install(this)
             Os.setenv("KARTPAD_ANDROID_FILES_DIR", filesDir.absolutePath, true)
             Os.setenv("KARTPAD_ANDROID_CACHE_DIR", cacheDir.absolutePath, true)
-            configureDebugRuntimeProfile()
+            configureRuntimeProfile()
             configureDebugRkgInput()
             configureDebugStateTrace()
         }
@@ -42,14 +42,18 @@ class KartPadActivity : SDLActivity() {
         Log.i(TAG, "A0 SDLActivity shell created")
     }
 
-    private fun configureDebugRuntimeProfile() {
-        if (!BuildConfig.DEBUG) return
+    private fun configureRuntimeProfile() {
+        val debugRequested = if (BuildConfig.DEBUG) {
+            intent.getStringExtra(DEBUG_EXTRA_RUNTIME_PROFILE)
+        } else {
+            null
+        }
+        val requested = debugRequested ?: intent.getStringExtra(EXTRA_RUNTIME_PROFILE) ?: "base"
 
-        when (val requested = intent.getStringExtra(DEBUG_EXTRA_RUNTIME_PROFILE)) {
-            null -> Os.unsetenv("KARTPAD_RUNTIME_PROFILE")
+        when (requested) {
             "base" -> {
                 Os.setenv("KARTPAD_RUNTIME_PROFILE", requested, true)
-                Log.i(TAG, "A3 debug runtime profile requested=base")
+                Log.i(TAG, "A3 runtime profile requested=base")
             }
             "retro_rewind" -> {
                 val installed = RetroRewindInstallValidator.validate(
@@ -58,12 +62,12 @@ class KartPadActivity : SDLActivity() {
                     RetroRewindInstallValidator.productionContract(),
                 )
                 check(installed.isValid) {
-                    "Debug Retro Rewind launch requires a validated installed pack"
+                    "Retro Rewind launch requires a validated installed pack"
                 }
                 Os.setenv("KARTPAD_RUNTIME_PROFILE", requested, true)
-                Log.i(TAG, "A3 debug runtime profile requested=retro_rewind installed=valid")
+                Log.i(TAG, "A3 runtime profile requested=retro_rewind installed=valid")
             }
-            else -> error("Unsupported debug runtime profile")
+            else -> error("Unsupported runtime profile")
         }
     }
 
@@ -199,6 +203,7 @@ class KartPadActivity : SDLActivity() {
     }
 
     companion object {
+        const val EXTRA_RUNTIME_PROFILE = "dev.kartpad.android.RUNTIME_PROFILE"
         private const val TAG = "KartPadFixture"
         private const val DEBUG_RKG_RELATIVE_PATH = "KartPad/Diagnostics/TestInput.rkg"
         private const val DEBUG_RKG_KEYBOARD_STEER_RELATIVE_PATH =

--- a/android/app/src/main/java/dev/kartpad/android/KartPadLaunchActivity.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadLaunchActivity.kt
@@ -1,0 +1,181 @@
+package dev.kartpad.android
+
+import android.app.Activity
+import android.content.Intent
+import android.graphics.Color
+import android.os.Bundle
+import android.util.Log
+import android.view.Gravity
+import android.view.View
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.ProgressBar
+import android.widget.ScrollView
+import android.widget.TextView
+import java.util.concurrent.Executors
+
+/** Production owner for choosing the immutable runtime profile before SDL starts. */
+class KartPadLaunchActivity : Activity() {
+    private lateinit var status: TextView
+    private lateinit var original: Button
+    private lateinit var retro: Button
+    private lateinit var progress: ProgressBar
+    private val validator = Executors.newSingleThreadExecutor()
+    private var validationGeneration = 0
+    private var retroInstalled = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(buildContent())
+        original.setOnClickListener { launch("base") }
+        retro.setOnClickListener {
+            if (retroInstalled) {
+                launch("retro_rewind")
+            } else {
+                startActivity(Intent(this, RetroRewindInstallActivity::class.java))
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        validateRetroRewind()
+    }
+
+    override fun onDestroy() {
+        validationGeneration += 1
+        validator.shutdownNow()
+        super.onDestroy()
+    }
+
+    private fun validateRetroRewind() {
+        val generation = ++validationGeneration
+        val forceNotInstalled = BuildConfig.DEBUG &&
+            intent.getBooleanExtra(EXTRA_DEBUG_RETRO_NOT_INSTALLED, false)
+        retroInstalled = false
+        status.text = "Checking Retro Rewind ${RetroRewindRelease.VERSION}…"
+        progress.visibility = View.VISIBLE
+        retro.isEnabled = false
+        validator.execute {
+            val valid = !forceNotInstalled && runCatching {
+                RetroRewindInstallStorage.recover(filesDir)
+                RetroRewindInstallValidator.validate(
+                    RetroRewindInstallStorage.installedRoot(filesDir)
+                        .resolve(RetroRewindRelease.ROOT),
+                    RetroRewindInstallValidator.productionContract(),
+                ).isValid
+            }.getOrDefault(false)
+            runOnUiThread {
+                if (generation != validationGeneration || isFinishing || isDestroyed) {
+                    return@runOnUiThread
+                }
+                retroInstalled = valid
+                progress.visibility = View.GONE
+                retro.isEnabled = true
+                if (valid) {
+                    status.text = "Retro Rewind ${RetroRewindRelease.VERSION} is ready"
+                    retro.text = "Retro Rewind\nInstalled ${RetroRewindRelease.VERSION} • Extra content + Retro WFC"
+                } else {
+                    status.text = "Retro Rewind is optional"
+                    retro.text = "Retro Rewind\nDownload ${RetroRewindRelease.VERSION} • Extra content + Retro WFC"
+                }
+                retro.contentDescription = retro.text
+                Log.i(LOG_TAG, "A3 mode chooser retro-installed=$valid")
+            }
+        }
+    }
+
+    private fun launch(profile: String) {
+        Log.i(LOG_TAG, "A3 mode chooser selected=$profile")
+        startActivity(
+            Intent(this, KartPadActivity::class.java)
+                .putExtra(KartPadActivity.EXTRA_RUNTIME_PROFILE, profile),
+        )
+        // The translated runtime is process-global and is not restartable in
+        // place. Do not leave the chooser behind the SDL activity where Back
+        // could imply that another profile can be selected in this process.
+        finish()
+    }
+
+    private fun buildContent(): View {
+        val density = resources.displayMetrics.density
+        fun dp(value: Int) = (value * density + 0.5f).toInt()
+        fun label(text: String, size: Float, color: Int): TextView = TextView(this).apply {
+            this.text = text
+            textSize = size
+            setTextColor(color)
+            gravity = Gravity.CENTER
+        }
+        fun layout(bottom: Int) = LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+        ).apply { bottomMargin = bottom }
+
+        val column = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            gravity = Gravity.CENTER
+            setPadding(dp(24), dp(12), dp(24), dp(12))
+            setBackgroundColor(Color.rgb(24, 12, 22))
+        }
+        column.addView(label("KartPad", 28f, Color.WHITE), layout(dp(2)))
+        column.addView(
+            label("Choose your way to race", 17f, Color.rgb(255, 117, 76)),
+            layout(dp(6)),
+        )
+        column.addView(
+            label(
+                "Your own RMCP01 disc image or extracted game data is required before play.",
+                13f,
+                Color.rgb(205, 194, 202),
+            ),
+            layout(dp(10)),
+        )
+        original = Button(this).apply {
+            id = R.id.kartpad_mode_original
+            text = "Mario Kart Wii\nOriginal game"
+            contentDescription = text
+            minHeight = dp(64)
+        }
+        retro = Button(this).apply {
+            id = R.id.kartpad_mode_retro_rewind
+            text = "Retro Rewind\nChecking installation…"
+            contentDescription = text
+            isEnabled = false
+            minHeight = dp(64)
+        }
+        val choices = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER
+            addView(
+                original,
+                LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+                    .apply { marginEnd = dp(6) },
+            )
+            addView(
+                retro,
+                LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+                    .apply { marginStart = dp(6) },
+            )
+        }
+        column.addView(choices, layout(dp(6)))
+        progress = ProgressBar(this).apply {
+            isIndeterminate = true
+        }
+        column.addView(progress, layout(dp(6)))
+        status = label("Checking Retro Rewind ${RetroRewindRelease.VERSION}…", 14f, Color.LTGRAY)
+        status.id = R.id.kartpad_mode_status
+        status.accessibilityLiveRegion = View.ACCESSIBILITY_LIVE_REGION_POLITE
+        column.addView(status, layout(0))
+
+        return ScrollView(this).apply {
+            isFillViewport = true
+            addView(column)
+        }
+    }
+
+    companion object {
+        private const val LOG_TAG = "KartPadLauncher"
+        private const val EXTRA_DEBUG_RETRO_NOT_INSTALLED =
+            "dev.kartpad.android.TEST_MODE_CHOOSER_RETRO_NOT_INSTALLED"
+    }
+}

--- a/android/app/src/main/res/values/ids.xml
+++ b/android/app/src/main/res/values/ids.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <item name="kartpad_mode_original" type="id" />
+    <item name="kartpad_mode_retro_rewind" type="id" />
+    <item name="kartpad_mode_status" type="id" />
     <item name="retro_rewind_install_status" type="id" />
     <item name="retro_rewind_install_detail" type="id" />
     <item name="retro_rewind_install_progress" type="id" />

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -53,8 +53,14 @@ stream through the exact `02:31.465` finish while leaving the save, Pulsar
 database, and RKG byte-identical. The same live Retro result then survived a
 forced 180-degree landscape change and a complete HOME/foreground
 `surfaceDestroyed`/`surfaceCreated` cycle in the original process, again with
-all three persistence hashes unchanged. General fresh-NAND handling, touch
-parity, and physical-device acceptance remain open.
+all three persistence hashes unchanged. A subsequent clean runtime correction
+keeps Wii's local KD/NCD services available when Internet networking is
+disabled. Two independent fresh redirected-NAND launches then created the
+exact format-valid empty RKSYS and reached the Retro title. From that empty
+state, the Android InputReader/SDL controller path created a KartPad license,
+and a cold production-chooser relaunch displayed the same license with the
+save byte-identical and CRC-valid. Touch parity and physical-device acceptance
+remain open.
 
 The first independent A3 source slice extracted archive member-path validation
 into `runtime/src/retro_rewind/archive_path.cpp`. The existing iOS/tvOS installer

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -32,15 +32,23 @@ covers twelve supported and rejected device states and proves that the ADB
 serial is not emitted; the current host has no attached ADB target, so this
 does not satisfy a physical A2 row.
 
-While that external A2 prerequisite is unavailable, the first independent A3
-source slice extracts archive member-path validation into
-`runtime/src/retro_rewind/archive_path.cpp`. The existing iOS/tvOS installer
+While that external A2 prerequisite is unavailable, A3 has advanced through
+the production installer and its first real dual-runtime gate. The complete
+Original/Retro Rewind graph now links into one Android `libmain.so`; an explicit
+validated Retro Rewind selection reaches its branded title and main menu
+offline on the ARM64 emulator and preserves the save across force-stop/cold
+relaunch without falling back to Original mode. A Retro Rewind race, the
+production mode chooser, general fresh-NAND handling, touch parity, and
+physical-device acceptance remain open.
+
+The first independent A3 source slice extracted archive member-path validation
+into `runtime/src/retro_rewind/archive_path.cpp`. The existing iOS/tvOS installer
 now consumes that byte-oriented contract using minizip's explicit filename
 length, including embedded-NUL rejection. Host tests cover every prohibited
 path class, the pinned NDK compiles it for API-28 ARM64 with warnings as errors,
-and fresh Apple patch preparation succeeds. Android download,
-storage, extraction, activation, rollback, and gameplay remain unimplemented;
-this does not pass A3 or change A2's status.
+and fresh Apple patch preparation succeeds. This historical slice did not pass
+A3 or change A2's status; later sections record the implemented Android
+download, storage, extraction, activation, and rollback pipeline.
 
 The next source-only slice adds `ArchiveScan` beside that validator and wires
 the Apple installer through it. The portable scan rejects invalid paths,
@@ -957,6 +965,20 @@ revalidated the installed 6.12.5 pack offline. This closes official pack
 installation on the emulator, not Retro Rewind gameplay, mode switching, or
 physical-device acceptance. Evidence is in
 `docs/artifacts/2026-09-04/android/a3-production-install.md`.
+
+The first dual-runtime A3 execution gate now passes as well. Android preparation
+normalizes generated Retro blob assembly to ELF section syntax, the dual product
+owns its shared-library output and precompiled header, and Gradle requests only
+the product represented by the prepared graph. The resulting 119,088,910-byte
+APK passes the strict privacy/package audit. With the production-validated pack
+and networking disabled, explicit `retro_rewind` selection reaches the branded
+title and main menu, mounts 4,878 overlays, and preserves the exact save hash
+across a force-stop/cold relaunch without Original-mode fallback. A base-mode
+control reproduced the wiped-NAND system-memory warning, so this bounded proof
+discloses its format-valid empty diagnostic save precondition. It does not prove
+a race, the production chooser, arbitrary fresh-NAND creation, touch/controller
+parity, or a physical device. Evidence is in
+`docs/artifacts/2026-09-04/android/a3-dual-runtime-offline-boot.md`.
 
 Do not begin the touch-UI port until A2's controller-driven Original-mode proof
 passes. Physical Android hardware remains authoritative for vendor Vulkan and

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -50,8 +50,11 @@ records are not represented by the base game's 32-slot RKSYS ghost bitfield,
 which explains the earlier false negative. The new process then surfaced the
 `KartPad 02:31.465` personal card as `1/2`; its Replay path consumed the stored
 stream through the exact `02:31.465` finish while leaving the save, Pulsar
-database, and RKG byte-identical. General fresh-NAND handling, touch parity,
-and physical-device acceptance remain open.
+database, and RKG byte-identical. The same live Retro result then survived a
+forced 180-degree landscape change and a complete HOME/foreground
+`surfaceDestroyed`/`surfaceCreated` cycle in the original process, again with
+all three persistence hashes unchanged. General fresh-NAND handling, touch
+parity, and physical-device acceptance remain open.
 
 The first independent A3 source slice extracted archive member-path validation
 into `runtime/src/retro_rewind/archive_path.cpp`. The existing iOS/tvOS installer

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -47,9 +47,11 @@ production-chooser relaunch. A second feedback-driven run finished in
 earlier `17m13s562.rkg` and updated Baby Park's `ldb.pul`. Those Pulsar files
 survived a force-stop and production-chooser cold relaunch. Retro custom-track
 records are not represented by the base game's 32-slot RKSYS ghost bitfield,
-which explains the earlier false negative. A visible cold replay from the
-personal-ghost browser, general fresh-NAND handling, touch parity, and
-physical-device acceptance remain open.
+which explains the earlier false negative. The new process then surfaced the
+`KartPad 02:31.465` personal card as `1/2`; its Replay path consumed the stored
+stream through the exact `02:31.465` finish while leaving the save, Pulsar
+database, and RKG byte-identical. General fresh-NAND handling, touch parity,
+and physical-device acceptance remain open.
 
 The first independent A3 source slice extracted archive member-path validation
 into `runtime/src/retro_rewind/archive_path.cpp`. The existing iOS/tvOS installer

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -37,9 +37,11 @@ the production installer and its first real dual-runtime gate. The complete
 Original/Retro Rewind graph now links into one Android `libmain.so`; an explicit
 validated Retro Rewind selection reaches its branded title and main menu
 offline on the ARM64 emulator and preserves the save across force-stop/cold
-relaunch without falling back to Original mode. A Retro Rewind race, the
-production mode chooser, general fresh-NAND handling, touch parity, and
-physical-device acceptance remain open.
+relaunch without falling back to Original mode. A production launcher now
+validates the installed pack and presents side-by-side Original/Retro choices
+before SDL starts; both paths reach their distinct titles through the visible
+chooser. A controller-driven Retro Rewind race, general fresh-NAND handling,
+touch parity, and physical-device acceptance remain open.
 
 The first independent A3 source slice extracted archive member-path validation
 into `runtime/src/retro_rewind/archive_path.cpp`. The existing iOS/tvOS installer
@@ -135,32 +137,34 @@ current iOS functionality from the longer-term parity target.
 ## Architecture
 
 ```text
-KartPadActivity : SDLActivity
+KartPadLaunchActivity
++-- validated Original / Retro Rewind chooser
 |
-+-- SDL SurfaceView
-|   `-- Aurora -> Dawn -> Vulkan
-|
-+-- KartPadOverlayView
-|   +-- gameplay touch controls
-|   +-- mode chooser
-|   +-- menus and settings
-|   `-- import/install/status layers
-|
-+-- Android services
-|   +-- Storage Access Framework import
-|   +-- Retro Rewind download/install
-|   +-- sensors and haptics
-|   `-- diagnostics share intent
-|
-`-- JNI / stable mobile-host C ABI
-    `-- libmain.so (arm64-v8a)
-        +-- Original profile
-        +-- Retro Rewind profile
-        +-- WiiCompiled runtime and HLE
-        +-- Android guest memory and fibers
-        +-- SDL audio and controllers
-        +-- Android TLS and BSD sockets
-        `-- Aurora / Dawn Vulkan
+`-- KartPadActivity : SDLActivity
+    |
+    +-- SDL SurfaceView
+    |   `-- Aurora -> Dawn -> Vulkan
+    |
+    +-- KartPadOverlayView
+    |   +-- gameplay touch controls
+    |   +-- menus and settings
+    |   `-- import/install/status layers
+    |
+    +-- Android services
+    |   +-- Storage Access Framework import
+    |   +-- Retro Rewind download/install
+    |   +-- sensors and haptics
+    |   `-- diagnostics share intent
+    |
+    `-- JNI / stable mobile-host C ABI
+        `-- libmain.so (arm64-v8a)
+            +-- Original profile
+            +-- Retro Rewind profile
+            +-- WiiCompiled runtime and HLE
+            +-- Android guest memory and fibers
+            +-- SDL audio and controllers
+            +-- Android TLS and BSD sockets
+            `-- Aurora / Dawn Vulkan
 ```
 
 The current
@@ -180,6 +184,7 @@ every visible application screen.
 Do not introduce a second engine framework or an elaborate Android navigation
 stack. The shell needs only:
 
+- `KartPadLaunchActivity`, the pre-SDL validated mode chooser;
 - `KartPadActivity`, derived from `SDLActivity`;
 - `KartPadOverlayView`, a deterministic Canvas-based overlay;
 - a small state coordinator for setup, menus, and native-runtime readiness;

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -980,6 +980,17 @@ a race, the production chooser, arbitrary fresh-NAND creation, touch/controller
 parity, or a physical device. Evidence is in
 `docs/artifacts/2026-09-04/android/a3-dual-runtime-offline-boot.md`.
 
+The next emulator isolation shows that Retro Rewind's native Replay path can
+execute the official SNES Donut Plains 1 expert through lap 2 and a three-lap
+finish/results presentation. The same RKG still diverges when converted into
+live Classic Controller state, whether the diagnostic base-course metadata
+override is enabled or disabled. The replay result time also does not match the
+official card, so this is execution-path evidence rather than timing or
+controller acceptance. Continue at the Retro Rewind transmission/RKG-to-live-
+input boundary; do not relabel the replay as the controller-driven A3 race.
+Evidence is in
+`docs/artifacts/2026-09-04/android/a3-retro-replay-isolation.md`.
+
 Do not begin the touch-UI port until A2's controller-driven Original-mode proof
 passes. Physical Android hardware remains authoritative for vendor Vulkan and
 controller behavior; Retro Rewind installation and touch parity follow from

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -42,10 +42,14 @@ validates the installed pack and presents side-by-side Original/Retro choices
 before SDL starts; both paths reach their distinct titles through the visible
 chooser. A virtual-controller-driven Retro Rewind Time Trial now reaches its
 ordinary result flow and persists a CRC-valid save mutation across a cold
-production-chooser relaunch. That deliberately slow run did not set a personal
-record or retain a personal ghost, so a faster record/save/reload proof,
-general fresh-NAND handling, touch parity, and physical-device acceptance
-remain open.
+production-chooser relaunch. A second feedback-driven run finished in
+`02:31.465`; Retro Rewind wrote it as a course-scoped `2m31s465.rkg` beside the
+earlier `17m13s562.rkg` and updated Baby Park's `ldb.pul`. Those Pulsar files
+survived a force-stop and production-chooser cold relaunch. Retro custom-track
+records are not represented by the base game's 32-slot RKSYS ghost bitfield,
+which explains the earlier false negative. A visible cold replay from the
+personal-ghost browser, general fresh-NAND handling, touch parity, and
+physical-device acceptance remain open.
 
 The first independent A3 source slice extracted archive member-path validation
 into `runtime/src/retro_rewind/archive_path.cpp`. The existing iOS/tvOS installer

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -40,8 +40,12 @@ offline on the ARM64 emulator and preserves the save across force-stop/cold
 relaunch without falling back to Original mode. A production launcher now
 validates the installed pack and presents side-by-side Original/Retro choices
 before SDL starts; both paths reach their distinct titles through the visible
-chooser. A controller-driven Retro Rewind race, general fresh-NAND handling,
-touch parity, and physical-device acceptance remain open.
+chooser. A virtual-controller-driven Retro Rewind Time Trial now reaches its
+ordinary result flow and persists a CRC-valid save mutation across a cold
+production-chooser relaunch. That deliberately slow run did not set a personal
+record or retain a personal ghost, so a faster record/save/reload proof,
+general fresh-NAND handling, touch parity, and physical-device acceptance
+remain open.
 
 The first independent A3 source slice extracted archive member-path validation
 into `runtime/src/retro_rewind/archive_path.cpp`. The existing iOS/tvOS installer

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2705,3 +2705,32 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   switching, physical hardware, and release acceptance remain open. No APK,
   AAB, or private input was published. Evidence:
   `docs/artifacts/2026-09-04/android/a3-retro-replay-isolation.md`.
+
+## 2026-09-04 — Android A3 Retro fixture simulator controls
+
+- Selected the official `ExpertsRT/10_150.rkg` card on the API 36 ARM64
+  emulator: Koopa Troopa, Cheep Charger, Manual, Classic Controller, course ID
+  16, 6,578 frames, and `01:45.736`. Because Cheep Charger is a kart, the
+  selected Outside transmission is a no-op matching the RKG default.
+- With metadata forcing disabled, the stage-1 fixture initially followed the
+  course but diverged near the fence around 21 seconds and was stationary by
+  about 35 seconds. This falsifies the remaining transmission explanation.
+- An experimental native build delayed input consumption until RaceManager
+  stage 2. Its transcript confirmed the changed boundary, but the same kart
+  diverged into water at about `00:07.383`, earlier than the control. The
+  one-line change was reverted; the observed 238-row trace offset represents
+  countdown samples rather than proven fixture-frame lead.
+- A subsequent oracle setup accidentally used the wrong Android debug-extra
+  name and launched the base profile. Its save-country recovery attempt left
+  the synthetic emulator save unusable; preserved copies and the pre-existing
+  Retro save were not deleted. This invalidates the current emulator save as a
+  continuation precondition but does not alter earlier committed evidence.
+- Restored the source behavior, rebuilt the dual ARM64 APK, and passed the
+  strict package/privacy audit at SHA-256
+  `44b485b9e0a6c2dcc0292777d32e81116981462881e14aa3ead739b5f1e386b1`.
+  That clean local APK was installed and the RKG/state-trace diagnostics were
+  removed; it was not launched against the now-invalid save.
+- Classification: **Fail for both proposed fixture causes; useful narrowing.**
+  Metadata forcing, transmission choice, and the stage-2 start theory are now
+  ruled out. A real controller race and a clean simulator save precondition
+  remain open. No APK, AAB, RKG, disc, save, or pack was published.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2877,3 +2877,27 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   controller-driven record/save/reload proof remains open. The emulator was
   left running visibly in Retro Rewind; no private save or binary was
   published.
+
+## 2026-09-04 — Android A3 Retro Rewind save-diff and fast-fixture rejection
+
+- Recovered the retained ignored pre-race save directly from the emulator and
+  verified its full SHA-256 is the recorded `3c4aeacd...`. It differs from the
+  cold-loaded `7279ad4d...` post-race save by only 12 bytes: ordinary
+  race/statistic updates within the initialized license plus the core CRC.
+  Neither leaderboard data nor a personal-ghost bit/payload changed.
+- Identified Retro Rewind's zero-based track map and inspected its Baby Park
+  expert RKGs structurally. The primary `01:15.379` stream requires Peach,
+  Mach Bike, Manual and 4,759 frames; the alternate `01:26.822` stream requires
+  Mario, Standard Kart M, Manual and 5,445 frames.
+- Ran the matching primary metadata visibly through the existing ignored debug
+  input boundary, selecting Peach, Mach Bike and Baby Park on-screen. Both
+  Retro-specific Inside and Outside transmission variants consumed the full
+  stream but diverged and remained at race stage 2. The alternate stream also
+  diverged. No finish was forced and the save stayed byte-identical at
+  `7279ad4d...`.
+- Classification: **Rejected diagnostic, with useful narrowing.** Packaged
+  ghost playback cannot stand in for a fast live-player record on this build.
+  The next record/save/reload attempt must use ordinary controller steering or
+  first diagnose the offline replay-to-live-player divergence. All temporary
+  RKG and trace markers were removed, and the visible emulator was left at the
+  clean production chooser.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2828,3 +2828,29 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   selection.** Controller-driven Retro race/save, trustworthy timing, physical
   controller/audio/rumble, hardware, and release acceptance remain open. No
   private input or binary was committed or published.
+
+## 2026-09-04 — Android A3 Retro Rewind controller race/save
+
+- Registered an ignored Xbox-compatible virtual controller through Android's
+  normal `uinput`/InputReader path, selected the production Retro Rewind
+  profile, and used controller input for title/license/menu navigation and all
+  live race acceleration/steering.
+- Rejected blind long steering intervals after they repeatedly left a narrow
+  lava course. Selected GCN Baby Park and replaced them with a content-free
+  state-trace feedback loop that emitted only ordinary analog controller
+  events. It completed the live Time Trial at finish stage 4; results reported
+  `17:13.562`, best lap `00:19.742`, and ghost creation.
+- The controller's explicit one-hour registration expired mid-race. The
+  runtime logged channel-zero disconnect/reconnect and completed the same race
+  after reattachment, with no fatal signature.
+- Advancing results changed the isolated Retro save from SHA-256 `3c4aeacd...`
+  to `7279ad4d...`. A force-stop and production-chooser cold relaunch as a new
+  process retained the exact post-results hash, reconnected the controller,
+  reached the branded title, and accepted navigation back to Baby Park.
+- Classification: **Pass for controller-driven Retro emulator gameplay,
+  race/results, save mutation, and byte-stable controller-attached cold
+  relaunch.** The deliberately slow record did not replace the faster bundled
+  selectable ghost, so visible new-record reload, trustworthy timing, physical
+  controller/audio/rumble, physical hardware, and release acceptance remain
+  open. No APK, AAB, private input, save, trace, console, or screenshot was
+  published.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2800,3 +2800,31 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   timing, production mode selection, physical controller/audio/rumble,
   physical hardware, and release acceptance remain open. No private input or
   binary was committed or published.
+
+## 2026-09-04 — Android A3 production mode chooser
+
+- Replaced normal reliance on the debug runtime-profile extra with a
+  production launcher that validates Retro Rewind before SDL starts and shows
+  side-by-side Original and Retro choices. The first vertical render put Retro
+  below the fold and was rejected; the compact layout shows both choices at
+  the emulator's landscape phone density.
+- Selecting the preserved valid install through the visible chooser reached
+  the branded Retro title beyond 30 seconds. A cold chooser launch then
+  selected Original and reached its title beyond 30 seconds. The production
+  profile logs were distinct, both save hashes stayed exact, and no new
+  missing-target record appeared.
+- A landscape flip recreated the chooser with both controls restored. A
+  debug-only missing-install control showed the download state and routed to
+  the production installer without moving or deleting the installed pack.
+- Made the SDL activity private in the release manifest while retaining
+  `DUMP`-protected shell access in debug builds. Android lint also exposed and
+  fixed an existing API-28-incompatible `Stream.toList()` call in a debug
+  install fixture.
+- Full dual-profile build, lint, release-manifest merge, content/storage/
+  pipeline/worker contracts, and strict package/privacy audit pass for the
+  local-only APK at SHA-256
+  `7088f683c9cc765c77a12203646af6d9ecdb13f1eb77f559b4bfdbc75e1caf94`.
+- Classification: **Pass for the production chooser and bounded emulator mode
+  selection.** Controller-driven Retro race/save, trustworthy timing, physical
+  controller/audio/rumble, hardware, and release acceptance remain open. No
+  private input or binary was committed or published.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2638,3 +2638,40 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   offline pack revalidation on the ARM64 emulator.** Gameplay/mode switching,
   physical acceptance, and publishing remain open. Evidence:
   `docs/artifacts/2026-09-04/android/a3-production-install.md`.
+
+## 2026-09-04 — Android A3 dual-runtime offline boot
+
+- Regenerated the full private dual translation graph and drove it through the
+  real Android build. The first builds exposed three integration defects:
+  Gradle tried to build standalone products, Android `KartPadDual` inherited a
+  standalone-base dependency through PCH reuse, and generated Retro blob
+  assembly used Windows-only section syntax.
+- Android now selects exactly `WiiCompiled` or `KartPadDual` from the prepared
+  graph, builds the dual product as the sole `libmain.so` with its own PCH, and
+  normalizes copied Retro `.S` inputs to an ELF read-only data section without
+  mutating private generated sources.
+- A fresh patch preparation and complete dual build pass. The strict audit
+  accepts the 119,088,910-byte APK at SHA-256
+  `d1490d5b6d9ed38012a5793e609c6c05dd4d26c1704abad9d6e423cac43867c9`
+  and finds only SDL, libc++, and `libmain.so` native libraries with no private
+  data or local-path leakage.
+- The preserved 6 GiB emulator data filesystem had only about 2.3 GiB free, so
+  the roughly 1.9 GiB validated pack and 2.5 GiB disc could not coexist. After
+  a recoverable overlay backup, the disposable AVD was expanded/wiped to a
+  10 GiB filesystem and retained about 3.8 GiB free after staging.
+- With airplane mode enabled, explicit validated `retro_rewind` selection
+  activated the Retro profile, mounted 4,878 overlays, emitted Vulkan/audio
+  evidence, and reached the branded title and main menu without base fallback.
+  A format-valid empty diagnostic save was used only after both base and Retro
+  controls reproduced the wiped-NAND system-memory warning.
+- Retro Rewind created a KartPad license. Its real save hash remained exactly
+  `9c451f517267b800a7100bcf3f7445917ddca2361dc7deb1d184f76086600604`
+  across force-stop/airplane-mode cold relaunch, which again reached the Retro
+  main menu. Source contracts, generated link test, shell syntax, package
+  audit, and diff checks pass.
+- Classification: **Pass for Android dual linking and an explicit validated
+  Retro Rewind 6.12.5 offline title/menu boot with save-preserving cold
+  relaunch.** A race, production chooser, general fresh-NAND creation, touch
+  parity, physical hardware, and release acceptance remain open. No private
+  input, APK, or AAB was committed or published. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-dual-runtime-offline-boot.md`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2901,3 +2901,29 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   first diagnose the offline replay-to-live-player divergence. All temporary
   RKG and trace markers were removed, and the visible emulator was left at the
   clean production chooser.
+
+## 2026-09-04 — Android A3 Retro Rewind fast live record and storage correction
+
+- Returned to the visible API 36 ARM64 emulator and drove GCN Baby Park with
+  the Android InputReader-visible virtual Xbox controller. A revised bounded
+  feedback driver completed the live run at finish stage 4 in `02:31.465`, with
+  three valid recorded lap splits and no guest-memory or finish-state writes.
+- The result flow displayed `A ghost has been created for KartPad!` and placed
+  `02:31.465` ahead of the prior `17:13.562` result. Advancing results changed
+  the redirected RKSYS from `7279ad4d...` to CRC-valid `9c6c7b52...`; its 11
+  changed bytes were still ordinary statistics plus the core CRC, with a zero
+  base-game personal-ghost bitfield.
+- Corrected the interpretation by inspecting Retro Rewind's Pulsar storage.
+  Course key `d6cac6a4` identifies GCN Baby Park, and its separate custom-track
+  database now contains `150/2m31s465.rkg` beside the earlier retained
+  `150/17m13s562.rkg`. The updated 4,544-byte `ldb.pul` names GCN Baby Park.
+  These files survived force-stop and a new process launched through the
+  production chooser; the base game's 32-slot RKSYS fields are not the source
+  of truth for Retro's expanded course set.
+- Classification: **Pass for repeatable ordinary-controller completion and
+  durable Retro custom-track ghost storage across cold relaunch.** A fully
+  visible cold selection/replay of the personal ghost remains open, as do
+  trustworthy timing, physical controller/audio/rumble, physical hardware,
+  and release acceptance. The emulator was left visibly running at the clean
+  production chooser; no APK, AAB, game data, save, trace, or screenshot was
+  published.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2946,3 +2946,21 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   trustworthy timing, audio/rumble quality, and release acceptance remain
   open. No APK, AAB, game data, save, trace, console, or screenshot was
   published.
+
+## 2026-09-04 — Android A3 Retro runtime lifecycle
+
+- With the cold personal replay result still visible, forced the emulator from
+  rotation 0 to rotation 180. Android delivered `surfaceChanged`, rendering
+  remained intact, and the game process retained PID 12558.
+- Sent HOME and observed `onPause`, `surfaceDestroyed`, and `onStop`. Bringing
+  the existing singleTask forward was a hot task resume, not a new launch; it
+  delivered `onStart`, `onResume`, `surfaceCreated`, and `surfaceChanged`, and
+  restored the exact Retro result screen in the same PID.
+- Restored the emulator to automatic rotation 0. RKSYS, Baby Park `ldb.pul`,
+  and `2m31s465.rkg` remained byte-identical at `9c6c7b52...`, `638186a6...`,
+  and `1858e595...`, and PID-scoped logcat contained no fatal signature.
+- Classification: **Pass for Retro runtime landscape rotation and full
+  background/foreground surface recreation on the emulator.** This is not
+  physical-device, physical-controller, audio/rumble-quality, performance, or
+  release acceptance. No APK, AAB, game data, save, log, or screenshot was
+  published.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2997,3 +2997,29 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   running at the clean Retro title; no private data or application package was
   published. Evidence:
   `docs/artifacts/2026-09-04/android/a3-fresh-save-offline-kd.md`.
+
+## 2026-09-04 — Android A3 first license from clean save
+
+- Continued on the unchanged clean APK with the standalone emulator still
+  visible. Registered the temporary Xbox-compatible `/dev/uinput` device;
+  Android InputReader exposed it as `/dev/input/event12` with keyboard,
+  gamepad, joystick, external, and Xbox-layout classification.
+- Preserved the exact active Retro save app-privately and substituted the
+  exact game-created empty RKSYS from the fresh-save pass. Ordinary controller
+  input advanced through the title, first `NEW` slot, creation confirmation,
+  KartPad Mii selection, and final `Your new license is ready` screen.
+- The created 2,867,200-byte save changed to SHA-256
+  `4b83dc4a02dd351d1e594b1c9c13ecd7530e6c80520957d4c576c46c88b0972d`.
+  Read-only inspection validated its `RKSD0006` header, slot-zero `RKPD`, and
+  exact stored/calculated core CRC-32 `21a244ff`.
+- After force-stop and production-chooser cold relaunch, the save remained
+  byte-identical and the first license card visibly displayed the KartPad Mii
+  and name. The test-created state was retained only in ignored app-private
+  storage, the original Retro save was restored to exact SHA-256 `9c6c7b52...`,
+  and a final clean Retro launch reached the title.
+- Classification: **Pass for controller-driven first license creation and
+  byte-stable cold license reload from a clean emulator save.** This is not
+  physical-controller/device, audio/rumble, performance, or release evidence.
+  The emulator was left visibly running; no application package, save, private
+  input, or screenshot was published. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-fresh-save-offline-kd.md`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2675,3 +2675,33 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   parity, physical hardware, and release acceptance remain open. No private
   input, APK, or AAB was committed or published. Evidence:
   `docs/artifacts/2026-09-04/android/a3-dual-runtime-offline-boot.md`.
+
+## 2026-09-04 — Android A3 Retro replay isolation
+
+- Reused the validated offline 6.12.5 pack on the API 36 ARM64 emulator and
+  manually matched the official SNES Donut Plains 1 expert's Mario,
+  Sneakster, and Manual metadata.
+- Added a temporary debug launch switch that disabled the existing base-course
+  RKG metadata writes. The live-controller fixture retained its expected
+  238-frame synchronization offset but again entered the barrier/off-road
+  failure around `00:19.380`; the switch was removed after it falsified the
+  metadata-overwrite hypothesis.
+- Renamed the diagnostic input out of its recognized path, cold-started Retro
+  Rewind, and selected its native Replay path for the same official card. It
+  followed the expanded course, crossed into lap 2, and reached the three-lap
+  finish/results presentation without an Android fatal record. The result was
+  `00:57.691`, not the card's `01:34.086`, so no timing-fidelity claim is made.
+- The KartPad save changed from the prior accepted cold-relaunch SHA-256
+  `9c451f517267b800a7100bcf3f7445917ddca2361dc7deb1d184f76086600604`
+  to `c5496e08dceab593a787b1363b2a4ce756313cebd768ab2d0d814c99db931383`
+  after results. After diagnostic cleanup and installation of the clean rebuilt
+  APK, a force-stop/cold launch returned to the branded Retro title and retained
+  that exact changed hash.
+- Classification: **Partial pass for native Retro Rewind expanded-course replay
+  and results on the Android emulator; fail for using the live-controller RKG
+  fixture as A3 race proof.** The metadata override is ruled out. The remaining
+  boundary is most likely Retro Rewind transmission/RKG input semantics, but a
+  controller-driven race, trustworthy timing, its save/relaunch, mode
+  switching, physical hardware, and release acceptance remain open. No APK,
+  AAB, or private input was published. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-retro-replay-isolation.md`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2854,3 +2854,26 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   controller/audio/rumble, physical hardware, and release acceptance remain
   open. No APK, AAB, private input, save, trace, console, or screenshot was
   published.
+
+## 2026-09-04 — Android A3 Retro Rewind cold record inspection
+
+- Repeated the cold-relaunch test visibly in the API 36 ARM64 emulator with
+  the Android-recognized virtual Xbox controller attached. A direct launch of
+  the private SDL activity first selected `base` by design and was rejected as
+  a test-harness error; the corrected production launcher showed both choices,
+  selected validated Retro Rewind, and reached its branded title as new PID
+  7904.
+- Controller navigation returned to the course ghost screen after the true
+  production-path cold launch. It still showed only `1/1`, with a faster
+  packaged Rewind ghost rather than the completed `17:13.562` run.
+- Pulled the exact cold-loaded save read-only. It remained 2,867,200 bytes at
+  SHA-256 `7279ad4d...`, had valid `RKSD0006` and `RKPD` structures, and its
+  stored core CRC-32 exactly matched a fresh calculation. The only initialized
+  license had personal-ghost bitfield `0x00000000` and no nonzero primary Time
+  Trial leaderboard timer.
+- Classification: **Correction and narrowed pass.** The prior race/results,
+  save mutation, and byte-stable cold persistence remain valid, but the slow
+  result did not create a retained personal record/ghost. A faster
+  controller-driven record/save/reload proof remains open. The emulator was
+  left running visibly in Retro Rewind; no private save or binary was
+  published.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2756,3 +2756,22 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   title. No APK, AAB, save, disc, RKG, or pack was published.
 - Classification: **Pass for simulator-state recovery and root-boundary
   isolation; general fresh Retro save creation remains open.**
+
+## 2026-09-04 — Android A3 save-precondition correction
+
+- Revalidated the prior save-precondition diagnosis rather than building on a
+  single process exit. Temporary content-free telemetry around Mii-library
+  allocations showed heap `0x9011299c`, vtable `0x802a2ff8`, a 417,568-byte
+  first allocation, and two 6,400-byte allocations without corruption.
+- With the Retro redirect absent, the runtime populated it from the valid empty
+  base save and reached the branded title. After removing the telemetry and
+  rebuilding the exact clean APK at the prior audited SHA-256, the same empty
+  save remained alive beyond 55 seconds. Removing only the leaderboard also
+  stayed alive.
+- Six subsequent identical clean force-stop/cold-launch cycles all remained
+  alive after 22 seconds. The preserved original Retro save and leaderboard
+  were restored afterward and the title again stayed live.
+- Classification: **Correction.** The earlier exits are not reproducible and
+  do not prove a missing-save, settings, leaderboard, or Mii-manager defect.
+  Full first-run license creation remains open. No private file or diagnostic
+  APK was committed or published.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2927,3 +2927,22 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   and release acceptance. The emulator was left visibly running at the clean
   production chooser; no APK, AAB, game data, save, trace, or screenshot was
   published.
+
+## 2026-09-04 — Android A3 Retro Rewind cold personal replay
+
+- From the clean production chooser, selected Retro Rewind and navigated with
+  the Android InputReader-visible controller to 150cc Time Trials, GCN Baby
+  Park. The fresh process displayed the persisted `KartPad 02:31.465` personal
+  card as `1/2`, correcting the earlier wrong-course `1/1` observation.
+- Selected the card's Replay action. The cold-loaded stream visibly advanced
+  around Baby Park and reached the exact `02:31.465` result with its original
+  `00:35.374`, `00:30.012`, and `00:26.009` recorded splits. No live steering
+  driver or debug RKG fixture was present.
+- After replay, RKSYS remained `9c6c7b52...`, Baby Park `ldb.pul` remained
+  `638186a6...`, and `2m31s465.rkg` remained `1858e595...`. The new-process
+  console SHA-256 was `8f456db1...` and contained no fatal signature.
+- Classification: **Pass for visible production-path cold personal-ghost
+  selection and full replay on the emulator.** Physical controller/device,
+  trustworthy timing, audio/rumble quality, and release acceptance remain
+  open. No APK, AAB, game data, save, trace, console, or screenshot was
+  published.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2734,3 +2734,25 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   Metadata forcing, transmission choice, and the stage-2 start theory are now
   ruled out. A real controller race and a clean simulator save precondition
   remain open. No APK, AAB, RKG, disc, save, or pack was published.
+
+## 2026-09-04 — Android A3 Retro save-precondition recovery
+
+- Instrumented the API 36 ARM64 emulator after the diagnostic save-country
+  setup. With the Retro `rksys.dat` absent, translated Mii initialization failed
+  before the runtime received a `NANDCreate` call. A format-valid empty save
+  that boots Original mode also failed in Retro after the branded title.
+- Isolated the adjacent Retro state. Removing the leaderboard and regenerating
+  `RRGameSettings.pul` did not fix the empty-save launch. The old and fresh
+  settings differed only at `MiscParams.lastSelectedCup` (`0x42` versus
+  `0xffffffff`), and both failed against the empty save.
+- Restoring the preserved original Retro save, settings, and leaderboard as a
+  coherent trio remained alive beyond 50 seconds and reached the branded
+  title. This separates the damaged diagnostic precondition from the earlier
+  live-player replay divergence.
+- Removed the temporary NAND logging, rebuilt the clean dual ARM64 APK, passed
+  the strict package/privacy audit at SHA-256
+  `340c33f207a651cb2be0f01cc7663dca64a946adfd7e2f033ae4882f5e4b807e`,
+  installed it locally, and cold-launched the restored Retro state to the
+  title. No APK, AAB, save, disc, RKG, or pack was published.
+- Classification: **Pass for simulator-state recovery and root-boundary
+  isolation; general fresh Retro save creation remains open.**

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2775,3 +2775,28 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   do not prove a missing-save, settings, leaderboard, or Mii-manager defect.
   Full first-run license creation remains open. No private file or diagnostic
   APK was committed or published.
+
+## 2026-09-04 — Android A3 RFL alarm context isolation
+
+- Explicit Original to Retro Rewind to Original switching reproduced the
+  intermittent Mii initialization exit once across eight observed pre-fix
+  Original launches: six base-only controls and two within the switch sequence.
+  The private crash record showed r30 changed from the
+  expected guest heap pointer to a callback result before the second allocation.
+- Root cause was RFL alarm polling executing guest callbacks against the live
+  translated caller register file. The override now uses a private interrupt
+  context and suppresses guest scheduler switching only while pumping the
+  bounded alarm queue.
+- Ten of ten patched Original cold launches remained alive after 28 seconds. A
+  subsequent visible-emulator Original/Retro/Original sequence passed beyond
+  35/35/40 seconds, retained both exact save hashes, and produced no new
+  missing-target record.
+- Fresh Android preparation reproduced the source, the affected Apple arm64
+  runtime object compiled, and the strict package/privacy audit passed for the
+  local-only APK at SHA-256
+  `2ba4b4acf7a395c3d810ff81c0327ad15f9bfbbcbcd76da026ec37444ff7b7d2`.
+- Classification: **Pass for the diagnosed callback corruption and bounded
+  emulator mode switch.** Controller-driven Retro race/save, trustworthy
+  timing, production mode selection, physical controller/audio/rumble,
+  physical hardware, and release acceptance remain open. No private input or
+  binary was committed or published.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -2964,3 +2964,36 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   physical-device, physical-controller, audio/rumble-quality, performance, or
   release acceptance. No APK, AAB, game data, save, log, or screenshot was
   published.
+
+## 2026-09-04 — Android A3 fresh offline save initialization
+
+- Reproduced the clean redirected-NAND failure visibly on the standalone API
+  36 ARM64 emulator. Retro created a correctly sized but all-zero RKSYS and
+  reported that Wii system memory could not be written or read.
+- Narrow instrumentation showed that file creation/preallocation succeeded,
+  while the following virtual-device open failed after two `-42` operations.
+  The offline preference was rejecting all `/dev/net/*` devices before
+  classification, including local Wii KD request/time and NCD services needed
+  by first-run save initialization.
+- Added a common runtime patch that keeps those KD/NCD services available when
+  online networking is disabled while preserving the offline gate for IP and
+  SSL. Also retained an Android NAND semantic correction that removes the
+  unrelated create-on-open fallback. All temporary tracing was removed.
+- A fully fresh runtime preparation and clean Android build passed. The local
+  APK SHA-256 is
+  `262d821e6b2b769872df50e48e16a36b8c636b528bc9c1d03a17ae37624baaa7`,
+  its package/privacy audit passed, and its native library has no save-trace
+  markers.
+- Two independent fresh redirected-NAND cold launches visibly reached the
+  Retro Rewind title and generated the exact known-valid 2,867,200-byte empty
+  RKSYS at SHA-256
+  `708c7a040e0cfe6cd815690e63f46d1678f17899bce0e786f7480030830f1d13`.
+  Cold relaunch passed. The original base and Retro saves were restored and
+  retained their exact pre-test hashes after a final launch.
+- Classification: **Pass for fresh offline Retro system-memory creation and
+  cold title relaunch on the emulator.** Controller-driven new-license
+  creation, physical hardware/controller, audio/rumble quality, performance,
+  and release acceptance remain open. The standalone emulator was left visibly
+  running at the clean Retro title; no private data or application package was
+  published. Evidence:
+  `docs/artifacts/2026-09-04/android/a3-fresh-save-offline-kd.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -549,13 +549,25 @@ inspection of the exact cold-loaded, CRC-valid save found a zero personal-ghost
 bitfield and no Time Trial leaderboard timer in its only initialized license.
 The retained exact pre-race save was then recovered read-only from the emulator:
 the pre/post files differ by only 12 bytes, confined to ordinary race/statistic
-fields plus the core CRC, with no leaderboard or ghost payload change. The slow
-run therefore did not create a retained personal record/ghost. Both variants of
-a matching packaged Baby Park RKG were rejected after visible live-player runs
-diverged and remained at race stage 2; neither changed the save. A
-faster record/save/reload proof remains open alongside
-trustworthy timing, physical controller/audio/rumble, physical hardware, and
-release acceptance. Evidence:
+fields plus the core CRC, with no leaderboard or ghost payload change. Both
+variants of a matching packaged Baby Park RKG were rejected after visible
+live-player runs diverged and remained at race stage 2; neither changed the
+save.
+
+A subsequent ordinary-controller feedback run finished Baby Park in
+`02:31.465`, with three recorded lap splits and native finish stage 4. The game
+reported ghost creation and showed the new result ahead of `17:13.562` in the
+same-session leaderboard. Advancing results changed RKSYS from `7279ad4d...`
+to CRC-valid `9c6c7b52...`, again only in ordinary statistics and the core CRC.
+Inspection of Retro's actual custom-track storage corrected the earlier RKSYS-
+only conclusion: Baby Park is stored under Pulsar course key `d6cac6a4`, whose
+`ldb.pul` and `150/2m31s465.rkg` were written beside the already-retained
+`150/17m13s562.rkg`. All three survived force-stop and a new production-chooser
+process. The base game's 32-bit RKSYS personal-ghost field does not describe
+Retro Rewind's expanded course set. This closes durable custom-track record
+storage on the emulator; a visible cold personal-replay selection still remains
+open alongside trustworthy timing, physical controller/audio/rumble, physical
+hardware, and release acceptance. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-retro-controller-race-save.md`](artifacts/2026-09-04/android/a3-retro-controller-race-save.md).
 
 ## Native tvOS work

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -547,7 +547,12 @@ the production chooser again selected Retro, reached the branded title, and
 returned to the course ghost screen. It still showed only `1/1`; read-only
 inspection of the exact cold-loaded, CRC-valid save found a zero personal-ghost
 bitfield and no Time Trial leaderboard timer in its only initialized license.
-The slow run therefore did not create a retained personal record/ghost; a
+The retained exact pre-race save was then recovered read-only from the emulator:
+the pre/post files differ by only 12 bytes, confined to ordinary race/statistic
+fields plus the core CRC, with no leaderboard or ghost payload change. The slow
+run therefore did not create a retained personal record/ghost. Both variants of
+a matching packaged Baby Park RKG were rejected after visible live-player runs
+diverged and remained at race stage 2; neither changed the save. A
 faster record/save/reload proof remains open alongside
 trustworthy timing, physical controller/audio/rumble, physical hardware, and
 release acceptance. Evidence:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -495,6 +495,23 @@ than a proven save/settings defect. Full first-run license creation is still
 open, and the controller-race fixture conclusion is unchanged. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-retro-replay-isolation.md`](artifacts/2026-09-04/android/a3-retro-replay-isolation.md).
 
+The disclosed format-valid empty-save precondition is now removed for the
+fresh Retro emulator path. With `[network] enabled = false`, the runtime had
+incorrectly rejected every `/dev/net/*` device before classification, including
+the local Wii KD request/time and NCD services required during first-run
+system-memory initialization. The common runtime patch now leaves those local
+services available offline while continuing to gate only IP and SSL devices.
+Two independent fresh redirected-NAND launches visibly reached the Retro
+Rewind title and each created the exact 2,867,200-byte format-valid empty RKSYS
+with SHA-256 `708c7a040e0cfe6cd815690e63f46d1678f17899bce0e786f7480030830f1d13`;
+a cold relaunch also passed. The clean local APK passed package/privacy audit,
+and the original emulator saves were restored with exact hashes after the
+test. This closes fresh offline Retro system-memory creation on the API 36
+ARM64 emulator, not controller-driven first license creation, physical
+hardware/controller, audio/rumble quality, performance, or release acceptance.
+Evidence:
+[`docs/artifacts/2026-09-04/android/a3-fresh-save-offline-kd.md`](artifacts/2026-09-04/android/a3-fresh-save-offline-kd.md).
+
 Explicit Original to Retro Rewind to Original switching then reproduced the
 previously intermittent Mii exit once across eight observed pre-fix Original
 launches (six base-only controls and two within the switch sequence). The crash

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -484,15 +484,15 @@ reverted. The remaining fault is still within the diagnostic RKG/player-state
 boundary; a controller-driven race remains open. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-retro-replay-isolation.md`](artifacts/2026-09-04/android/a3-retro-replay-isolation.md).
 
-The simulator save damaged by the later save-country diagnostic is now
-isolated and recovered. Retro fails during translated Mii initialization when
-its redirected save is absent, before any `NANDCreate`, and an
-Original-compatible empty `rksys.dat` still fails after the Retro title even
-with a regenerated settings file and no leaderboard. Restoring the preserved
-Retro save, settings, and leaderboard as one coherent set stays alive beyond
-50 seconds and reaches the branded title under the clean audited APK. This
-keeps the replay-fixture finding valid while leaving general fresh Retro save
-creation open. Evidence:
+The later simulator save-precondition diagnosis was revalidated and corrected.
+Guest-address-only instrumentation showed valid Mii-library heap allocations;
+with the redirected save absent, Retro populated it from the format-valid
+empty base save and reached the branded title. The exact clean build then
+remained alive with that byte-identical empty save and no leaderboard, followed
+by six of six identical cold-launch passes. Removing the leaderboard alone also
+did not reproduce the earlier exit. Those exits are transient evidence rather
+than a proven save/settings defect. Full first-run license creation is still
+open, and the controller-race fixture conclusion is unchanged. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-retro-replay-isolation.md`](artifacts/2026-09-04/android/a3-retro-replay-isolation.md).
 
 ## Native tvOS work

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -476,9 +476,12 @@ through KartPad's diagnostic live-controller bridge still diverges around 19
 seconds even when the base-course metadata override is disabled, so that
 override is ruled out and the fixture is not valid A3 acceptance. The replay's
 displayed result also differs from the official card time, so timing fidelity
-is not claimed. This narrows the remaining problem to the diagnostic
-RKG/live-controller boundary, most likely Retro Rewind transmission semantics;
-a controller-driven race remains open. Evidence:
+is not claimed. A second exact kart/default-transmission card diverged too,
+ruling out Retro Rewind's Inside/Outside bike choice. Delaying fixture
+consumption from countdown stage 1 to race stage 2 made divergence earlier
+(`00:07.383` versus roughly 21 seconds), so that experimental timing change was
+reverted. The remaining fault is still within the diagnostic RKG/player-state
+boundary; a controller-driven race remains open. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-retro-replay-isolation.md`](artifacts/2026-09-04/android/a3-retro-replay-isolation.md).
 
 ## Native tvOS work

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -513,6 +513,23 @@ not the production chooser, controller-driven Retro race/save, trustworthy
 timing, physical controller/audio/rumble, hardware, or release gates. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-rfl-alarm-context.md`](artifacts/2026-09-04/android/a3-rfl-alarm-context.md).
 
+Android now has a production-owned pre-SDL mode chooser. It validates the
+pinned Retro Rewind installation off the UI thread, presents Original and
+Retro choices together at landscape phone density, routes an unavailable
+Retro choice to the existing installer, and passes activity recreation after
+a landscape flip. The exact audited APK selected Retro without a debug extra,
+reached its branded title beyond 30 seconds, then cold-selected Original and
+reached its distinct title beyond 30 seconds. Both saves retained their exact
+hashes and no new missing-target record appeared. The production manifest
+exports only the chooser; the SDL activity is private, with protected shell
+access retained only in debug builds. Build, lint, four installer contracts,
+release-manifest merge, and package/privacy audit pass for local APK SHA-256
+`7088f683c9cc765c77a12203646af6d9ecdb13f1eb77f559b4bfdbc75e1caf94`.
+This closes the emulator production-chooser/mode-selection slice, not the
+controller-driven Retro race/save, timing, physical controller/audio/rumble,
+hardware, or release gates. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-production-mode-chooser.md`](artifacts/2026-09-04/android/a3-production-mode-chooser.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -495,6 +495,24 @@ than a proven save/settings defect. Full first-run license creation is still
 open, and the controller-race fixture conclusion is unchanged. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-retro-replay-isolation.md`](artifacts/2026-09-04/android/a3-retro-replay-isolation.md).
 
+Explicit Original to Retro Rewind to Original switching then reproduced the
+previously intermittent Mii exit once across eight observed pre-fix Original
+launches (six base-only controls and two within the switch sequence). The crash
+record showed an alarm callback had overwritten the
+interrupted translated caller's callee-saved r30 heap pointer. RFL alarm
+polling now runs callbacks against a private interrupt register context while
+briefly suppressing guest scheduler switching. The patched build passed ten of
+ten Original cold launches and a visible-emulator Original/Retro/Original
+sequence; the final Original process continued through the title attract
+sequence, both saves retained their exact hashes, and no new missing-target
+record appeared. Fresh patch reproduction, Apple arm64 compilation, and the
+strict package/privacy audit pass for local APK SHA-256
+`2ba4b4acf7a395c3d810ff81c0327ad15f9bfbbcbcd76da026ec37444ff7b7d2`.
+This closes the reproduced callback corruption and bounded emulator switch,
+not the production chooser, controller-driven Retro race/save, trustworthy
+timing, physical controller/audio/rumble, hardware, or release gates. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-rfl-alarm-context.md`](artifacts/2026-09-04/android/a3-rfl-alarm-context.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -542,8 +542,13 @@ accepted controller navigation back to Baby Park. The temporary controller's
 explicit one-hour registration expired mid-race; the runtime recorded an
 ordinary disconnect/reconnect and the same live race completed afterward.
 This closes the emulator controller gameplay, race/results, save mutation, and
-byte-stable cold-relaunch slice. The slow new ghost did not replace the faster
-bundled selectable ghost, so visible new-record reload remains open alongside
+byte-stable cold-relaunch slice. A second visible force-stop/relaunch through
+the production chooser again selected Retro, reached the branded title, and
+returned to the course ghost screen. It still showed only `1/1`; read-only
+inspection of the exact cold-loaded, CRC-valid save found a zero personal-ghost
+bitfield and no Time Trial leaderboard timer in its only initialized license.
+The slow run therefore did not create a retained personal record/ghost; a
+faster record/save/reload proof remains open alongside
 trustworthy timing, physical controller/audio/rumble, physical hardware, and
 release acceptance. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-retro-controller-race-save.md`](artifacts/2026-09-04/android/a3-retro-controller-race-save.md).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -570,7 +570,12 @@ Baby Park, displayed `KartPad 02:31.465` as personal card `1/2`, selected
 Replay, and reached the exact `02:31.465` result with the original three lap
 splits. The save, Pulsar database, and RKG retained their exact pre-replay
 hashes, and the new-process console had no fatal signature. This also closes
-visible cold personal-ghost reload/replay on the emulator. Trustworthy timing,
+visible cold personal-ghost reload/replay on the emulator. The same PID then
+survived a forced 180-degree landscape change and a HOME/foreground cycle that
+logged `onPause`, `surfaceDestroyed`, `onStop`, followed by `onStart`,
+`onResume`, and `surfaceCreated`; rendering returned to the intact result and
+all three persistence hashes remained exact. This closes Retro runtime
+rotation/background surface recreation on the emulator. Trustworthy timing,
 physical controller/audio/rumble, physical hardware, and release acceptance
 remain open. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-retro-controller-race-save.md`](artifacts/2026-09-04/android/a3-retro-controller-race-save.md).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -453,6 +453,21 @@ offline installed-content revalidation on the emulator, not Retro Rewind
 gameplay/mode switching or physical hardware. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-production-install.md`](artifacts/2026-09-04/android/a3-production-install.md).
 
+The complete Android Original/Retro Rewind graph now also compiles and links as
+one `libmain.so`, and the Retro Rewind profile passes an explicit offline
+runtime boot on the expanded API 36 ARM64 emulator. The first attempts exposed
+and fixed Android product over-building, an accidental standalone-base target
+dependency through precompiled-header reuse, and Windows-only section syntax in
+generated Retro blob assembly. With airplane mode enabled, the app selected the
+Retro Rewind translated profile, mounted 4,878 overlays, reached the branded
+title and main menu, preserved its save exactly across force-stop/cold relaunch,
+and did not fall back to Original mode. A base-mode control showed the wiped-
+NAND system-memory warning was shared; a format-valid diagnostic empty save was
+therefore used as a disclosed test precondition. This closes dual linking and
+offline title/menu relaunch, not a race, production mode chooser, general
+fresh-NAND creation, touch parity, or physical hardware. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-dual-runtime-offline-boot.md`](artifacts/2026-09-04/android/a3-dual-runtime-offline-boot.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -491,8 +491,9 @@ empty base save and reached the branded title. The exact clean build then
 remained alive with that byte-identical empty save and no leaderboard, followed
 by six of six identical cold-launch passes. Removing the leaderboard alone also
 did not reproduce the earlier exit. Those exits are transient evidence rather
-than a proven save/settings defect. Full first-run license creation is still
-open, and the controller-race fixture conclusion is unchanged. Evidence:
+than a proven save/settings defect. At that checkpoint, full first-run license
+creation was still open; the controller-race fixture conclusion is unchanged.
+Evidence:
 [`docs/artifacts/2026-09-04/android/a3-retro-replay-isolation.md`](artifacts/2026-09-04/android/a3-retro-replay-isolation.md).
 
 The disclosed format-valid empty-save precondition is now removed for the
@@ -507,9 +508,23 @@ with SHA-256 `708c7a040e0cfe6cd815690e63f46d1678f17899bce0e786f7480030830f1d13`;
 a cold relaunch also passed. The clean local APK passed package/privacy audit,
 and the original emulator saves were restored with exact hashes after the
 test. This closes fresh offline Retro system-memory creation on the API 36
-ARM64 emulator, not controller-driven first license creation, physical
-hardware/controller, audio/rumble quality, performance, or release acceptance.
+ARM64 emulator, not physical hardware/controller, audio/rumble quality,
+performance, or release acceptance.
 Evidence:
+[`docs/artifacts/2026-09-04/android/a3-fresh-save-offline-kd.md`](artifacts/2026-09-04/android/a3-fresh-save-offline-kd.md).
+
+The controller-driven continuation now closes first license creation on that
+fresh emulator state. Starting from the exact game-created empty RKSYS, an
+Android InputReader-visible virtual Xbox controller selected `NEW`, confirmed
+license creation, selected the existing KartPad Mii, and reached `Your new
+license is ready.` The resulting 2,867,200-byte save has valid `RKSD0006` and
+slot-zero `RKPD` structures, a matching core CRC-32, and SHA-256
+`4b83dc4a02dd351d1e594b1c9c13ecd7530e6c80520957d4c576c46c88b0972d`.
+After force-stop and a new production-chooser process, the save remained
+byte-identical and slot 1 visibly displayed the KartPad license. The original
+Retro save was then restored to its exact pre-test `9c6c7b52...` hash and the
+clean title relaunched. This is emulator controller evidence, not physical
+controller/device or release acceptance. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-fresh-save-offline-kd.md`](artifacts/2026-09-04/android/a3-fresh-save-offline-kd.md).
 
 Explicit Original to Retro Rewind to Original switching then reproduced the

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -530,6 +530,24 @@ controller-driven Retro race/save, timing, physical controller/audio/rumble,
 hardware, or release gates. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-production-mode-chooser.md`](artifacts/2026-09-04/android/a3-production-mode-chooser.md).
 
+The same production Retro profile now passes a complete controller-driven
+emulator race/results/save/cold-relaunch slice. An Android InputReader-visible
+Xbox-compatible virtual controller navigated the retail menus and drove Mario
+through Retro Rewind's GCN Baby Park to finish stage 4. The results reported
+`17:13.562`, best lap `00:19.742`, and ghost creation; advancing results changed
+the isolated Retro save from SHA-256 `3c4aeacd...` to `7279ad4d...`. A cold
+production-chooser relaunch with the controller already attached reached the
+branded title as a new process, retained the exact post-results hash, and
+accepted controller navigation back to Baby Park. The temporary controller's
+explicit one-hour registration expired mid-race; the runtime recorded an
+ordinary disconnect/reconnect and the same live race completed afterward.
+This closes the emulator controller gameplay, race/results, save mutation, and
+byte-stable cold-relaunch slice. The slow new ghost did not replace the faster
+bundled selectable ghost, so visible new-record reload remains open alongside
+trustworthy timing, physical controller/audio/rumble, physical hardware, and
+release acceptance. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-retro-controller-race-save.md`](artifacts/2026-09-04/android/a3-retro-controller-race-save.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -484,6 +484,17 @@ reverted. The remaining fault is still within the diagnostic RKG/player-state
 boundary; a controller-driven race remains open. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-retro-replay-isolation.md`](artifacts/2026-09-04/android/a3-retro-replay-isolation.md).
 
+The simulator save damaged by the later save-country diagnostic is now
+isolated and recovered. Retro fails during translated Mii initialization when
+its redirected save is absent, before any `NANDCreate`, and an
+Original-compatible empty `rksys.dat` still fails after the Retro title even
+with a regenerated settings file and no leaderboard. Restoring the preserved
+Retro save, settings, and leaderboard as one coherent set stays alive beyond
+50 seconds and reaches the branded title under the clean audited APK. This
+keeps the replay-fixture finding valid while leaving general fresh Retro save
+creation open. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-retro-replay-isolation.md`](artifacts/2026-09-04/android/a3-retro-replay-isolation.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -468,6 +468,19 @@ offline title/menu relaunch, not a race, production mode chooser, general
 fresh-NAND creation, touch parity, or physical hardware. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-dual-runtime-offline-boot.md`](artifacts/2026-09-04/android/a3-dual-runtime-offline-boot.md).
 
+A bounded follow-up now proves that Retro Rewind's native Replay path can load
+the official SNES Donut Plains 1 expert card, follow the expanded course, cross
+into lap 2, and reach a three-lap finish/results presentation on the API 36
+ARM64 emulator. The save hash changed after the result. Running the same RKG
+through KartPad's diagnostic live-controller bridge still diverges around 19
+seconds even when the base-course metadata override is disabled, so that
+override is ruled out and the fixture is not valid A3 acceptance. The replay's
+displayed result also differs from the official card time, so timing fidelity
+is not claimed. This narrows the remaining problem to the diagnostic
+RKG/live-controller boundary, most likely Retro Rewind transmission semantics;
+a controller-driven race remains open. Evidence:
+[`docs/artifacts/2026-09-04/android/a3-retro-replay-isolation.md`](artifacts/2026-09-04/android/a3-retro-replay-isolation.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -565,9 +565,14 @@ only conclusion: Baby Park is stored under Pulsar course key `d6cac6a4`, whose
 `150/17m13s562.rkg`. All three survived force-stop and a new production-chooser
 process. The base game's 32-bit RKSYS personal-ghost field does not describe
 Retro Rewind's expanded course set. This closes durable custom-track record
-storage on the emulator; a visible cold personal-replay selection still remains
-open alongside trustworthy timing, physical controller/audio/rumble, physical
-hardware, and release acceptance. Evidence:
+storage on the emulator. A subsequent controlled cold navigation selected GCN
+Baby Park, displayed `KartPad 02:31.465` as personal card `1/2`, selected
+Replay, and reached the exact `02:31.465` result with the original three lap
+splits. The save, Pulsar database, and RKG retained their exact pre-replay
+hashes, and the new-process console had no fatal signature. This also closes
+visible cold personal-ghost reload/replay on the emulator. Trustworthy timing,
+physical controller/audio/rumble, physical hardware, and release acceptance
+remain open. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-retro-controller-race-save.md`](artifacts/2026-09-04/android/a3-retro-controller-race-save.md).
 
 ## Native tvOS work

--- a/docs/artifacts/2026-09-04/android/a3-dual-runtime-offline-boot.md
+++ b/docs/artifacts/2026-09-04/android/a3-dual-runtime-offline-boot.md
@@ -1,0 +1,116 @@
+# Android A3 dual-runtime offline boot
+
+## Falsifiable subgoal
+
+Build the Android app from the complete Original/Retro Rewind translation
+graph, select the Retro Rewind profile explicitly, and reach its main menu on
+the API 36 ARM64 emulator with networking disabled. Then force-stop and cold
+relaunch the same installed app, proving that it selects Retro Rewind again,
+does not fall back to Original mode, and preserves the save bytes.
+
+This is an emulator runtime-link and offline-boot gate. It is not a race,
+general fresh-NAND setup, touch/controller parity, physical-device acceptance,
+or release acceptance.
+
+## Inputs and private-data boundary
+
+- The dual translation graph was regenerated locally from the maintainer's
+  authorized private inputs. It contained 29,065 base functions, 29,052 shared
+  functions, 13 sensitive base functions, and 3,919 Retro Rewind functions.
+- The installed Retro Rewind pack passed the production validator, including
+  the pinned `Code.pul` and Riivolution XML hashes.
+- The disc tree, installed pack, generated translation, save, logs, screenshots,
+  APK, and emulator image remained ignored/private and were not committed or
+  published.
+- The strict APK audit found only `libSDL3.so`, `libc++_shared.so`, and
+  `libmain.so` under `lib/arm64-v8a`; it found no private content or local path
+  leakage.
+
+## Failures exposed by the real dual graph
+
+The first Android dual build requested every upstream product and therefore
+attempted to link standalone executables that require a desktop `main`. The
+Android Gradle build now requests only the product represented by the prepared
+graph: `WiiCompiled` for base-only input or `KartPadDual` for a dual graph.
+
+The next build showed that reusing `WiiCompiled`'s precompiled header made the
+Android dual product depend on the standalone base executable. `KartPadDual`
+now owns its Android precompiled header and is itself the sole shared library
+with output name `main`.
+
+The final compile failure came from generated Retro Rewind blob assembly using
+the Windows-only `.rdata,"dr"` section spelling. Android preparation now emits
+build-directory copies of `.S` inputs with the equivalent ELF
+`.rodata,"a",%progbits` section. The private generated input is not mutated.
+
+## Build and package evidence
+
+- A fresh dual runtime preparation completed from the patch stack and emitted
+  an Android `KartPadDual` shared product with a private precompiled header.
+- The complete Android dual build completed successfully.
+- Debug APK size: 119,088,910 bytes.
+- Debug APK SHA-256:
+  `d1490d5b6d9ed38012a5793e609c6c05dd4d26c1704abad9d6e423cac43867c9`.
+- Strict package/privacy audit: pass.
+- Android Retro Rewind source contract: pass.
+- Generated link contract unit test: pass.
+- Shell syntax and repository diff checks: pass.
+
+## Emulator storage control
+
+The preserved emulator initially exposed a 6 GiB data filesystem with roughly
+2.3 GiB free. The validated installed pack is about 1.9 GiB and the extracted
+disc tree about 2.5 GiB, so they could not coexist. This was a real simulator
+capacity failure, not a runtime-profile failure.
+
+After a recoverable copy of the AVD overlay was made, the disposable emulator
+data image was expanded and wiped. The fresh guest exposed a 10 GiB filesystem
+with about 9 GiB free; after staging the validated pack, disc, configuration,
+and APK, about 3.8 GiB remained. The test then ran with airplane mode enabled
+and Wi-Fi/mobile data disabled.
+
+## Runtime evidence
+
+The explicit debug route accepted `retro_rewind` only after the production
+installed-pack validator passed. Log evidence then showed:
+
+- the requested Retro Rewind profile and a valid installed pack;
+- activation of profile `retro_rewind` with one deferred mod registration;
+- selection of the `retro_rewind` translated-function profile;
+- the canonical Retro Rewind overlay root;
+- one active XML patch, 154 mappings, and 4,878 overlay registrations;
+- a 2,037-file disc index;
+- networking disabled;
+- Vulkan presentation and non-silent PCM output;
+- no fatal error and no base-profile fallback.
+
+The app reached the branded Retro Rewind title and then the Retro Rewind main
+menu. The best ignored evidence screenshots have SHA-256 values
+`5cce863792c43de03afcaeab4dd3b7b91f14233adda51da333675daa5c32700a`
+and `987d13a1a8e6dd795bfe7e9c0cfc9e9d80649cd6b8ffa4252c9963bb167d0c4d`
+for the initial title/menu sequence.
+
+Both Original and Retro Rewind initially displayed the same Wii system-memory
+warning on the wiped NAND. That base-mode control isolates the warning from the
+Retro Rewind link/profile changes. To continue this bounded runtime test, a
+format-valid empty diagnostic `RKSYS` was seeded. It was a test precondition,
+not proof that KartPad handles arbitrary fresh-NAND creation. Retro Rewind then
+created a real KartPad license and updated the save.
+
+Before and after a force-stop/airplane-mode cold relaunch, the save SHA-256 was
+identically
+`9c451f517267b800a7100bcf3f7445917ddca2361dc7deb1d184f76086600604`.
+The cold process again reached the Retro Rewind main menu with explicit
+Retro Rewind selection and no fallback. Its ignored screenshot SHA-256 is
+`1c5c5ab4b12be915a53741ce0560dc0c19ab7b6a09398f0cbfd03152eb0e7e7d`.
+
+## Classification
+
+**Pass for linking the complete Android dual product and explicitly booting
+the validated Retro Rewind 6.12.5 profile offline through title, license, and
+main menu, including a save-preserving cold relaunch.**
+
+Still open: a Retro Rewind race/gameplay proof, production mode chooser,
+fresh-NAND creation without a diagnostic seed, touch controls, physical-device
+Vulkan/controller acceptance, and release packaging. No APK or AAB was
+published.

--- a/docs/artifacts/2026-09-04/android/a3-fresh-save-offline-kd.md
+++ b/docs/artifacts/2026-09-04/android/a3-fresh-save-offline-kd.md
@@ -91,12 +91,52 @@ retained as a correctness fix, but it did not by itself resolve this failure.
   `9c6c7b52c0d1ae7c74489be53123d1943a84917f6869119ca319af5c33b58917`
   after a final clean launch.
 
+## Controller-driven first license and cold reload
+
+The immediate continuation tested the remaining first-run interaction on the
+same clean APK and standalone emulator. Before starting the game, a temporary
+Xbox-compatible `/dev/uinput` controller was registered through Android's
+documented command boundary. InputReader classified `/dev/input/event12` as an
+external keyboard, gamepad, and joystick with the Xbox key layout. All game
+input below followed the ordinary InputReader, SDL, Aurora, Classic-controller,
+and KPAD path; no application or guest state was injected.
+
+The existing Retro save was copied to an app-private test backup, then the
+exact game-created empty RKSYS above was placed at the redirected Retro path.
+The production chooser launched Retro Rewind and ordinary south-button input:
+
+1. advanced the title to four `NEW` license slots;
+2. selected the first slot and confirmed creation;
+3. displayed and selected the existing KartPad Mii;
+4. confirmed `A new license will be created for KartPad`; and
+5. reached `Your new license is ready` with the KartPad card visible.
+
+The resulting RKSYS remained 2,867,200 bytes and changed to SHA-256
+`4b83dc4a02dd351d1e594b1c9c13ecd7530e6c80520957d4c576c46c88b0972d`.
+Read-only semantic validation found `RKSD0006` at the file header, `RKPD` in
+license slot zero, and an exact stored/calculated core CRC-32 match
+(`21a244ff`).
+
+The app was force-stopped and started again through the production chooser as
+a new process. It reached the Retro title, retained the exact license-save
+hash, and ordinary controller input advanced to the license screen where slot
+1 visibly displayed the KartPad Mii and name rather than `NEW`. The accepted
+created-license and cold-license screenshots have SHA-256 values
+`5c27520ec6b5e58b67826ff772313ca89b3d414dd05b59ec45839471f647d8cf`
+and
+`310517bbfdb1192eb96659fa12ebe80e5c4503c05593bf16483a5a02d41e1da0`;
+the private screenshots were not added to the repository.
+
+Finally, the test-created save was retained only in app-private test storage,
+the original Retro save was restored to exact SHA-256
+`9c6c7b52c0d1ae7c74489be53123d1943a84917f6869119ca319af5c33b58917`,
+and a final production Retro launch reached the title.
+
 ## Classification
 
-**Pass for fresh offline Retro system-memory creation and cold title relaunch
-on the API 36 ARM64 emulator.** The prior seeded-empty-save precondition is no
-longer required for this path. Controller-driven creation of a new player
-license from that title was not exercised in this check, and physical hardware,
-physical controller behavior, audio/rumble quality, performance, and release
-acceptance remain open. No APK, AAB, game data, save, trace, or screenshot was
-published.
+**Pass for fresh offline Retro system-memory creation, controller-driven first
+license creation, and byte-stable cold license reload on the API 36 ARM64
+emulator.** The prior seeded-empty-save precondition is no longer required for
+this path. Physical hardware, physical controller behavior, audio/rumble
+quality, performance, and release acceptance remain open. No APK, AAB, game
+data, save, trace, or screenshot was published.

--- a/docs/artifacts/2026-09-04/android/a3-fresh-save-offline-kd.md
+++ b/docs/artifacts/2026-09-04/android/a3-fresh-save-offline-kd.md
@@ -1,0 +1,102 @@
+# Android A3 fresh-save initialization with networking disabled
+
+Date: 2026-09-04
+
+## Scope
+
+This check targeted the previously disclosed format-valid empty-save
+precondition in the Retro Rewind emulator boot evidence. The falsifiable
+subgoal was to remove the redirected Retro RKSYS from an otherwise configured
+install, cold-launch the production profile with online networking disabled,
+and determine whether the game could create and reopen its own system-memory
+state without a seeded save.
+
+Target and build:
+
+- standalone `KartPad_API_36_ARM64` AVD (`emulator-5554`), Android API 36,
+  arm64-v8a;
+- production mode chooser and Retro Rewind 6.12.5 installation already
+  validated by the preceding A3 checks;
+- runtime configuration retained `[network] enabled = false`;
+- clean Android runtime preparation and full debug APK rebuild after the fix.
+
+This is emulator evidence. It is not physical-device, controller, audio,
+rumble, performance, or release acceptance.
+
+## Reproduction and diagnosis
+
+With the redirected Retro save absent, the unmodified runtime displayed
+`Could not write to / read from Wii system memory.` It created
+`title/00010004/524d4350/data/rksys.dat` at the expected 2,867,200-byte size,
+but the file remained all zeroes.
+
+Temporary local instrumentation narrowed the failure beyond the successful
+file creation and preallocation. The translated save setup called an auxiliary
+virtual-device open, which returned failure after its underlying operation
+returned `-42` twice, approximately ten seconds apart. The runtime's global
+`NetworkEnabled` check was rejecting every `/dev/net/*` path before device
+classification. That included these local Wii system services:
+
+- `/dev/net/kd/request`
+- `/dev/net/kd/time`
+- `/dev/net/ncd/manage`
+
+Because `/dev/net/kd/request` was not claimed by the network HLE while online
+networking was disabled, it fell through as an unknown NAND device and the
+first-run system-memory sequence timed out. Internet socket and TLS devices
+(`/dev/net/ip/top` and `/dev/net/ssl`) are a separate boundary and should
+remain unavailable under the offline setting.
+
+## Fix
+
+`patches/wiicompiled-offline-kd-services.patch` classifies the requested
+device first. It permits KD request/time and NCD management regardless of the
+online-network preference, while retaining the preference gate for IP and SSL
+devices. The common patch is applied by both portable runtime preparation
+paths, including Android's delegated preparation path.
+
+The diagnostic sequence after this change matched the expected KD state
+machine: command `0x02` initially returned `-42`; commands `0x01`, `0x0f`, and
+`0x03` ran; a second `0x02` returned `-42`; the third returned `0`. The
+translated auxiliary open, allocation, probe, and final return then all
+succeeded. Temporary trace statements were removed before the clean build.
+
+The separate Android NAND-open patch removes a create-on-open fallback from
+the high-level NAND open operation. That preserves Wii open semantics and was
+retained as a correctness fix, but it did not by itself resolve this failure.
+
+## Clean-build and emulator results
+
+- Fresh prepared source: `build/a3-android-offline-kd-clean-source`.
+- Full clean build completed successfully.
+- Local-only debug APK SHA-256:
+  `262d821e6b2b769872df50e48e16a36b8c636b528bc9c1d03a17ae37624baaa7`.
+- `scripts/audit-android-package.sh` passed for that APK.
+- The packaged `libmain.so` contains no `KARTPAD_SAVE_TRACE` or `TRACE rksys`
+  diagnostic marker.
+- From a fresh redirected Retro NAND, a cold production launch passed the
+  former system-memory error and visibly reached the Retro Rewind
+  `Press the A Button` title.
+- The game-created RKSYS is 2,867,200 bytes with SHA-256
+  `708c7a040e0cfe6cd815690e63f46d1678f17899bce0e786f7480030830f1d13`,
+  exactly matching the known format-valid empty-save fixture.
+- A second independent fresh-NAND run reached the same title and produced the
+  same exact RKSYS hash.
+- A force-stop and cold relaunch with the newly created save again reached the
+  title.
+- The emulator's original base and Retro saves were restored after testing.
+  Their SHA-256 values remained exactly
+  `708c7a040e0cfe6cd815690e63f46d1678f17899bce0e786f7480030830f1d13`
+  and
+  `9c6c7b52c0d1ae7c74489be53123d1943a84917f6869119ca319af5c33b58917`
+  after a final clean launch.
+
+## Classification
+
+**Pass for fresh offline Retro system-memory creation and cold title relaunch
+on the API 36 ARM64 emulator.** The prior seeded-empty-save precondition is no
+longer required for this path. Controller-driven creation of a new player
+license from that title was not exercised in this check, and physical hardware,
+physical controller behavior, audio/rumble quality, performance, and release
+acceptance remain open. No APK, AAB, game data, save, trace, or screenshot was
+published.

--- a/docs/artifacts/2026-09-04/android/a3-production-mode-chooser.md
+++ b/docs/artifacts/2026-09-04/android/a3-production-mode-chooser.md
@@ -1,0 +1,78 @@
+# Android A3 production mode chooser
+
+Date: 2026-09-04
+
+## Scope
+
+This checkpoint replaces the debug-only Android runtime-profile intent with a
+production-owned Original/Retro Rewind chooser that runs before SDL and the
+translated runtime start. It covers the API 36 ARM64 emulator. It does not
+claim a controller-driven Retro Rewind race or physical-device acceptance.
+
+## Implementation
+
+- `KartPadLaunchActivity` is the production launcher and presents the KartPad
+  title, data requirement, and side-by-side Mario Kart Wii and Retro Rewind
+  choices before native startup.
+- Retro Rewind validation runs away from the UI thread. A valid pinned 6.12.5
+  installation enables direct launch; a missing or invalid installation shows
+  the download state and routes to the existing production installer.
+- `KartPadActivity` receives one explicit production profile, independently
+  validates Retro Rewind before exporting `KARTPAD_RUNTIME_PROFILE`, and still
+  permits the pre-existing protected debug override in debug builds.
+- The chooser finishes after selection because the translated runtime is
+  process-global and is not restartable in place. It does not leave a screen
+  behind the SDL activity that would imply an unsupported same-process switch.
+- The SDL activity is not exported in the release manifest. Debug builds retain
+  shell access protected by Android's `DUMP` permission for existing fixtures.
+- The same lint run found an existing API-28 violation in a debug install
+  fixture. Its Java 16 `Stream.toList()` call was replaced by the compatible
+  collector without changing fixture behavior.
+
+## Emulator evidence
+
+The visible test used `KartPad_API_36_ARM64`, API 36, `arm64-v8a`, a 4 KiB page
+size, and a 1280 by 720 test display.
+
+- The initial vertical layout placed Retro Rewind below the fold. That result
+  was rejected. The corrected side-by-side layout presents both complete
+  choices and the validation status without scrolling.
+- With the preserved production-size pack, the chooser reported `Retro Rewind
+  6.12.5 is ready`. Selecting it logged `selected=retro_rewind`, the SDL owner
+  logged `requested=retro_rewind installed=valid`, and the branded Retro Rewind
+  title remained alive beyond 30 seconds.
+- A cold return through the chooser selected Original, logged `selected=base`
+  and `requested=base`, and reached the Original title beyond 30 seconds.
+- A physical landscape flip recreated the chooser; both choices returned
+  visible and enabled after validation.
+- A debug-only missing-install state displayed `Download 6.12.5`; selecting it
+  opened `RetroRewindInstallActivity`. No installed content was moved or
+  deleted for that control.
+- The Original save remained SHA-256
+  `708c7a040e0cfe6cd815690e63f46d1678f17899bce0e786f7480030830f1d13`.
+- The Retro save remained SHA-256
+  `3c4aeacd0356a679f261571b53cddfd371a5dc3ff9602be39ca26bdef06ea40e`.
+- No new missing-target crash record appeared during the exact-build switch.
+
+## Verification
+
+- Full dual-profile ARM64 debug build: pass.
+- Android lint, including the API-28 surface: pass.
+- Release main-manifest merge: pass; chooser exported, SDL activity private.
+- Content, storage, install-pipeline, and worker-policy contracts: pass.
+- Strict package/privacy audit: pass for the local-only APK at SHA-256
+  `7088f683c9cc765c77a12203646af6d9ecdb13f1eb77f559b4bfdbc75e1caf94`.
+- SunPad overlay snapshot: unchanged. Source verification reaches the known
+  ignored `rr-pulsar` mismatch (`b566a5d` local versus `29e76d4` pinned) after
+  all patch hunks and earlier references pass; this checkpoint does not mutate
+  that user/reference checkout.
+
+## Classification
+
+**Pass for the production chooser and bounded emulator mode-switch gate.** The
+app no longer relies on the debug profile extra for normal mode selection, and
+the exact audited APK reaches the correct profile in both directions without
+changing either save. A controller-driven Retro Rewind race/results/save,
+trustworthy timing, physical controller/audio/rumble, physical Android
+hardware, and release acceptance remain open. No APK, AAB, pack, save, disc,
+or private capture was published.

--- a/docs/artifacts/2026-09-04/android/a3-retro-controller-race-save.md
+++ b/docs/artifacts/2026-09-04/android/a3-retro-controller-race-save.md
@@ -162,6 +162,23 @@ and `2m31s465.rkg` remained `1858e595...`. The new-process console has SHA-256
 and no fatal signature. Durable storage and visible cold personal replay are
 therefore both proven on the emulator.
 
+## Retro runtime lifecycle follow-up
+
+With the exact replay result still visible, the emulator was forced from
+rotation 0 to rotation 180. Android delivered a same-size `surfaceChanged`, the
+Retro frame remained visible, and the process retained PID 12558. HOME then
+delivered `onPause`, `surfaceDestroyed`, and `onStop`. Bringing the existing
+singleTask forward produced a hot resume with `onStart`, `onResume`,
+`surfaceCreated`, and `surfaceChanged`; the exact result returned in the same
+process.
+
+The rotation and post-resume screenshots have SHA-256 values `d80c372d...` and
+`fccebe13...`. After restoring automatic rotation 0, the intact-result
+screenshot has SHA-256 `a04b7709...`. PID-scoped logcat had no fatal signature,
+and RKSYS, `ldb.pul`, and `2m31s465.rkg` retained their exact hashes. This closes
+Retro runtime rotation and background/foreground surface recreation on the
+emulator without broadening the claim to physical hardware.
+
 ## Honest classification
 
 **Pass for production-profile Retro Rewind controller discovery, menu input,

--- a/docs/artifacts/2026-09-04/android/a3-retro-controller-race-save.md
+++ b/docs/artifacts/2026-09-04/android/a3-retro-controller-race-save.md
@@ -1,0 +1,91 @@
+# Android A3 Retro Rewind controller race/save evidence
+
+Date: 2026-09-04
+
+Branch: `codex/android-a3-retro-runtime`
+
+Target: visible `KartPad_API_36_ARM64`, Android API 36, `arm64-v8a`,
+4,096-byte pages, 1280x720 display override
+
+## Falsifiable subgoal
+
+Launch the production Retro Rewind profile, attach an Android-recognized game
+controller before gameplay, navigate to a Retro Rewind course, finish a Time
+Trial through the ordinary Android InputReader-to-SDL path, persist the
+post-results save, force-stop the process, and prove the exact save survives a
+cold controller-attached relaunch. Do not count this virtual controller as
+physical-controller or physical-device acceptance.
+
+## Exact candidate and input boundary
+
+The run used the unchanged local-only debug APK from the production-chooser
+checkpoint, SHA-256
+`7088f683c9cc765c77a12203646af6d9ecdb13f1eb77f559b4bfdbc75e1caf94`.
+The Android production chooser selected the preserved validated Retro Rewind
+6.12.5 installation without a debug profile extra.
+
+An ignored temporary Xbox-compatible `/dev/uinput` device was registered with
+Android's documented `uinput` command contract. Android classified it as an
+external keyboard/gamepad/joystick and assigned `/dev/input/event12` with the
+Xbox key layout. Title, license, mode, character, vehicle, transmission,
+course, acceleration, steering, results, and cold-relaunch navigation used
+ordinary controller events. The Android chooser itself used its native touch
+button before SDL started.
+
+The race feedback loop read only the opt-in content-free native state trace
+and emitted analog-axis/button events to `/dev/input/event12`. It did not write
+guest memory, alter lap state, force a finish, inject application input, or
+stage a replay. The first registration reached its explicit one-hour lifetime
+during the race. The runtime recorded a normal controller disconnect and
+reconnect before the same live race completed.
+
+## Race, results, and save result
+
+Mario / Standard Kart M / Manual completed Retro Rewind's GCN Baby Park Time
+Trial. The result presentation reported total `17:13.562`, best lap
+`00:19.742`, and `A ghost has been created for KartPad!`. The deliberately slow
+total includes the rejected open-loop steering attempts and is not performance
+or trustworthy timing evidence.
+
+The retained ignored state trace contains 24,500 samples, reached finish stage
+4 at race timer tick `62191`, and has SHA-256
+`03a1f5bc447c22e21fb37a33f2c81e0cbf8aac2f884a2a958895af397bb86127`.
+The ignored race console records the canonical Retro Rewind overlay, controller
+connection at line 536, the one-hour-lifetime disconnect at line 762,
+reconnection at line 765, and no fatal signature. Its SHA-256 is
+`1e2ceafea22b33750d2eb5da4b9bdcebd3036a903de9b12d99f593580d190bd6`.
+
+Advancing the retail results changed the isolated Retro Rewind save from
+SHA-256
+`3c4aeacd0356a679f261571b53cddfd371a5dc3ff9602be39ca26bdef06ea40e`
+to
+`7279ad4db655b893f8b2dd1a1427512c4d5799efe9047a94e67b35080c600401`.
+The Original save remained out of scope and untouched.
+
+## Cold relaunch
+
+With the controller attached, the app was force-stopped and relaunched through
+the production chooser as new PID 7432. It reached the branded Retro Rewind
+title, retained the exact post-results save SHA-256
+`7279ad4db655b893f8b2dd1a1427512c4d5799efe9047a94e67b35080c600401`,
+and accepted controller navigation back to the Baby Park ghost menu. The cold
+console records the canonical overlay at line 101, controller channel-zero
+connection at line 533, active KPAD reads, and no fatal signature; its SHA-256
+is `7ea11624c6e1a1982baabb5735e61834440ec7d88fd2001a2e7c9dd28f7426e6`.
+
+The menu continued to surface the faster bundled `01:15.379` Rewind ghost as
+the single selectable entry, so this checkpoint does not claim a visible
+reload of the much slower new ghost. It proves the post-results save mutation
+and byte-stable cold-process persistence. A faster valid record or direct
+save-semantic inspection is still needed before claiming visible new-result
+reload.
+
+## Honest classification
+
+**Pass for production-profile Retro Rewind controller discovery, menu input,
+live analog gameplay, normal disconnect/reconnect handling, complete race and
+results presentation, post-results save mutation, and byte-stable
+controller-attached cold relaunch.** It is not physical-controller, physical-
+device, tactile-rumble, audible-quality, sustained-performance, trustworthy-
+timing, faster-record reload, or release acceptance. No APK, AAB, game data,
+save, trace, console, or screenshot was published.

--- a/docs/artifacts/2026-09-04/android/a3-retro-controller-race-save.md
+++ b/docs/artifacts/2026-09-04/android/a3-retro-controller-race-save.md
@@ -73,12 +73,21 @@ console records the canonical overlay at line 101, controller channel-zero
 connection at line 533, active KPAD reads, and no fatal signature; its SHA-256
 is `7ea11624c6e1a1982baabb5735e61834440ec7d88fd2001a2e7c9dd28f7426e6`.
 
-The menu continued to surface the faster bundled `01:15.379` Rewind ghost as
-the single selectable entry, so this checkpoint does not claim a visible
-reload of the much slower new ghost. It proves the post-results save mutation
-and byte-stable cold-process persistence. A faster valid record or direct
-save-semantic inspection is still needed before claiming visible new-result
-reload.
+The menu continued to surface only one faster packaged Rewind ghost, so the
+initial checkpoint did not claim a visible reload of the much slower run.
+
+A follow-up visible-emulator test force-stopped the app again, launched the
+production `KartPadLaunchActivity`, selected the validated Retro Rewind choice
+on-screen, reached the branded title as new PID 7904, and navigated by the same
+Android-recognized controller back to the course ghost screen. It again showed
+only `1/1`. The exact cold-loaded 2,867,200-byte save retained SHA-256
+`7279ad4db655b893f8b2dd1a1427512c4d5799efe9047a94e67b35080c600401`.
+Read-only semantic inspection found valid `RKSD0006`/`RKPD` structures and an
+exact core CRC-32 match, but the only initialized license had personal-ghost
+bitfield `0x00000000` and no nonzero primary Time Trial leaderboard timers.
+The post-results mutation therefore did not include a retained personal record
+or ghost. A faster controller-driven result is still required for the
+record/save/reload part of A3.
 
 ## Honest classification
 
@@ -87,5 +96,5 @@ live analog gameplay, normal disconnect/reconnect handling, complete race and
 results presentation, post-results save mutation, and byte-stable
 controller-attached cold relaunch.** It is not physical-controller, physical-
 device, tactile-rumble, audible-quality, sustained-performance, trustworthy-
-timing, faster-record reload, or release acceptance. No APK, AAB, game data,
+timing, personal-record/ghost persistence, or release acceptance. No APK, AAB, game data,
 save, trace, console, or screenshot was published.

--- a/docs/artifacts/2026-09-04/android/a3-retro-controller-race-save.md
+++ b/docs/artifacts/2026-09-04/android/a3-retro-controller-race-save.md
@@ -93,9 +93,10 @@ only `1/1`. The exact cold-loaded 2,867,200-byte save retained SHA-256
 Read-only semantic inspection found valid `RKSD0006`/`RKPD` structures and an
 exact core CRC-32 match, but the only initialized license had personal-ghost
 bitfield `0x00000000` and no nonzero primary Time Trial leaderboard timers.
-The post-results mutation therefore did not include a retained personal record
-or ghost. A faster controller-driven result is still required for the
-record/save/reload part of A3.
+At that point this was interpreted as no retained personal record or ghost.
+The later custom-track storage inspection below corrects that RKSYS-only
+conclusion: Retro Rewind stores expanded-course records under Pulsar rather
+than the base game's 32-slot ghost table.
 
 ## Rejected fast-fixture follow-up
 
@@ -115,6 +116,44 @@ the bounded fixture console has SHA-256
 These attempts are rejected diagnostics, not race, record, or controller
 acceptance. The RKG and trace markers were removed from the app afterward.
 
+## Faster live-controller follow-up and storage correction
+
+A revised bounded feedback driver was attached to a fresh, ordinary-controller
+Baby Park Time Trial in the same visible emulator. It emitted only accelerator,
+brake, and analog-axis events through Android InputReader. The run reached
+native finish stage 4 at race timer tick 9,326 and reported `02:31.465`. The
+result screen displayed three valid lap splits, the remaining expanded lap
+slots as `99:59.999`, and `A ghost has been created for KartPad!`. The next
+screen showed `02:31.465` ahead of `17:13.562` in the session leaderboard.
+
+The ignored 702,567-byte state trace has SHA-256
+`c3d5a9bbd0d0b03e0c730b74ab281b23d2215840bf8a24e411a4215542518682`.
+Advancing results changed the redirected RKSYS from `7279ad4d...` to
+`9c6c7b52c0d1ae7c74489be53123d1943a84917f6869119ca319af5c33b58917`.
+The latter has valid `RKSD0006`/`RKPD` structures and matching core CRC; versus
+`7279ad4d...`, only seven statistic bytes and the four-byte CRC changed. Its
+base-game personal-ghost bitfield remains zero and has no primary timer.
+
+That is expected for this expanded Retro course. Read-only inspection found
+the actual course-scoped storage at
+`NAND/shared2/Pulsar/RetroRewind6/Ghosts/d6cac6a4`: its 4,544-byte `ldb.pul`
+identifies `GCN Baby Park` and has SHA-256
+`638186a678f60fea6e3c3b6bab03b8745059c57d4c47c21c4ba3dd989a3838f9`.
+The `150` directory contains both durable personal streams:
+
+- `2m31s465.rkg`, 368 bytes, SHA-256
+  `1858e595a7d79a8aa144a698e6dce144e7017b683eca621a14d5b77a21d19ff3`;
+- `17m13s562.rkg`, 460 bytes, SHA-256
+  `3f0b33ecd602601b69fbdf0711941b09884a0ed740047d8ea8657f6748946571`.
+
+The app was force-stopped and relaunched through the production chooser as a
+new process. The Pulsar database and both RKGs remained present with the exact
+hashes above. A controller-navigation attempt reached the correct Baby Park
+packaged-ghost card, but a reconnect modal and repeated virtual D-pad input
+prevented a clean capture of the personal `Select Ghost` replay path. Durable
+custom-track record storage is therefore proven; visible cold personal-replay
+selection remains open.
+
 ## Honest classification
 
 **Pass for production-profile Retro Rewind controller discovery, menu input,
@@ -122,5 +161,7 @@ live analog gameplay, normal disconnect/reconnect handling, complete race and
 results presentation, post-results save mutation, and byte-stable
 controller-attached cold relaunch.** It is not physical-controller, physical-
 device, tactile-rumble, audible-quality, sustained-performance, trustworthy-
-timing, personal-record/ghost persistence, or release acceptance. No APK, AAB, game data,
-save, trace, console, or screenshot was published.
+timing, visible cold personal-replay selection, or release acceptance. Durable
+Retro custom-track personal-record/ghost storage across a production-path cold
+relaunch now passes. No APK, AAB, game data, save, trace, console, or screenshot
+was published.

--- a/docs/artifacts/2026-09-04/android/a3-retro-controller-race-save.md
+++ b/docs/artifacts/2026-09-04/android/a3-retro-controller-race-save.md
@@ -62,6 +62,14 @@ to
 `7279ad4db655b893f8b2dd1a1427512c4d5799efe9047a94e67b35080c600401`.
 The Original save remained out of scope and untouched.
 
+The exact pre-race file was later recovered read-only from an ignored emulator
+recovery copy and independently matched the recorded `3c4aeacd...` hash. A
+byte comparison against the cold-loaded post-race file found only 12 changed
+bytes: four single-byte increments and one four-byte distance/statistic value
+inside the initialized license's ordinary race-statistics region, plus the
+four-byte core CRC-32. No leaderboard entry, personal-ghost bitfield, or ghost
+payload byte changed.
+
 ## Cold relaunch
 
 With the controller attached, the app was force-stopped and relaunched through
@@ -88,6 +96,24 @@ bitfield `0x00000000` and no nonzero primary Time Trial leaderboard timers.
 The post-results mutation therefore did not include a retained personal record
 or ghost. A faster controller-driven result is still required for the
 record/save/reload part of A3.
+
+## Rejected fast-fixture follow-up
+
+Retro Rewind's own Baby Park expert streams were tested only as an ignored
+debug diagnostic. The primary `01:15.379` stream identifies Peach, Mach Bike,
+Manual and 4,759 frames. A visible emulator retry selected that exact
+character, vehicle and course, then tested both Retro Rewind transmission
+choices. Both live-player runs consumed the complete stream but diverged,
+remained at race stage 2, and stopped against the course boundary. The earlier
+alternate `01:26.822` Mario/Standard Kart stream likewise diverged. No native
+finish was forced and the save remained exactly `7279ad4d...` afterward.
+
+The retained ignored Outside-variant trace has SHA-256
+`7fbd18d913818f07731ef602fc1f898ba3c460b5db9c8cfa97184ee124aa1623`;
+the bounded fixture console has SHA-256
+`b711da419151d366159698113786592d9d10a21827fbec7742ff5a7a91692bdd`.
+These attempts are rejected diagnostics, not race, record, or controller
+acceptance. The RKG and trace markers were removed from the app afterward.
 
 ## Honest classification
 

--- a/docs/artifacts/2026-09-04/android/a3-retro-controller-race-save.md
+++ b/docs/artifacts/2026-09-04/android/a3-retro-controller-race-save.md
@@ -148,11 +148,19 @@ The `150` directory contains both durable personal streams:
 
 The app was force-stopped and relaunched through the production chooser as a
 new process. The Pulsar database and both RKGs remained present with the exact
-hashes above. A controller-navigation attempt reached the correct Baby Park
-packaged-ghost card, but a reconnect modal and repeated virtual D-pad input
-prevented a clean capture of the personal `Select Ghost` replay path. Durable
-custom-track record storage is therefore proven; visible cold personal-replay
-selection remains open.
+hashes above. Controlled controller navigation returned to 150cc Time Trials
+and selected GCN Baby Park. The cold-loaded screen displayed the personal
+`KartPad 02:31.465` card as `1/2`, and its Replay action visibly consumed the
+stored stream through the exact `02:31.465` finish with recorded splits
+`00:35.374`, `00:30.012`, and `00:26.009`.
+
+The replay-selection, active-replay, and exact-finish screenshots have
+SHA-256 values `2b682429...`, `925c4bf6...`, and `d6e834d3...`, respectively.
+After replay, RKSYS remained `9c6c7b52...`, `ldb.pul` remained `638186a6...`,
+and `2m31s465.rkg` remained `1858e595...`. The new-process console has SHA-256
+`8f456db1ed18ac0624639fb11c691a18d5a1f4a406284505a0801c9c9d91afc4`
+and no fatal signature. Durable storage and visible cold personal replay are
+therefore both proven on the emulator.
 
 ## Honest classification
 
@@ -161,7 +169,6 @@ live analog gameplay, normal disconnect/reconnect handling, complete race and
 results presentation, post-results save mutation, and byte-stable
 controller-attached cold relaunch.** It is not physical-controller, physical-
 device, tactile-rumble, audible-quality, sustained-performance, trustworthy-
-timing, visible cold personal-replay selection, or release acceptance. Durable
-Retro custom-track personal-record/ghost storage across a production-path cold
-relaunch now passes. No APK, AAB, game data, save, trace, console, or screenshot
-was published.
+timing, or release acceptance. Durable Retro custom-track personal-record/ghost
+storage and visible full replay across a production-path cold relaunch now
+pass. No APK, AAB, game data, save, trace, console, or screenshot was published.

--- a/docs/artifacts/2026-09-04/android/a3-retro-replay-isolation.md
+++ b/docs/artifacts/2026-09-04/android/a3-retro-replay-isolation.md
@@ -63,6 +63,28 @@ package/privacy audit at SHA-256
 It was installed locally after removing the RKG and state-trace diagnostics;
 it was not published.
 
+## Save-precondition recovery
+
+The later save-country diagnostic had replaced the Retro redirect's
+`rksys.dat` with a format-valid empty file that boots Original mode. A cold
+Retro launch with no save did not create one: it failed during translated Mii
+manager initialization before any `NANDCreate` request. Supplying that same
+empty save also failed after the branded title. Removing the leaderboard file
+and regenerating `RRGameSettings.pul` did not repair the launch.
+
+The original Retro save, settings, and leaderboard were then restored as one
+coherent set from the preserved pre-test copies. A cold launch remained alive
+beyond 50 seconds and reached the branded title. The old and regenerated
+settings files differed only in `MiscParams.lastSelectedCup` (`0x00000042`
+versus the fresh `0xffffffff` sentinel), but both failed with the empty save;
+that field and the leaderboard are therefore not sufficient causes.
+
+Temporary NAND-path logging was removed. The clean dual ARM64 APK rebuilt,
+passed the strict package/privacy audit at SHA-256
+`340c33f207a651cb2be0f01cc7663dca64a946adfd7e2f033ae4882f5e4b807e`,
+installed over the diagnostic build, and cold-launched the restored coherent
+Retro state to the branded title. It remains local and was not published.
+
 ## Native replay control
 
 The diagnostic RKG file was renamed out of the recognized path and the process
@@ -94,3 +116,8 @@ is within fixture-to-player state/cadence or another unisolated race-state
 difference. A controller-driven race, trustworthy timing, save/relaunch
 verification for that controller-driven race, mode switching, and
 physical-device execution remain open.
+
+The recovery control also establishes that the fixture divergence is separate
+from the later test-save damage. Retro Rewind currently requires the preserved
+coherent save set on this emulator; general missing-save creation and reuse of
+an Original-compatible empty `rksys.dat` remain unsupported boundaries.

--- a/docs/artifacts/2026-09-04/android/a3-retro-replay-isolation.md
+++ b/docs/artifacts/2026-09-04/android/a3-retro-replay-isolation.md
@@ -1,0 +1,68 @@
+# Android A3 Retro replay isolation
+
+Date: 2026-09-04
+
+## Scope
+
+This is a bounded API 36 ARM64 emulator diagnostic for the first Retro Rewind
+race gate. It distinguishes translated Retro Rewind race execution from the
+existing player-side RKG input fixture. It is not physical-device or complete
+A3 gameplay acceptance.
+
+## Preconditions
+
+- The previously validated Retro Rewind 6.12.5 installation and game disc were
+  retained in app-private storage.
+- Networking remained disabled.
+- The app explicitly selected the `retro_rewind` runtime and did not fall back
+  to Original Mario Kart Wii.
+- The official `Ghosts/ExpertsRT/0_150.rkg` card identified SNES Donut Plains
+  1, Mario, Sneakster, Manual, and `01:34.086`.
+- State trace output contained numeric guest state only. No RKG, disc, pack,
+  save, APK, or local path was copied into this artifact.
+
+## Metadata-override isolation
+
+A temporary debug-only launch switch disabled
+`KARTPAD_RKG_FORCE_METADATA_V2`. The official input was then supplied to the
+player fixture after manually selecting the matching course, character,
+vehicle, and drift mode. Outside transmission was selected because the RKG's
+Retro Rewind extension is `TRANSMISSION_DEFAULT`, which the two-choice player
+screen does not expose.
+
+The fixture armed at the normal countdown boundary and maintained the expected
+238-frame stream/race offset. At visible race time `00:19.380`, however, the
+player was still on lap 1 and had diverged into the same barrier/off-road state
+seen with metadata forcing enabled. Disabling the base-course metadata writes
+therefore did not fix the failure. The temporary launch switch was removed
+from source after this falsification.
+
+## Native replay control
+
+The diagnostic RKG file was renamed out of the recognized path and the process
+was cold-started. Retro Rewind's own Replay path loaded the same official card,
+followed the course, visibly crossed into lap 2, and reached the three-lap
+finish/results presentation without an Android fatal record. The bounded trace
+progressed through stages 0, 1, 2, and 4. The result presentation showed
+`00:57.691`; because this does not equal the card's `01:34.086`, this run does
+not claim replay timing fidelity.
+
+The KartPad save changed from the prior cold-relaunch hash
+`9c451f517267b800a7100bcf3f7445917ddca2361dc7deb1d184f76086600604`
+to `c5496e08dceab593a787b1363b2a4ce756313cebd768ab2d0d814c99db931383`
+after the result presentation. After removing all diagnostic files, installing
+the clean rebuilt APK, and force-stop/cold-launching the explicit Retro profile
+at the emulator's native display size, the branded title returned and that
+changed hash remained exact.
+
+## Classification
+
+**Partial pass.** The Android Retro Rewind runtime can execute the expanded
+course and its native replay through a three-lap finish/results path, so the
+earlier failure is not caused by the metadata override or a general inability
+to run Retro Rewind race physics. The player-side diagnostic RKG bridge still
+diverges and cannot be used as A3 race acceptance. Its most likely remaining
+boundary is Retro Rewind's transmission/RKG-to-live-controller semantics, but
+that cause is not yet proven. A controller-driven race, trustworthy timing,
+save/relaunch verification for that controller-driven race, mode switching,
+and physical-device execution remain open.

--- a/docs/artifacts/2026-09-04/android/a3-retro-replay-isolation.md
+++ b/docs/artifacts/2026-09-04/android/a3-retro-replay-isolation.md
@@ -37,6 +37,32 @@ seen with metadata forcing enabled. Disabling the base-course metadata writes
 therefore did not fix the failure. The temporary launch switch was removed
 from source after this falsification.
 
+## Default-kart and countdown controls
+
+A second official card, `ExpertsRT/10_150.rkg`, identified Koopa Troopa,
+Cheep Charger, Manual, Classic Controller, course ID 16, 6,578 input frames,
+and `01:45.736`. Cheep Charger is a kart, so Retro Rewind's Outside
+transmission choice is a no-op and matches the RKG's default transmission.
+After manually selecting that exact setup with metadata forcing disabled, the
+fixture was on course initially but diverged beside the fence around 21
+seconds and was stationary against it by about 35 seconds. This rules out the
+Inside/Outside bike-transmission mismatch as the general cause.
+
+The trace's 238-sample difference from race time initially suggested that RKG
+consumption began too early. A one-line experimental build delayed fixture
+consumption from countdown stage 1 to active-race stage 2. The runtime
+transcript confirmed `synchronized at RaceManager stage=2`, but the same kart
+then diverged into the water around `00:07.383`, materially earlier than the
+stage-1 control. The experiment therefore falsified that start-boundary fix
+and was reverted from source. The 238 samples are countdown rows in the state
+trace, not proof of an RKG-frame lead.
+
+The reverted dual ARM64 APK rebuilt successfully and passed the strict
+package/privacy audit at SHA-256
+`44b485b9e0a6c2dcc0292777d32e81116981462881e14aa3ead739b5f1e386b1`.
+It was installed locally after removing the RKG and state-trace diagnostics;
+it was not published.
+
 ## Native replay control
 
 The diagnostic RKG file was renamed out of the recognized path and the process
@@ -60,9 +86,11 @@ changed hash remained exact.
 **Partial pass.** The Android Retro Rewind runtime can execute the expanded
 course and its native replay through a three-lap finish/results path, so the
 earlier failure is not caused by the metadata override or a general inability
-to run Retro Rewind race physics. The player-side diagnostic RKG bridge still
-diverges and cannot be used as A3 race acceptance. Its most likely remaining
-boundary is Retro Rewind's transmission/RKG-to-live-controller semantics, but
-that cause is not yet proven. A controller-driven race, trustworthy timing,
-save/relaunch verification for that controller-driven race, mode switching,
-and physical-device execution remain open.
+to run Retro Rewind race physics. The default-kart control also rules out the
+Inside/Outside transmission choice, and the stage-2 control rules out the
+proposed countdown-start correction. The player-side diagnostic RKG bridge
+still diverges and cannot be used as A3 race acceptance; the remaining cause
+is within fixture-to-player state/cadence or another unisolated race-state
+difference. A controller-driven race, trustworthy timing, save/relaunch
+verification for that controller-driven race, mode switching, and
+physical-device execution remain open.

--- a/docs/artifacts/2026-09-04/android/a3-retro-replay-isolation.md
+++ b/docs/artifacts/2026-09-04/android/a3-retro-replay-isolation.md
@@ -63,21 +63,21 @@ package/privacy audit at SHA-256
 It was installed locally after removing the RKG and state-trace diagnostics;
 it was not published.
 
-## Save-precondition recovery
+## Save-precondition revalidation
 
-The later save-country diagnostic had replaced the Retro redirect's
-`rksys.dat` with a format-valid empty file that boots Original mode. A cold
-Retro launch with no save did not create one: it failed during translated Mii
-manager initialization before any `NANDCreate` request. Supplying that same
-empty save also failed after the branded title. Removing the leaderboard file
-and regenerating `RRGameSettings.pul` did not repair the launch.
+An initial recovery sequence appeared to associate post-title process exits
+with a missing or format-valid empty redirected `rksys.dat`. That association
+did not survive controlled repetition. Temporary guest-address-only telemetry
+showed both Mii-library allocations using the same valid heap and vtable. With
+the redirected save absent, the runtime populated it from the valid empty base
+save and reached the branded title.
 
-The original Retro save, settings, and leaderboard were then restored as one
-coherent set from the preserved pre-test copies. A cold launch remained alive
-beyond 50 seconds and reached the branded title. The old and regenerated
-settings files differed only in `MiscParams.lastSelectedCup` (`0x00000042`
-versus the fresh `0xffffffff` sentinel), but both failed with the empty save;
-that field and the leaderboard are therefore not sufficient causes.
+The telemetry was then removed and the exact clean build was retested. It
+remained alive with the byte-identical empty save and no leaderboard. Six
+additional identical force-stop/cold-launch cycles each remained alive after
+22 seconds. Removing only the leaderboard also did not reproduce the exit.
+The earlier process exits are therefore non-reproducible transient evidence,
+not proof of a fresh-save, settings, leaderboard, or Mii-manager defect.
 
 Temporary NAND-path logging was removed. The clean dual ARM64 APK rebuilt,
 passed the strict package/privacy audit at SHA-256
@@ -117,7 +117,7 @@ difference. A controller-driven race, trustworthy timing, save/relaunch
 verification for that controller-driven race, mode switching, and
 physical-device execution remain open.
 
-The recovery control also establishes that the fixture divergence is separate
-from the later test-save damage. Retro Rewind currently requires the preserved
-coherent save set on this emulator; general missing-save creation and reuse of
-an Original-compatible empty `rksys.dat` remain unsupported boundaries.
+The revalidation also establishes that the fixture divergence is separate
+from the later diagnostic state changes. The emulator can repopulate the Retro
+redirect from the Original-compatible empty save and cold-launch repeatedly;
+full first-run license creation is not claimed until that UI flow is completed.

--- a/docs/artifacts/2026-09-04/android/a3-rfl-alarm-context.md
+++ b/docs/artifacts/2026-09-04/android/a3-rfl-alarm-context.md
@@ -1,0 +1,64 @@
+# Android A3 RFL alarm context isolation
+
+Date: 2026-09-04
+
+## Scope
+
+This is a bounded API 36 ARM64 emulator regression for explicit Original to
+Retro Rewind to Original switching. It covers a translated-runtime callback
+failure discovered during that sequence. It is not controller-race,
+performance, physical-device, or release acceptance.
+
+## Reproduction and diagnosis
+
+Across eight observed pre-fix Original launches, seven completed: six were
+base-only cold-launch controls, while one initial switch-sequence launch also
+passed. The return to Original after a successful Retro Rewind launch exited
+while initializing Miis. Its private crash record identified a missing target
+at `MiiManager::Init+0x134`: the second heap allocation saw r30 changed from the
+expected guest heap pointer `0x9011299c` to `0x909999e0`, with a zero indirect
+call target. Both the Original and Retro save hashes remained byte-identical.
+
+`RFLiIsWorking_HLE_800bd860` pumped guest alarm callbacks using the translated
+caller's live `CpuContext`. A callback could consequently publish its return
+registers into the interrupted `RFLInitRes` caller, including its callee-saved
+r30 heap pointer. The timing dependence explains why most cold launches passed
+and why the earlier save-focused controls could not reproduce the exit.
+
+## Repair
+
+The RFL polling override now seeds `GuestInterruptCallbackContext` from the
+current guest thread and executes the alarm queue against that private register
+copy. Callback register writes therefore cannot escape into the translated
+caller. Scheduler switching is suppressed only while that bounded queue is
+pumped, including exception-safe restoration of the disable count.
+
+The source change is carried by
+`patches/wiicompiled-rfl-alarm-context.patch`. Both normal iOS preparation and
+the G7 preparation path apply it; Android inherits the normal iOS patch stack.
+A fresh Android runtime preparation reproduced the changed source byte-for-byte.
+The affected Apple arm64 guest-system unity object also compiled successfully.
+
+## Emulator result
+
+- Ten of ten patched Original cold launches remained alive after 28 seconds.
+- A subsequent visible-emulator sequence reached and retained Original,
+  Retro Rewind, and Original again. The final Original process remained alive
+  beyond 40 seconds and continued into the title attract sequence.
+- The Original save remained SHA-256
+  `708c7a040e0cfe6cd815690e63f46d1678f17899bce0e786f7480030830f1d13`.
+- The Retro save remained SHA-256
+  `3c4aeacd0356a679f261571b53cddfd371a5dc3ff9602be39ca26bdef06ea40e`.
+- No new missing-target crash record appeared during the patched switch run.
+- The local-only ARM64 debug APK passed the strict package/privacy audit at
+  SHA-256 `2ba4b4acf7a395c3d810ff81c0327ad15f9bfbbcbcd76da026ec37444ff7b7d2`.
+
+## Classification
+
+**Pass for the reproduced RFL callback corruption and this bounded emulator
+mode-switch regression.** The evidence changes the earlier unexplained
+intermittent Mii exit into a diagnosed and repaired guest-context isolation
+defect. A production mode chooser, controller-driven Retro Rewind race and
+save/relaunch, trustworthy timing, physical controller/audio/rumble, physical
+Android hardware, and release acceptance remain open. No APK, AAB, save, disc,
+pack, or private crash record was published.

--- a/patches/wiicompiled-android-nand-open.patch
+++ b/patches/wiicompiled-android-nand-open.patch
@@ -1,0 +1,17 @@
+diff --git a/src/hle/storage/nand_api.cpp b/src/hle/storage/nand_api.cpp
+--- a/src/hle/storage/nand_api.cpp
++++ b/src/hle/storage/nand_api.cpp
+@@ -144,13 +144,4 @@
+     FILE* file = std::fopen(hostPath.c_str(), fopenMode);
+-    if (!file && mode >= 2) {
+-        // Try creating for write modes
+-        file = std::fopen(hostPath.c_str(), "w+b");
+-    }
+-    
+-    // Create parent directories and retry
+-    if (!file && CreateParentDirectories(hostPath)) {
+-        file = std::fopen(hostPath.c_str(), mode >= 2 ? "w+b" : "rb");
+-    }
+ 
+     if (!file) {
+         if (IsFaceLibSeedPath(path) && SeedFaceLibFile(path, hostPath)) {

--- a/patches/wiicompiled-android-runtime.patch
+++ b/patches/wiicompiled-android-runtime.patch
@@ -165,6 +165,33 @@
  if(MKW_CPPWINRT_INCLUDE_DIR)
      if(NOT EXISTS "${MKW_CPPWINRT_INCLUDE_DIR}/winrt/base.h")
          message(FATAL_ERROR
+@@ -154,6 +165,26 @@ if(MKW_HAVE_RETRO_REWIND)
+         target_precompile_headers(mkw_retro_sensitive REUSE_FROM mkw_base_shared)
+     endif()
+ 
++    if(ANDROID)
++        set(MKW_ANDROID_RETRO_EXTRA_SOURCES)
++        foreach(source IN LISTS MKW_RETRO_EXTRA_SOURCES)
++            if(source MATCHES "\\.S$")
++                file(READ "${source}" MKW_ANDROID_RETRO_BLOB_CONTENT)
++                string(REPLACE ".section .rdata,\"dr\""
++                    ".section .rodata,\"a\",%progbits"
++                    MKW_ANDROID_RETRO_BLOB_CONTENT
++                    "${MKW_ANDROID_RETRO_BLOB_CONTENT}")
++                get_filename_component(source_name "${source}" NAME)
++                set(normalized_source "${CMAKE_CURRENT_BINARY_DIR}/android_${source_name}")
++                file(WRITE "${normalized_source}" "${MKW_ANDROID_RETRO_BLOB_CONTENT}")
++                list(APPEND MKW_ANDROID_RETRO_EXTRA_SOURCES "${normalized_source}")
++            else()
++                list(APPEND MKW_ANDROID_RETRO_EXTRA_SOURCES "${source}")
++            endif()
++        endforeach()
++        set(MKW_RETRO_EXTRA_SOURCES "${MKW_ANDROID_RETRO_EXTRA_SOURCES}")
++    endif()
++
+     set(MKW_RETRO_TRANSLATED_SOURCES ${MKW_RETRO_MOD_SHARDS} ${MKW_RETRO_EXTRA_SOURCES})
+     set(MKW_RETRO_BLOB_OBJECTS)
+     foreach(source IN LISTS MKW_RETRO_EXTRA_SOURCES)
 @@ -180,7 +191,7 @@
          "${MKW_RUNTIME_SOURCE_DIR}/.."
          "${MKW_RUNTIME_SOURCE_DIR}/../aurora-main/include")
@@ -232,7 +259,7 @@
  endfunction()
  
 -add_executable(WiiCompiled "${MKW_BASE_PRODUCT_SOURCE}" ${MKW_BASE_REGISTRATION_SOURCES})
-+if(ANDROID)
++if(ANDROID AND NOT MKW_HAVE_RETRO_REWIND)
 +    add_library(WiiCompiled SHARED "${MKW_BASE_PRODUCT_SOURCE}" ${MKW_BASE_REGISTRATION_SOURCES})
 +    set_target_properties(WiiCompiled PROPERTIES OUTPUT_NAME main)
 +else()

--- a/patches/wiicompiled-dual-product-target.patch
+++ b/patches/wiicompiled-dual-product-target.patch
@@ -18,17 +18,30 @@ diff --git a/cmake/PublicProducts.cmake b/cmake/PublicProducts.cmake
 index 111d354..366d43e 100644
 --- a/cmake/PublicProducts.cmake
 +++ b/cmake/PublicProducts.cmake
-@@ -282,9 +282,80 @@ else()
+@@ -282,9 +282,93 @@ else()
      message(STATUS "RetroRewind target disabled (run translate-mod and emit-build-shards)")
  endif()
  
 +if(MKW_HAVE_RETRO_REWIND)
-+    add_executable(KartPadDual
-+        "${MKW_KARTPAD_DUAL_PRODUCT_SOURCE}"
-+        ${MKW_BASE_REGISTRATION_SOURCES}
-+        ${MKW_RETRO_REGISTRATION_SOURCES})
++    if(ANDROID)
++        add_library(KartPadDual SHARED
++            "${MKW_KARTPAD_DUAL_PRODUCT_SOURCE}"
++            ${MKW_BASE_REGISTRATION_SOURCES}
++            ${MKW_RETRO_REGISTRATION_SOURCES})
++        set_target_properties(KartPadDual PROPERTIES OUTPUT_NAME main)
++    else()
++        add_executable(KartPadDual
++            "${MKW_KARTPAD_DUAL_PRODUCT_SOURCE}"
++            ${MKW_BASE_REGISTRATION_SOURCES}
++            ${MKW_RETRO_REGISTRATION_SOURCES})
++    endif()
 +    mkw_configure_product(KartPadDual)
-+    target_precompile_headers(KartPadDual REUSE_FROM WiiCompiled)
++    if(ANDROID)
++        target_precompile_headers(KartPadDual PRIVATE
++            "${MKW_RUNTIME_SOURCE_DIR}/include/mkw_pch.h")
++    else()
++        target_precompile_headers(KartPadDual REUSE_FROM WiiCompiled)
++    endif()
 +    if(TARGET mkw_base_sensitive)
 +        target_sources(KartPadDual PRIVATE $<TARGET_OBJECTS:mkw_base_sensitive>)
 +    endif()

--- a/patches/wiicompiled-offline-kd-services.patch
+++ b/patches/wiicompiled-offline-kd-services.patch
@@ -1,0 +1,37 @@
+--- a/src/hle/net/network_core.cpp
++++ b/src/hle/net/network_core.cpp
+@@ -675,15 +675,18 @@ extern "C" int32_t Network_HLE_OpenDevice(const char* path, uint32_t mode) {
+     if (!path) {
+         return -101;
+     }
+-    if (!RuntimeConfigFile::NetworkEnabled(true)) {
+-        // The guest opens several /dev/net nodes at boot and retries; report the
+-        // reason online will not work exactly once.
++    const bool isIpTop = std::strcmp(path, "/dev/net/ip/top") == 0;
++    const bool isSsl = std::strcmp(path, "/dev/net/ssl") == 0;
++    if ((isIpTop || isSsl) && !RuntimeConfigFile::NetworkEnabled(true)) {
++        // KD request/time and NCD are local Wii system services, not Internet
++        // access. They must remain available offline so first-run save and
++        // license initialization can complete. Gate only socket/TLS devices.
+         static bool reported = false;
+         if (!reported) {
+             reported = true;
+             NetFail("networking is disabled in Config.toml; online play is unavailable");
+         }
+         return 0;
+     }
+     DeviceKind kind;
+     if (std::strcmp(path, "/dev/net/kd/request") == 0) {
+@@ -693,10 +696,10 @@ extern "C" int32_t Network_HLE_OpenDevice(const char* path, uint32_t mode) {
+         kind = DeviceKind::KdTime;
+     } else if (std::strcmp(path, "/dev/net/ncd/manage") == 0) {
+         kind = DeviceKind::NcdManage;
+-    } else if (std::strcmp(path, "/dev/net/ip/top") == 0) {
++    } else if (isIpTop) {
+         kind = DeviceKind::IpTop;
+         EnsureSocketRuntime();
+-    } else if (std::strcmp(path, "/dev/net/ssl") == 0) {
++    } else if (isSsl) {
+         kind = DeviceKind::Ssl;
+         EnsureSocketRuntime();
+     } else {

--- a/patches/wiicompiled-rfl-alarm-context.patch
+++ b/patches/wiicompiled-rfl-alarm-context.patch
@@ -1,0 +1,33 @@
+--- a/src/hle/os/os_alarm.cpp
++++ b/src/hle/os/os_alarm.cpp
+@@ -446,15 +446,22 @@
+ // returning 0 when the manager pointer (0x80386298) is null.
+ extern "C" uint32_t RFLiIsWorking_HLE_800bd860()
+ {
+-    // Pump alarms/callbacks on the current guest thread when available. Using a
+-    // detached persistent context here can leave the busy loop waiting on work
+-    // that completed on the wrong scheduling context.
+-    CpuContext* cpu = TryGetCpuContext();
+-    if (!cpu) {
+-        cpu = &GetPersistentCpuContext();
+-    }
++    // RFL polls from the middle of translated RFLInitRes. Alarm handlers are
++    // guest interrupts and must not publish their return registers into that
++    // live caller (notably its callee-saved heap pointer in r30). Seed a private
++    // interrupt context from the current thread so callbacks still observe the
++    // correct guest state while their register writes remain isolated.
++    GuestInterruptCallbackContext interrupt;
++    CpuContext* cpu = interrupt.get();
+     EnsureSda1Base(cpu);
+-    ProcessAlarmQueue(cpu, 32);
++    IncrementSchedulerDisableCount();
++    try {
++        ProcessAlarmQueue(cpu, 32);
++    } catch (...) {
++        DecrementSchedulerDisableCount();
++        throw;
++    }
++    DecrementSchedulerDisableCount();
+ 
+     // Now return the actual "working" status
+     constexpr uint32_t kRflManagerPtrAddr = 0x80386298u;

--- a/scripts/build-android-game-app.sh
+++ b/scripts/build-android-game-app.sh
@@ -34,6 +34,12 @@ if [[ ! -f "$(dirname "$runtime_source")/generated/data_sections_init.cpp" ]]; t
   exit 1
 fi
 
+native_target="WiiCompiled"
+if grep -Eq '^set\(MKW_HAVE_RETRO_REWIND_SHARDS ON\)' \
+  "$translation_root/build_shards/shards.cmake"; then
+  native_target="KartPadDual"
+fi
+
 export JAVA_HOME="$repo_root/.android-bootstrap/jdk-$KARTPAD_ANDROID_JDK_VERSION/Contents/Home"
 export ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/Library/Android/sdk}}"
 export DAWN_ANDROID_ROOT="$dawn_root"
@@ -42,6 +48,7 @@ export MINIZIP_ANDROID_ROOT="$minizip_root"
 "$repo_root/android/gradlew" --project-dir "$repo_root/android" --no-daemon \
   -PkartpadGameRuntimeSource="$runtime_source" \
   -PkartpadTranslatedShardManifest="$translation_root/build_shards/shards.cmake" \
+  -PkartpadAndroidNativeTarget="$native_target" \
   :app:assembleDebug
 
 apk="$repo_root/android/app/build/outputs/apk/debug/app-debug.apk"

--- a/scripts/prepare-android-game-runtime.sh
+++ b/scripts/prepare-android-game-runtime.sh
@@ -47,6 +47,8 @@ patch --batch -p1 -d "$runtime_source" < \
 patch --batch -p1 -d "$runtime_source" < \
   "$repo_root/patches/wiicompiled-android-private-paths.patch"
 patch --batch -p1 -d "$runtime_source" < \
+  "$repo_root/patches/wiicompiled-android-nand-open.patch"
+patch --batch -p1 -d "$runtime_source" < \
   "$repo_root/patches/wiicompiled-android-surface-resume.patch"
 patch --batch -p1 -d "$runtime_source" < \
   "$repo_root/patches/wiicompiled-android-keyboard-steer.patch"

--- a/scripts/prepare-g7-game-runtime.sh
+++ b/scripts/prepare-g7-game-runtime.sh
@@ -63,6 +63,8 @@ patch -p1 -d "${runtime_source}" < \
 patch -p1 -d "${runtime_source}" < \
   "${repo_root}/patches/wiicompiled-local-wfc-test-route.patch"
 patch -p1 -d "${runtime_source}" < \
+  "${repo_root}/patches/wiicompiled-offline-kd-services.patch"
+patch -p1 -d "${runtime_source}" < \
   "${repo_root}/patches/wiicompiled-blocking-stream-recv-wait.patch"
 patch -p1 -d "${runtime_source}" < \
   "${repo_root}/patches/wiicompiled-mii-seed.patch"

--- a/scripts/prepare-g7-game-runtime.sh
+++ b/scripts/prepare-g7-game-runtime.sh
@@ -53,6 +53,8 @@ patch --batch -p1 -d "${runtime_source}/aurora-main" < \
   "${repo_root}/patches/aurora-gx-resolve-snapshot-copy-src.patch"
 patch -p1 -d "${runtime_source}" < "${repo_root}/patches/wiicompiled-apple-runtime.patch"
 patch -p1 -d "${runtime_source}" < \
+  "${repo_root}/patches/wiicompiled-rfl-alarm-context.patch"
+patch -p1 -d "${runtime_source}" < \
   "${repo_root}/patches/wiicompiled-experimental-wiimote-preset.patch"
 patch -p1 -d "${runtime_source}" < \
   "${repo_root}/patches/wiicompiled-macos-cursor-visibility.patch"

--- a/scripts/prepare-ios-game-runtime.sh
+++ b/scripts/prepare-ios-game-runtime.sh
@@ -84,6 +84,8 @@ patch --batch -p1 -d "${runtime_source}/aurora-main" < \
   "${repo_root}/patches/aurora-ios-simulator-single-pipeline-worker.patch"
 patch --batch -p1 -d "${runtime_source}" < "${repo_root}/patches/wiicompiled-apple-runtime.patch"
 patch --batch -p1 -d "${runtime_source}" < \
+  "${repo_root}/patches/wiicompiled-rfl-alarm-context.patch"
+patch --batch -p1 -d "${runtime_source}" < \
   "${repo_root}/patches/wiicompiled-experimental-wiimote-preset.patch"
 patch --batch -p1 -d "${runtime_source}" < \
   "${repo_root}/patches/wiicompiled-apple-network-tls.patch"

--- a/scripts/prepare-ios-game-runtime.sh
+++ b/scripts/prepare-ios-game-runtime.sh
@@ -92,6 +92,8 @@ patch --batch -p1 -d "${runtime_source}" < \
 patch --batch -p1 -d "${runtime_source}" < \
   "${repo_root}/patches/wiicompiled-local-wfc-test-route.patch"
 patch --batch -p1 -d "${runtime_source}" < \
+  "${repo_root}/patches/wiicompiled-offline-kd-services.patch"
+patch --batch -p1 -d "${runtime_source}" < \
   "${repo_root}/patches/wiicompiled-blocking-stream-recv-wait.patch"
 patch --batch -p1 -d "${runtime_source}" < \
   "${repo_root}/patches/wiicompiled-mii-seed.patch"

--- a/tests/test_offline_kd_services_contract.py
+++ b/tests/test_offline_kd_services_contract.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+class OfflineKdServicesContractTests(unittest.TestCase):
+    def test_patch_gates_only_internet_devices(self) -> None:
+        patch = (REPO / "patches/wiicompiled-offline-kd-services.patch").read_text()
+
+        for local_service in (
+            '"/dev/net/kd/request"',
+            '"/dev/net/ncd/manage"',
+        ):
+            self.assertIn(local_service, patch)
+        self.assertIn("KD request/time and NCD are local Wii system services", patch)
+        self.assertIn("if ((isIpTop || isSsl) && !RuntimeConfigFile::NetworkEnabled(true))", patch)
+        self.assertNotIn("+    if (!RuntimeConfigFile::NetworkEnabled(true))", patch)
+
+    def test_common_runtime_preparation_applies_patch(self) -> None:
+        patch_name = "wiicompiled-offline-kd-services.patch"
+        for script_name in (
+            "prepare-ios-game-runtime.sh",
+            "prepare-g7-game-runtime.sh",
+        ):
+            script = (REPO / "scripts" / script_name).read_text()
+            self.assertIn(patch_name, script, script_name)
+
+        android_script = (REPO / "scripts/prepare-android-game-runtime.sh").read_text()
+        self.assertIn("prepare-ios-game-runtime.sh", android_script)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- build only the selected Android native product and link the complete Original/Retro Rewind graph as `libmain.so`
- normalize Retro generated blob assembly for ELF and remove the Android dual target's standalone-base PCH dependency
- add an explicit debug-only validated runtime selector and document offline Retro title/menu plus save-preserving cold relaunch evidence

## Verification
- fresh dual runtime preparation: pass
- complete dual Android build: pass
- `./scripts/audit-android-package.sh android/app/build/outputs/apk/debug/app-debug.apk`: pass
- `./scripts/test-android-retro-rewind-content.sh`: pass
- `python3 -m unittest tests.test_builder_generated_link_contract`: pass
- `bash -n scripts/build-android-game-app.sh`: pass
- `git diff --check`: pass

## Acceptance boundary
This proves explicit validated Retro Rewind 6.12.5 offline title/menu boot and save-preserving cold relaunch on the API 36 ARM64 emulator. It does not yet prove a race, production mode chooser, arbitrary fresh-NAND creation, touch parity, physical hardware, or release acceptance.