### PR TITLE
Fix iOS installed-version launch crash

### DIFF
--- a/patches/aurora-viewport-policy-window-guard.patch
+++ b/patches/aurora-viewport-policy-window-guard.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/dolphin/gx/GXAurora.cpp b/lib/dolphin/gx/GXAurora.cpp
+--- a/lib/dolphin/gx/GXAurora.cpp
++++ b/lib/dolphin/gx/GXAurora.cpp
+@@ -47,7 +47,7 @@ void AuroraSetViewportPolicy(AuroraViewportPolicy policy) {
+   g_gxState.viewportPolicy = policy;
+   aurora::window::set_frame_buffer_aspect_fit(policy == AURORA_VIEWPORT_FIT);
+   aurora::window::set_present_surface_fill(policy == AURORA_VIEWPORT_STRETCH);
+-  if (changed) {
++  if (changed && aurora::window::get_sdl_window() != nullptr) {
+     // Reapply the guest viewport and scissor after a resize.
+     aurora::gx::set_logical_viewport(g_gxState.logicalViewport);
+     aurora::gx::set_logical_scissor(g_gxState.logicalScissor);

--- a/scripts/prepare-g7-game-runtime.sh
+++ b/scripts/prepare-g7-game-runtime.sh
@@ -51,6 +51,8 @@ patch --batch -p1 -d "${runtime_source}/aurora-main" < \
   "${repo_root}/patches/aurora-present-telemetry.patch"
 patch --batch -p1 -d "${runtime_source}/aurora-main" < \
   "${repo_root}/patches/aurora-gx-resolve-snapshot-copy-src.patch"
+patch --batch -p1 -d "${runtime_source}/aurora-main" < \
+  "${repo_root}/patches/aurora-viewport-policy-window-guard.patch"
 patch -p1 -d "${runtime_source}" < "${repo_root}/patches/wiicompiled-apple-runtime.patch"
 patch -p1 -d "${runtime_source}" < \
   "${repo_root}/patches/wiicompiled-experimental-wiimote-preset.patch"

--- a/scripts/prepare-ios-game-runtime.sh
+++ b/scripts/prepare-ios-game-runtime.sh
@@ -82,6 +82,8 @@ patch --batch -p1 -d "${runtime_source}/aurora-main" < \
   "${repo_root}/patches/aurora-ios-opaque-letterbox.patch"
 patch --batch -p1 -d "${runtime_source}/aurora-main" < \
   "${repo_root}/patches/aurora-ios-simulator-single-pipeline-worker.patch"
+patch --batch -p1 -d "${runtime_source}/aurora-main" < \
+  "${repo_root}/patches/aurora-viewport-policy-window-guard.patch"
 patch --batch -p1 -d "${runtime_source}" < "${repo_root}/patches/wiicompiled-apple-runtime.patch"
 patch --batch -p1 -d "${runtime_source}" < \
   "${repo_root}/patches/wiicompiled-experimental-wiimote-preset.patch"

--- a/tests/test_aurora_viewport_policy_window_guard.py
+++ b/tests/test_aurora_viewport_policy_window_guard.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+PATCH_NAME = "aurora-viewport-policy-window-guard.patch"
+
+
+class AuroraViewportPolicyWindowGuardTests(unittest.TestCase):
+    def test_policy_change_defers_viewport_reapply_until_window_exists(self) -> None:
+        patch = (REPO / "patches" / PATCH_NAME).read_text()
+        self.assertIn(
+            "if (changed && aurora::window::get_sdl_window() != nullptr)",
+            patch,
+        )
+        self.assertIn("aurora::gx::set_logical_viewport", patch)
+        self.assertIn("aurora::gx::set_logical_scissor", patch)
+
+    def test_runtime_preparation_applies_window_guard(self) -> None:
+        for script_name in (
+            "prepare-g7-game-runtime.sh",
+            "prepare-ios-game-runtime.sh",
+        ):
+            script = (REPO / "scripts" / script_name).read_text()
+            self.assertIn(PATCH_NAME, script, script_name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

On iOS, pressing **Launch Installed Version** could leave a white runtime view
and terminate the app instead of starting the installed game. LLDB showed an
abort while applying the saved viewport policy before Aurora had created its
SDL window.

## Cause

`AuroraSetViewportPolicy` immediately reapplied the guest viewport and scissor
whenever the policy changed. During startup, that path queries the render-target
size through a null SDL window and calls Aurora's fatal handler.

## Fix

Only defer the viewport/scissor reapply when the SDL window does not exist. The
policy, aspect-fit, and surface-fill state is still recorded, and normal runtime
initialization applies it after creating the window.

Apply the Aurora patch in both Apple runtime preparation paths.

## Tests

- `PYTHONPATH=builder python3 -m unittest -v tests.test_aurora_viewport_policy_window_guard`
- `PYTHONPATH=builder python3 -m unittest discover -s tests` (55 passed, 1 skipped)
- iPhone 17 Pro: build 27 launched the installed Retro Rewind runtime offline and raced for more than one minute
