### PR TITLE
Add shake gestures for tricks and bike wheelies on iOS

### DIFF
--- a/apple/ios/KartPadRuntimeOverlayHost.mm
+++ b/apple/ios/KartPadRuntimeOverlayHost.mm
@@ -2231,8 +2231,9 @@ NSError *KartPadPerformGameDataImport(NSURL *url,
   KartPadMotionSteering *motion = [KartPadMotionSteering sharedSteering];
   NSString *status = motion.sensorAvailable
       ? [NSString stringWithFormat:
-            @"Tilt the device like a steering wheel. Current state: %@. Sensitivity: %.1fx. Physical controllers take priority.",
-            motion.enabled ? @"On" : @"Off", motion.sensitivity]
+            @"Tilt steering: %@. Shake tricks/wheelies: %@. Sensitivity: %.1fx. Physical controllers take priority.",
+            motion.enabled ? @"On" : @"Off",
+            motion.shakeTricksEnabled ? @"On" : @"Off", motion.sensitivity]
       : @"Motion data is unavailable on this device or Simulator. Touch and physical-controller steering remain available.";
   UIAlertController *sheet =
       [UIAlertController alertControllerWithTitle:@"Motion Steering"
@@ -2261,6 +2262,15 @@ NSError *KartPadPerformGameDataImport(NSURL *url,
                   handler:^(UIAlertAction *action) {
       (void)action;
       motion.inverted = !motion.inverted;
+    }]];
+    [sheet addAction:[UIAlertAction
+        actionWithTitle:motion.shakeTricksEnabled
+            ? @"Disable Shake Tricks/Wheelies"
+            : @"Enable Shake Tricks/Wheelies"
+                    style:UIAlertActionStyleDefault
+                  handler:^(UIAlertAction *action) {
+      (void)action;
+      motion.shakeTricksEnabled = !motion.shakeTricksEnabled;
     }]];
     [sheet addAction:[UIAlertAction
         actionWithTitle:@"Cycle Sensitivity"
@@ -2774,14 +2784,12 @@ extern "C" bool KartPadMobileReadClassicInputForPlayer(
   }
   KartPadClassicInputState adapted =
       kartpad::mobile::AdaptSunPadInput(source);
+  KartPadMotionSteering *motion = [KartPadMotionSteering sharedSteering];
+  const BOOL shakeTrick = player == 0 ? [motion consumeShakeTrick] : NO;
   if (player == 0 &&
       [KartPadPhysicalControllers sharedControllers].connectedControllerCount == 0) {
-    const float motion = [KartPadMotionSteering sharedSteering].currentSteering;
-    const int motionStick = static_cast<int>(std::lround(motion * 127.0f));
-    if (std::abs(motionStick) > std::abs(static_cast<int>(adapted.leftStickX))) {
-      adapted.leftStickX = static_cast<std::int8_t>(
-          std::clamp(motionStick, -127, 127));
-    }
+    kartpad::mobile::ApplyMotionInput(adapted, motion.currentSteering,
+                                      shakeTrick);
   }
   snapshot->buttons = adapted.buttons;
   snapshot->leftStickX = std::clamp(static_cast<float>(adapted.leftStickX) / 127.0f,

--- a/apple/mobile/KartPadClassicInput.h
+++ b/apple/mobile/KartPadClassicInput.h
@@ -43,4 +43,9 @@ inline constexpr std::uint32_t kClassicButtonRight = 0x00008000;
  * unchanged; only this boundary is game-specific. */
 [[nodiscard]] KartPadClassicInputState AdaptSunPadInput(SunPadInputState input) noexcept;
 
+/* Merge phone motion after touch adaptation. A shake is exposed as one Classic
+ * D-pad Up sample; Mario Kart decides whether that means a trick or wheelie. */
+void ApplyMotionInput(KartPadClassicInputState& input, float steering,
+                      bool shakeTrick) noexcept;
+
 }  // namespace kartpad::mobile

--- a/apple/mobile/KartPadClassicInput.mm
+++ b/apple/mobile/KartPadClassicInput.mm
@@ -1,5 +1,8 @@
 #include "KartPadClassicInput.h"
 
+#include <algorithm>
+#include <cmath>
+
 namespace kartpad::mobile {
 namespace {
 
@@ -42,6 +45,19 @@ KartPadClassicInputState AdaptSunPadInput(const SunPadInputState input) noexcept
     }
   }
   return output;
+}
+
+void ApplyMotionInput(KartPadClassicInputState& input, const float steering,
+                      const bool shakeTrick) noexcept {
+  const float boundedSteering =
+      std::isfinite(steering) ? std::clamp(steering, -1.0f, 1.0f) : 0.0f;
+  const int motionStick = static_cast<int>(std::lround(boundedSteering * 127.0f));
+  if (std::abs(motionStick) > std::abs(static_cast<int>(input.leftStickX))) {
+    input.leftStickX = static_cast<std::int8_t>(motionStick);
+  }
+  if (shakeTrick) {
+    input.buttons |= kClassicButtonUp;
+  }
 }
 
 }  // namespace kartpad::mobile

