### PR TITLE
Reduce iOS audio queue latency

### DIFF
--- a/patches/wiicompiled-ios-low-latency-audio.patch
+++ b/patches/wiicompiled-ios-low-latency-audio.patch
@@ -1,0 +1,34 @@
+diff --git a/src/audio_backend.cpp b/src/audio_backend.cpp
+--- a/src/audio_backend.cpp
++++ b/src/audio_backend.cpp
+@@ -7,7 +7,9 @@
+ #include <cstdlib>
+ #include <iostream>
+ 
++#include <SDL3/SDL_hints.h>
+ #include <SDL3/SDL_init.h>
++#include <TargetConditionals.h>
+ 
+ AudioBackend& AudioBackend::Instance() {
+     static AudioBackend instance;
+@@ -47,4 +49,8 @@ bool AudioBackend::EnsureInitializedLocked(uint32_t sampleRate, uint32_t channel
++#if TARGET_OS_IOS
++    SDL_SetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, "512");
++#endif
++
+     if (!SDL_InitSubSystem(SDL_INIT_AUDIO)) {
+         RT_LOG(RT_TAG_AUDIO) << "SDL_InitSubSystem(SDL_INIT_AUDIO) failed: " << SDL_GetError() << std::endl;
+         return false;
+     }
+@@ -114,7 +120,11 @@ void AudioBackend::Shutdown() {
+ }
+ 
+ uint32_t AudioBackend::QueueLimitBytesLocked() const {
++#if TARGET_OS_IOS
++    constexpr uint32_t queueMs = 60;
++#else
+     constexpr uint32_t queueMs = 120;
++#endif
+ 
+     const uint64_t bytesPerSecond = static_cast<uint64_t>(m_spec.freq) *
+                                     static_cast<uint64_t>(m_spec.channels) *

--- a/scripts/prepare-ios-game-runtime.sh
+++ b/scripts/prepare-ios-game-runtime.sh
@@ -84,6 +84,8 @@ patch --batch -p1 -d "${runtime_source}/aurora-main" < \
   "${repo_root}/patches/aurora-ios-simulator-single-pipeline-worker.patch"
 patch --batch -p1 -d "${runtime_source}" < "${repo_root}/patches/wiicompiled-apple-runtime.patch"
 patch --batch -p1 -d "${runtime_source}" < \
+  "${repo_root}/patches/wiicompiled-ios-low-latency-audio.patch"
+patch --batch -p1 -d "${runtime_source}" < \
   "${repo_root}/patches/wiicompiled-experimental-wiimote-preset.patch"
 patch --batch -p1 -d "${runtime_source}" < \
   "${repo_root}/patches/wiicompiled-apple-network-tls.patch"

--- a/tests/test_ios_low_latency_audio_contract.py
+++ b/tests/test_ios_low_latency_audio_contract.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class IOSLowLatencyAudioContractTests(unittest.TestCase):
+    def test_audio_patch_is_applied_after_the_apple_runtime_patch(self) -> None:
+        script = (ROOT / "scripts/prepare-ios-game-runtime.sh").read_text()
+        apple_runtime = "wiicompiled-apple-runtime.patch"
+        low_latency = "wiicompiled-ios-low-latency-audio.patch"
+
+        self.assertEqual(script.count(low_latency), 1)
+        self.assertLess(script.index(apple_runtime), script.index(low_latency))
+
+    def test_policy_is_ios_only_and_keeps_the_existing_fallback(self) -> None:
+        patch = (ROOT / "patches/wiicompiled-ios-low-latency-audio.patch").read_text()
+
+        self.assertIn("#if TARGET_OS_IOS", patch)
+        self.assertIn('SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, "512"', patch)
+        self.assertIn("constexpr uint32_t queueMs = 60", patch)
+        self.assertIn("constexpr uint32_t queueMs = 120", patch)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The iOS build currently inherits the 120 ms audio queue limit used on other
platforms. Because the producer stays slightly ahead of the output device, the
queue spends most of its time near that limit and adds noticeable latency.

This lowers the iOS queue limit to 60 ms and asks SDL for 512-frame output chunks
before initializing its audio subsystem. In the pinned SDL CoreAudio backend,
that changes the AudioQueue depth from 3 x 1024 frames to 4 x 512 frames: 64 ms
to about 43 ms at 48 kHz. Both changes are guarded by `TARGET_OS_IOS`; other
targets keep the existing 120 ms behavior.

The smaller queue also removes 60 ms of protection against producer stalls, so
a long frame or loading stall can reach silence sooner than before. SDL recovers
normally if that happens.

I tested the change in a Retro Rewind race on an iPhone 17 Pro with AirPods Max.
SDL opened the output device at 48 kHz with 512-frame chunks. The bounded queue
dropped about 0.94% of submitted audio because the producer ran slightly faster
than the device. I did not hear breakup or instability during the race.

Tests:

- `PYTHONPATH=builder python3 -m unittest -v tests.test_ios_low_latency_audio_contract`
- `bash -n scripts/prepare-ios-game-runtime.sh`
- `git diff --check`
- Physical-device race using Retro Rewind and AirPods Max
