### PR TITLE
Fix Retro Rewind cup and course names

### DIFF
--- a/patches/wiicompiled-dynamic-overrides.patch
+++ b/patches/wiicompiled-dynamic-overrides.patch
@@ -1,0 +1,132 @@
+diff --git a/translator/src/Translator.Core/Build/TranslatedBuildShardEmitter.cs b/translator/src/Translator.Core/Build/TranslatedBuildShardEmitter.cs
+--- a/translator/src/Translator.Core/Build/TranslatedBuildShardEmitter.cs
++++ b/translator/src/Translator.Core/Build/TranslatedBuildShardEmitter.cs
+@@ -185,7 +185,16 @@
+         var rrTraits = new Dictionary<uint, Trait>(BuildRetroTraits(activeBase, baseTraits, retroEntries));
+         foreach (var address in nativeOverrides.RawTranslatedOverrides.Keys)
+             rrTraits[address] = baseTraits[address];
++        var overriddenTargets = FindOverriddenTargets(baseTraits, rrTraits);
++        foreach (var address in overriddenTargets)
++        {
++            if (baseTraits.TryGetValue(address, out var baseTrait))
++                baseTraits[address] = baseTrait with { MustRemainDynamicallyDispatchable = true };
++            if (rrTraits.TryGetValue(address, out var rrTrait))
++                rrTraits[address] = rrTrait with { MustRemainDynamicallyDispatchable = true };
++        }
+         var sensitiveTargets = FindProfileSensitiveTargets(baseTraits, rrTraits);
++        sensitiveTargets.UnionWith(overriddenTargets);
+         var sensitiveCallers = activeBase
+             .Where(record => record.DirectCalls.Any(sensitiveTargets.Contains))
+             .Select(static record => record.Address)
+@@ -573,6 +582,25 @@
+                 baseTrait.Available != rrTrait.Available ||
+                 baseTrait.PreservesNonvolatileFprs != rrTrait.PreservesNonvolatileFprs ||
+                 baseTrait.NonvolatileFprWriteMask != rrTrait.NonvolatileFprWriteMask)
++            {
++                result.Add(address);
++            }
++        }
++        return result;
++    }
++
++    private static HashSet<uint> FindOverriddenTargets(
++        IReadOnlyDictionary<uint, Trait> baseTraits,
++        IReadOnlyDictionary<uint, Trait> rrTraits)
++    {
++        var result = new HashSet<uint>();
++        foreach (var (address, baseTrait) in baseTraits)
++        {
++            if (!rrTraits.TryGetValue(address, out var rrTrait) ||
++                baseTrait.Available != rrTrait.Available ||
++                !string.Equals(baseTrait.WinnerSymbol, rrTrait.WinnerSymbol, StringComparison.Ordinal) ||
++                !string.Equals(baseTrait.WinnerKind, rrTrait.WinnerKind, StringComparison.OrdinalIgnoreCase) ||
++                baseTrait.WinnerPriority != rrTrait.WinnerPriority)
+             {
+                 result.Add(address);
+             }
+@@ -589,10 +617,12 @@
+         output.AppendLine($"// Translator-owned direct-call traits: {label}.");
+         foreach (var (address, trait) in traits.OrderBy(static pair => pair.Key))
+         {
+-            if (!trait.Available || string.IsNullOrWhiteSpace(trait.WinnerSymbol)) continue;
+-            // Dynamic-dispatch and preserves_nonvolatile_fprs are deliberately not arguments here:
+-            // direct calls are always non-overridable literal edges, and the macro guard is
+-            // selected by the mask alone.
++            if (!trait.Available ||
++                trait.MustRemainDynamicallyDispatchable ||
++                string.IsNullOrWhiteSpace(trait.WinnerSymbol)) continue;
++            // Only non-overridable winners receive a static specialization. Dynamic targets keep
++            // the primary template and therefore route InvokeDirectCpu through the registry.
++            // The macro guard is selected by the nonvolatile FPR mask alone.
+             output.AppendLine(
+                 $"MKW_TRANSLATED_TRAIT({address:X8}, {trait.WinnerSymbol}, 0x{trait.NonvolatileFprWriteMask:X8}u);");
+         }
+@@ -639,7 +669,7 @@
+                 .Where(traits.ContainsKey)
+                 .ToDictionary(address => address, address => traits[address]);
+             var traitIdentity = string.Join("\n", dependencyTraits.OrderBy(static pair => pair.Key).Select(pair =>
+-                $"{pair.Key:X8}:{pair.Value.Available}:{pair.Value.PreservesNonvolatileFprs}:{pair.Value.NonvolatileFprWriteMask:X8}:{pair.Value.WinnerSymbol}"));
++                $"{pair.Key:X8}:{pair.Value.Available}:{pair.Value.PreservesNonvolatileFprs}:{pair.Value.NonvolatileFprWriteMask:X8}:{pair.Value.MustRemainDynamicallyDispatchable}:{pair.Value.WinnerSymbol}"));
+             var identity = string.Join("\n", group.Select(function => $"{function.Address:X8}:{function.SourceFingerprint}")) + "\n" + traitIdentity;
+             var hash = ChecksumUtilities.Sha256Hex(Encoding.UTF8.GetBytes($"{partition}\n{identity}"));
+             // Membership, not the transient scheduling position, is the shard
+@@ -970,7 +1000,9 @@
+         {
+             var group = groups[index];
+             if (group.Count == 0) continue;
+-            var identity = string.Join("\n", group.Select(record => $"{record.Address:X8}:{record.Symbol}:{record.SourceFingerprint}"));
++            var identity = string.Join("\n", group.Select(record =>
++                $"{record.Address:X8}:{record.Symbol}:{record.SourceFingerprint}:" +
++                $"{(traits.TryGetValue(record.Address, out var trait) && trait.MustRemainDynamicallyDispatchable)}"));
+             var hash = ChecksumUtilities.Sha256Hex(Encoding.UTF8.GetBytes($"{profile}\n{identity}"));
+             var path = Path.Combine(directory, $"registration_{index:D2}_{hash[..16]}.cpp");
+             var source = new StringBuilder();
+diff --git a/translator/tests/Translator.Tests/TranslatedBuildShardEmitterTests.cs b/translator/tests/Translator.Tests/TranslatedBuildShardEmitterTests.cs
+--- a/translator/tests/Translator.Tests/TranslatedBuildShardEmitterTests.cs
++++ b/translator/tests/Translator.Tests/TranslatedBuildShardEmitterTests.cs
+@@ -111,13 +111,13 @@
+             var shardText = File.ReadAllText(shard);
+             Assert.Contains("#include \"abi_bridge.h\"", shardText);
+             Assert.DoesNotContain("#include \"" + Path.GetFullPath(Path.Combine(functions, "func_80001000.cpp")).Replace('\\', '/'), shardText);
+-            Assert.Contains("MKW_STATIC_TRANSLATED_CALL(0x80002000u, func_80002000, ctx);", shardText);
++            Assert.Contains("InvokeDirectCpu<0x80002000u>(ctx);", shardText);
+             Assert.Contains("ApplyRuntimeCallOptions(Target, Context)", shardText);
+ 
+             var portableBaseTraits = Directory.GetFiles(Path.Combine(output, "base_portable_sensitive"), "*_traits.h").Single();
+             var portableRetroTraits = Directory.GetFiles(Path.Combine(output, "retro_portable_sensitive"), "*_traits.h").Single();
+-            Assert.Contains("MKW_TRANSLATED_TRAIT(80002000, func_80002000,", File.ReadAllText(portableBaseTraits));
+-            Assert.Contains("MKW_TRANSLATED_TRAIT(80002000, rr_80002000,", File.ReadAllText(portableRetroTraits));
++            Assert.DoesNotContain("MKW_TRANSLATED_TRAIT(80002000,", File.ReadAllText(portableBaseTraits));
++            Assert.DoesNotContain("MKW_TRANSLATED_TRAIT(80002000,", File.ReadAllText(portableRetroTraits));
+             var baseDispatch = Directory.GetFiles(Path.Combine(output, "base_dispatch"), "*.cpp").Single();
+             var baseDispatchText = File.ReadAllText(baseDispatch);
+             Assert.Contains("const StaticIndirectDispatchSegment kSegments[256]", baseDispatchText);
+@@ -151,7 +151,7 @@
+     }
+ 
+     [Fact]
+-    public void BindsDirectCallsToTheSelectedProfileWinner()
++    public void KeepsOverriddenTargetsDynamicallyDispatchable()
+     {
+         var root = Path.Combine(Path.GetTempPath(), $"translator-same-tu-calls-{Guid.NewGuid():N}");
+         var functions = Path.Combine(root, "functions");
+@@ -247,9 +247,18 @@
+             var baseSpecific = Directory.GetFiles(Path.Combine(output, "base_portable_sensitive"), "*.cpp")
+                 .Select(File.ReadAllText)
+                 .Aggregate(string.Concat);
+-            Assert.Contains("MKW_STATIC_TRANSLATED_CALL(0x80005000u, func_80005000, ctx);", baseSpecific);
++            Assert.Contains("InvokeDirectCpu<0x80005000u>(ctx);", baseSpecific);
+             Assert.Contains("MKW_STATIC_TRANSLATED_CALL(0x80002000u, func_80002000, ctx);", baseSpecific);
+ 
++            var baseTraits = Directory.GetFiles(Path.Combine(output, "base_portable_sensitive"), "*_traits.h")
++                .Select(File.ReadAllText)
++                .Aggregate(string.Concat);
++            var retroTraits = Directory.GetFiles(Path.Combine(output, "retro_portable_sensitive"), "*_traits.h")
++                .Select(File.ReadAllText)
++                .Aggregate(string.Concat);
++            Assert.DoesNotContain("MKW_TRANSLATED_TRAIT(80005000,", baseTraits);
++            Assert.DoesNotContain("MKW_TRANSLATED_TRAIT(80005000,", retroTraits);
++
+             // The lowering choice participates in shard identity, so a rebuild is
+             // byte-identical and file identities are stable.
+             var timestamps = Directory.GetFiles(output, "*", SearchOption.AllDirectories)

--- a/scripts/prepare-patched-translator.sh
+++ b/scripts/prepare-patched-translator.sh
@@ -9,6 +9,7 @@ dual_profile_patch="$repo/patches/wiicompiled-dual-profile-translator.patch"
 kamek_v2_patch="$repo/patches/wiicompiled-kamek-v2.patch"
 dual_symbols_patch="$repo/patches/wiicompiled-dual-profile-symbols.patch"
 dual_closure_patch="$repo/patches/wiicompiled-dual-profile-closure.patch"
+dynamic_overrides_patch="$repo/patches/wiicompiled-dynamic-overrides.patch"
 
 mkdir -p "$stage"
 rsync -a --delete --exclude .git --exclude bin --exclude obj \
@@ -18,6 +19,7 @@ git apply --recount --unsafe-paths --directory="$stage" "$dual_profile_patch"
 git apply --recount --unsafe-paths --directory="$stage" "$kamek_v2_patch"
 patch --batch -p1 -d "$stage" < "$dual_symbols_patch"
 patch --batch -p1 -d "$stage" < "$dual_closure_patch"
+patch --batch -p1 -d "$stage" < "$dynamic_overrides_patch"
 
 dotnet_bin=/opt/homebrew/opt/dotnet@8/bin/dotnet
 project="$stage/translator/src/Translator.Cli/Translator.Cli.csproj"


### PR DESCRIPTION
## Problem

Retro Rewind 6.12.5 could launch and race normally while showing stock Mario
Kart Wii cup and course names in its menus. The overlay contained the correct
message functions, but calls at `0x805F8C88` and `0x805F8CF0` still reached the
base-game implementations.

## Cause

The translator statically specializes direct calls to the winner selected when
it emits a shard. That is valid for targets shared by every profile. It is not
valid when an overlay replaces the target: the static call bypasses the runtime
registry and permanently binds the caller to the base winner.

## Fix

Compare the resolved base and Retro Rewind traits and mark targets with a
different winner as dynamically dispatchable. Calls to those targets keep the
registry-backed `InvokeDirectCpu` path. Invariant targets retain the static fast
path.

Include dispatchability in function and registration shard identities so an
incremental build cannot reuse output with stale call lowering.

## Tests

- focused translated-shard emitter tests: 4 passed
- full translator suite: 585 passed
- Retro Rewind 6.12.5 graph: 56 affected calls dynamic, none static; 84,960 invariant calls remain static
- iPhone 17 Pro: build 27 showed the correct Retro Rewind cup/course names and raced for more than one minute