--- a/apple/mobile/KartPadMotionSteering.h
+++ b/apple/mobile/KartPadMotionSteering.h
@@ -9,6 +9,19 @@ NS_ASSUME_NONNULL_BEGIN
 float KartPadMotionSteeringValue(double angle, double center,
                                  float sensitivity, BOOL inverted) noexcept;
 
+enum class KartPadShakeAction {
+  None,
+  Rearm,
+  Disarm,
+  Trigger,
+};
+
+/* Classifies one gravity-removed acceleration sample. A trigger is edge-based:
+ * another impulse is ignored until motion settles below the rearm threshold. */
+KartPadShakeAction KartPadShakeActionForSample(
+    double accelerationMagnitude, double timestamp, bool armed,
+    double lastTriggerTimestamp) noexcept;
+
 @interface KartPadMotionSteering : NSObject
 
 + (instancetype)sharedSteering;
@@ -16,9 +29,12 @@ float KartPadMotionSteeringValue(double angle, double center,
 @property(nonatomic, assign, getter=isEnabled) BOOL enabled;
 @property(nonatomic, assign, getter=isInverted) BOOL inverted;
 @property(nonatomic, assign) float sensitivity;
+@property(nonatomic, assign, getter=isShakeTricksEnabled)
+    BOOL shakeTricksEnabled;
 @property(nonatomic, readonly, getter=isSensorAvailable) BOOL sensorAvailable;
 @property(nonatomic, readonly) float currentSteering;
 
+- (BOOL)consumeShakeTrick;
 - (void)start;
 - (void)stop;
 - (void)recenter;

--- a/apple/mobile/KartPadMotionSteering.mm
+++ b/apple/mobile/KartPadMotionSteering.mm
@@ -15,6 +15,7 @@ namespace {
 NSString *const kEnabledKey = @"KartPadMotionSteeringEnabled";
 NSString *const kInvertedKey = @"KartPadMotionSteeringInverted";
 NSString *const kSensitivityKey = @"KartPadMotionSteeringSensitivity";
+NSString *const kShakeTricksEnabledKey = @"KartPadShakeTricksEnabled";
 
 double WrappedAngle(double value) {
   while (value > M_PI) value -= 2.0 * M_PI;
@@ -40,6 +41,30 @@ float KartPadMotionSteeringValue(const double angle, const double center,
   return static_cast<float>(value);
 }
 
+KartPadShakeAction KartPadShakeActionForSample(
+    const double accelerationMagnitude, const double timestamp,
+    const bool armed, const double lastTriggerTimestamp) noexcept {
+  if (!std::isfinite(accelerationMagnitude) || accelerationMagnitude < 0.0 ||
+      !std::isfinite(timestamp)) {
+    return KartPadShakeAction::None;
+  }
+
+  constexpr double kRearmAcceleration = 0.35;
+  constexpr double kTriggerAcceleration = 1.35;
+  constexpr double kCooldownSeconds = 0.45;
+  if (accelerationMagnitude <= kRearmAcceleration) {
+    return KartPadShakeAction::Rearm;
+  }
+  if (!armed || accelerationMagnitude < kTriggerAcceleration) {
+    return KartPadShakeAction::None;
+  }
+  if (lastTriggerTimestamp >= 0.0 &&
+      timestamp - lastTriggerTimestamp < kCooldownSeconds) {
+    return KartPadShakeAction::Disarm;
+  }
+  return KartPadShakeAction::Trigger;
+}
+
 @implementation KartPadMotionSteering {
 #if TARGET_OS_IOS
   CMMotionManager *_motionManager;
@@ -49,6 +74,10 @@ float KartPadMotionSteeringValue(const double angle, const double center,
   std::atomic<double> _centerAngle;
   std::atomic<float> _steering;
   std::atomic_bool _calibrated;
+  std::atomic_bool _shakeTricksEnabled;
+  std::atomic_bool _shakeArmed;
+  std::atomic<double> _lastShakeTimestamp;
+  std::atomic_bool _shakePending;
 }
 
 + (instancetype)sharedSteering {
@@ -75,6 +104,10 @@ float KartPadMotionSteeringValue(const double angle, const double center,
     _steering.store(0.0f);
     _calibrated.store(false);
     NSUserDefaults *defaults = NSUserDefaults.standardUserDefaults;
+    _shakeTricksEnabled.store([defaults boolForKey:kShakeTricksEnabledKey]);
+    _shakeArmed.store(true);
+    _lastShakeTimestamp.store(-1.0);
+    _shakePending.store(false);
     if ([defaults objectForKey:kSensitivityKey] == nil) {
       [defaults setFloat:1.0f forKey:kSensitivityKey];
     }
@@ -96,7 +129,7 @@ float KartPadMotionSteeringValue(const double angle, const double center,
 
 - (void)setEnabled:(BOOL)enabled {
   [NSUserDefaults.standardUserDefaults setBool:enabled forKey:kEnabledKey];
-  if (enabled) {
+  if (enabled || self.shakeTricksEnabled) {
     [self start];
   } else {
     [self stop];
@@ -124,13 +157,39 @@ float KartPadMotionSteeringValue(const double angle, const double center,
         forKey:kSensitivityKey];
 }
 
+- (BOOL)isShakeTricksEnabled {
+  return _shakeTricksEnabled.load(std::memory_order_relaxed);
+}
+
+- (void)setShakeTricksEnabled:(BOOL)enabled {
+  [NSUserDefaults.standardUserDefaults setBool:enabled
+                                        forKey:kShakeTricksEnabledKey];
+  _shakeTricksEnabled.store(enabled, std::memory_order_relaxed);
+  _shakeArmed.store(true, std::memory_order_relaxed);
+  _lastShakeTimestamp.store(-1.0, std::memory_order_relaxed);
+  _shakePending.store(false, std::memory_order_relaxed);
+  if (enabled || self.enabled) {
+    [self start];
+  } else {
+    [self stop];
+  }
+  SunPadLog(@"shake tricks enabled=%d sensor=%d", enabled,
+            self.sensorAvailable);
+}
+
 - (float)currentSteering {
   return self.enabled ? _steering.load(std::memory_order_relaxed) : 0.0f;
 }
 
+- (BOOL)consumeShakeTrick {
+  if (!self.shakeTricksEnabled) return NO;
+  return _shakePending.exchange(false, std::memory_order_acq_rel);
+}
+
 - (void)start {
 #if TARGET_OS_IOS
-  if (!self.enabled || !self.sensorAvailable || _motionManager.deviceMotionActive) {
+  if ((!self.enabled && !self.shakeTricksEnabled) || !self.sensorAvailable ||
+      _motionManager.deviceMotionActive) {
     return;
   }
   _calibrated.store(false, std::memory_order_relaxed);
@@ -152,8 +211,29 @@ float KartPadMotionSteeringValue(const double angle, const double center,
         angle, strongSelf->_centerAngle.load(std::memory_order_relaxed),
         strongSelf.sensitivity, strongSelf.inverted);
     strongSelf->_steering.store(value, std::memory_order_relaxed);
+
+    if (strongSelf->_shakeTricksEnabled.load(std::memory_order_relaxed)) {
+      const CMAcceleration acceleration = motion.userAcceleration;
+      const double magnitude = std::sqrt(
+          acceleration.x * acceleration.x + acceleration.y * acceleration.y +
+          acceleration.z * acceleration.z);
+      const KartPadShakeAction action = KartPadShakeActionForSample(
+          magnitude, motion.timestamp,
+          strongSelf->_shakeArmed.load(std::memory_order_relaxed),
+          strongSelf->_lastShakeTimestamp.load(std::memory_order_relaxed));
+      if (action == KartPadShakeAction::Rearm) {
+        strongSelf->_shakeArmed.store(true, std::memory_order_relaxed);
+      } else if (action == KartPadShakeAction::Disarm) {
+        strongSelf->_shakeArmed.store(false, std::memory_order_relaxed);
+      } else if (action == KartPadShakeAction::Trigger) {
+        strongSelf->_shakeArmed.store(false, std::memory_order_relaxed);
+        strongSelf->_lastShakeTimestamp.store(motion.timestamp,
+                                               std::memory_order_relaxed);
+        strongSelf->_shakePending.store(true, std::memory_order_release);
+      }
+    }
   }];
-  SunPadLog(@"motion steering started");
+  SunPadLog(@"motion input started");
 #endif
 }
 
@@ -163,6 +243,9 @@ float KartPadMotionSteeringValue(const double angle, const double center,
 #endif
   _steering.store(0.0f, std::memory_order_relaxed);
   _calibrated.store(false, std::memory_order_relaxed);
+  _shakeArmed.store(true, std::memory_order_relaxed);
+  _lastShakeTimestamp.store(-1.0, std::memory_order_relaxed);
+  _shakePending.store(false, std::memory_order_relaxed);
 }
 
 - (void)recenter {

--- a/runtime/tests/mobile_classic_input_tests.mm
+++ b/runtime/tests/mobile_classic_input_tests.mm
@@ -63,6 +63,21 @@ void TestEveryButton() {
   Require(output.buttons == allDestinations, "simultaneous-button mapping mismatch");
 }
 
+void TestMotionInput() {
+  KartPadClassicInputState input;
+  input.leftStickX = 90;
+  input.buttons = kartpad::mobile::kClassicButtonA;
+  kartpad::mobile::ApplyMotionInput(input, -0.5f, true);
+  Require(input.leftStickX == 90, "motion overrode stronger touch steering");
+  Require((input.buttons & kartpad::mobile::kClassicButtonUp) != 0,
+          "shake did not produce D-pad Up");
+  Require((input.buttons & kartpad::mobile::kClassicButtonA) != 0,
+          "shake cleared an existing button");
+
+  kartpad::mobile::ApplyMotionInput(input, -1.0f, false);
+  Require(input.leftStickX == -127, "stronger motion steering was ignored");
+}
+
 }  // namespace
 
 int main() {
@@ -70,6 +85,7 @@ int main() {
     try {
       TestAxesAndConnection();
       TestEveryButton();
+      TestMotionInput();
       std::cout << "KartPad mobile Classic input adapter passed\n";
       return EXIT_SUCCESS;
     } catch (const std::exception& error) {

--- a/runtime/tests/mobile_motion_steering_tests.mm
+++ b/runtime/tests/mobile_motion_steering_tests.mm
@@ -39,12 +39,38 @@ void TestMotionMapping() {
               "invalid sensor input was not neutral");
 }
 
+void TestShakeDetection() {
+  constexpr double neverTriggered = -1.0;
+  Require(KartPadShakeActionForSample(0.2, 1.0, true, neverTriggered) ==
+              KartPadShakeAction::Rearm,
+          "settled motion did not arm shake detection");
+  Require(KartPadShakeActionForSample(0.8, 1.0, true, neverTriggered) ==
+              KartPadShakeAction::None,
+          "ordinary motion triggered a shake");
+  Require(KartPadShakeActionForSample(1.5, 1.0, true, neverTriggered) ==
+              KartPadShakeAction::Trigger,
+          "deliberate shake did not trigger");
+  Require(KartPadShakeActionForSample(1.5, 1.1, false, 1.0) ==
+              KartPadShakeAction::None,
+          "held acceleration retriggered before rearming");
+  Require(KartPadShakeActionForSample(1.5, 1.2, true, 1.0) ==
+              KartPadShakeAction::Disarm,
+          "cooldown did not consume an early impulse");
+  Require(KartPadShakeActionForSample(1.5, 1.5, true, 1.0) ==
+              KartPadShakeAction::Trigger,
+          "shake did not trigger after cooldown");
+  Require(KartPadShakeActionForSample(NAN, 2.0, true, neverTriggered) ==
+              KartPadShakeAction::None,
+          "invalid acceleration changed detector state");
+}
+
 }  // namespace
 
 int main() {
   @autoreleasepool {
     try {
       TestMotionMapping();
+      TestShakeDetection();
       std::cout << "KartPad mobile motion-steering mapping passed\n";
       return EXIT_SUCCESS;
     } catch (const std::exception &error) {


### PR DESCRIPTION
## Problem

On iPhone, tricks and bike wheelies require pressing D-pad Up on the touch overlay. That is awkward while steering or holding other controls, and there is no motion equivalent to the Wii Remote flick.

## Changes

- Add an opt-in **Shake Tricks/Wheelies** setting to the existing Motion Steering menu.
- Detect deliberate shakes using gravity-removed device acceleration.
- Emit one Classic Controller D-pad Up press for each accepted shake. Mario Kart handles that input as an aerial trick or bike wheelie based on the current vehicle state.
- Require motion to settle before another shake can trigger, with a short cooldown to prevent duplicate inputs.
- Keep shake input independent from tilt steering.
- Preserve physical-controller priority.
- Persist the setting across launches; it remains disabled by default.

## Testing

- Added unit coverage for shake thresholds, rearming, cooldown behavior, invalid samples, and Classic Controller input merging.
- Built the complete `KartPadDual` Release target for physical iOS.
- Verified build 28 on an iPhone 17 Pro during a race.
- User confirmed the gesture works during normal play.
- CTest: 14/15 passed. `kartpad.subsystems.apple-smoke` could not create a Metal device in the headless test environment.
- Python tests: 53 passed, 1 skipped.
