### PR TITLE
Add initial Android touch overlay input

### DIFF
--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -77,7 +77,9 @@ if(KARTPAD_GAME_RUNTIME_SOURCE)
     message(FATAL_ERROR "Prepared game runtime has no Android product target")
   endif()
   target_sources(${KARTPAD_GAME_RUNTIME_TARGET} PRIVATE
+    kartpad_touch_input_jni.cpp
     retro_rewind_archive_jni.cpp
+    "${KARTPAD_REPO_ROOT}/runtime/src/android/touch_input.cpp"
     "${KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_extract.cpp"
     "${KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_path.cpp"
     "${KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_scan.cpp")
@@ -90,7 +92,9 @@ else()
     guest_memory_fixture.cpp
     scheduler_fixture.cpp
     fiber_switch_android.S
+    kartpad_touch_input_jni.cpp
     retro_rewind_archive_jni.cpp
+    "${KARTPAD_REPO_ROOT}/runtime/src/android/touch_input.cpp"
     "${KARTPAD_REPO_ROOT}/runtime/src/scheduler/guest_scheduler.cpp"
     "${KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_extract.cpp"
     "${KARTPAD_REPO_ROOT}/runtime/src/retro_rewind/archive_path.cpp"

--- a/android/app/src/main/cpp/kartpad_touch_input_jni.cpp
+++ b/android/app/src/main/cpp/kartpad_touch_input_jni.cpp
@@ -1,0 +1,23 @@
+#include "kartpad/android/touch_input.h"
+
+#include <jni.h>
+
+extern "C" JNIEXPORT void JNICALL
+Java_dev_kartpad_android_KartPadOverlayView_nativePublishTouchState(
+    JNIEnv*, jobject, jint buttons, jfloat left_x, jfloat left_y,
+    jfloat right_x, jfloat right_y, jboolean connected) {
+    kartpad::android::PublishTouchInput({
+        left_x,
+        left_y,
+        right_x,
+        right_y,
+        static_cast<std::uint32_t>(buttons),
+        connected == JNI_TRUE,
+    });
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_dev_kartpad_android_KartPadOverlayView_nativeClearTouchState(
+    JNIEnv*, jobject) {
+    kartpad::android::ClearTouchInput();
+}

--- a/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
@@ -15,6 +15,8 @@ import org.libsdl.app.SDLActivity
 import org.libsdl.app.SDLSurface
 
 class KartPadActivity : SDLActivity() {
+    private lateinit var kartPadOverlay: KartPadOverlayView
+
     override fun createSDLSurface(context: Context): SDLSurface = KartPadSurface(context)
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -30,16 +32,35 @@ class KartPadActivity : SDLActivity() {
         super.onCreate(savedInstanceState)
         runDebugRetroRewindExtractionFixture()
         runDebugRetroRewindWorkerFixture()
-        val overlay = KartPadOverlayView(this)
+        kartPadOverlay = KartPadOverlayView(this)
+        kartPadOverlay.visibility = if (BuildConfig.GAME_RUNTIME) {
+            android.view.View.VISIBLE
+        } else {
+            android.view.View.GONE
+        }
         mLayout.addView(
-            overlay,
+            kartPadOverlay,
             ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT,
             ),
         )
-        mLayout.bringChildToFront(overlay)
+        mLayout.bringChildToFront(kartPadOverlay)
         Log.i(TAG, "A0 SDLActivity shell created")
+    }
+
+    override fun onPause() {
+        if (::kartPadOverlay.isInitialized) {
+            kartPadOverlay.clearTouchInput()
+        }
+        super.onPause()
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        if (!hasFocus && ::kartPadOverlay.isInitialized) {
+            kartPadOverlay.clearTouchInput()
+        }
+        super.onWindowFocusChanged(hasFocus)
     }
 
     private fun configureRuntimeProfile() {

--- a/android/app/src/main/java/dev/kartpad/android/KartPadOverlayView.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadOverlayView.kt
@@ -2,16 +2,330 @@ package dev.kartpad.android
 
 import android.content.Context
 import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.RectF
+import android.view.MotionEvent
 import android.view.View
+import android.view.WindowInsets
+import kotlin.math.hypot
+import kotlin.math.max
+import kotlin.math.min
 
-/** Transparent project-owned layer; gameplay controls arrive only after A0/A1 gates. */
+/** Canvas-owned gameplay controls using KartPad's accepted phone geometry. */
 class KartPadOverlayView(context: Context) : View(context) {
+    private enum class Kind { BUTTON, LEFT_STICK, RIGHT_STICK }
+
+    private data class Control(
+        val id: String,
+        val label: String,
+        val kind: Kind,
+        val mask: Int = 0,
+        val centerX: Float = 0f,
+        val centerY: Float = 0f,
+        val width: Float,
+        val height: Float,
+        val fill: Int,
+        val darkText: Boolean = false,
+        val frame: RectF = RectF(),
+    )
+
+    private val controls = mutableListOf<Control>()
+    private val pointerOwners = mutableMapOf<Int, String>()
+    private val fillPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+    private val strokePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeWidth = dp(2f)
+        color = Color.argb(120, 255, 255, 255)
+    }
+    private val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        textAlign = Paint.Align.CENTER
+        typeface = android.graphics.Typeface.DEFAULT_BOLD
+    }
+    private var insetLeft = 0
+    private var insetTop = 0
+    private var insetRight = 0
+    private var insetBottom = 0
+    private var leftX = 0f
+    private var leftY = 0f
+    private var rightX = 0f
+    private var rightY = 0f
+
     init {
         setWillNotDraw(false)
-        importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
+        isFocusable = true
+        importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES
+        contentDescription = "KartPad touch controls"
+        buildControls()
+    }
+
+    @Suppress("DEPRECATION")
+    override fun onApplyWindowInsets(insets: WindowInsets): WindowInsets {
+        insetLeft = insets.systemWindowInsetLeft
+        insetTop = insets.systemWindowInsetTop
+        insetRight = insets.systemWindowInsetRight
+        insetBottom = insets.systemWindowInsetBottom
+        requestLayout()
+        invalidate()
+        return super.onApplyWindowInsets(insets)
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        publishState(connected = true)
+    }
+
+    override fun onDetachedFromWindow() {
+        clearTouchInput()
+        super.onDetachedFromWindow()
     }
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
+        layoutControls()
+        controls.forEach { control ->
+            when (control.kind) {
+                Kind.BUTTON -> drawButton(canvas, control)
+                Kind.LEFT_STICK -> drawStick(canvas, control, leftX, leftY)
+                Kind.RIGHT_STICK -> drawStick(canvas, control, rightX, rightY)
+            }
+        }
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        val actionIndex = event.actionIndex
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN,
+            MotionEvent.ACTION_POINTER_DOWN -> {
+                val pointerId = event.getPointerId(actionIndex)
+                val control = hitTest(event.getX(actionIndex), event.getY(actionIndex))
+                if (control == null) {
+                    return event.actionMasked != MotionEvent.ACTION_DOWN && pointerOwners.isNotEmpty()
+                }
+                pointerOwners[pointerId] = control.id
+                updateOwnedControl(control, event.getX(actionIndex), event.getY(actionIndex))
+            }
+            MotionEvent.ACTION_MOVE -> {
+                for (index in 0 until event.pointerCount) {
+                    val owner = pointerOwners[event.getPointerId(index)] ?: continue
+                    controls.firstOrNull { it.id == owner }?.let {
+                        updateOwnedControl(it, event.getX(index), event.getY(index))
+                    }
+                }
+            }
+            MotionEvent.ACTION_UP,
+            MotionEvent.ACTION_POINTER_UP -> {
+                releasePointer(event.getPointerId(actionIndex))
+                if (event.actionMasked == MotionEvent.ACTION_UP) performClick()
+            }
+            MotionEvent.ACTION_CANCEL -> clearTouchInput()
+            else -> return pointerOwners.isNotEmpty()
+        }
+        publishState(connected = true)
+        invalidate()
+        return true
+    }
+
+    override fun performClick(): Boolean {
+        super.performClick()
+        return true
+    }
+
+    fun clearTouchInput() {
+        pointerOwners.clear()
+        leftX = 0f
+        leftY = 0f
+        rightX = 0f
+        rightY = 0f
+        nativeClearTouchState()
+        invalidate()
+    }
+
+    private fun buildControls() {
+        val dark = Color.argb(225, 56, 56, 56)
+        controls += Control("move", "", Kind.LEFT_STICK, width = 126f, height = 126f,
+            centerX = 0.12347222f, centerY = 0.7803491f, fill = Color.argb(220, 33, 33, 33))
+        controls += Control("c", "", Kind.RIGHT_STICK, width = 86f, height = 86f,
+            centerX = 0.9233056f, centerY = 0.81300676f,
+            fill = Color.argb(230, 232, 168, 20))
+        controls += button("A", "A", BUTTON_A, 78f, 78f, 0f, 0f,
+            Color.argb(235, 20, 143, 74))
+        controls += button("B", "B", BUTTON_B, 67.19f, 67.19f,
+            0.8398611f, 0.6898649f, Color.argb(235, 199, 26, 33))
+        controls += button("X", "X", BUTTON_X, 46f, 46f,
+            0.9034167f, 0.4258446f, Color.argb(235, 184, 184, 184), true)
+        controls += button("Y", "Y", BUTTON_Y, 46f, 46f,
+            0.84525f, 0.5268581f, Color.argb(235, 184, 184, 184), true)
+        controls += button("L", "L", BUTTON_L, 94f, 46f,
+            0.09058333f, 0.25399774f, dark)
+        controls += button("R", "R", BUTTON_R, 210f, 46f,
+            0.86875f, 0.27291667f, dark)
+        controls += button("Z", "Z", BUTTON_ZR, 46f, 46f,
+            0.97125f, 0.43507883f, Color.argb(240, 97, 46, 148))
+        controls += button("Start", "START", BUTTON_PLUS, 92f, 46f,
+            0.09022222f, 0.11289414f, Color.argb(235, 71, 71, 71))
+
+        val dpadX = 0.08127778f
+        val dpadY = 0.46773648f
+        controls += button("DpadUp", "▲", BUTTON_UP, 36f, 36f,
+            dpadX, dpadY, dark)
+        controls += button("DpadDown", "▼", BUTTON_DOWN, 36f, 36f,
+            dpadX, dpadY, dark)
+        controls += button("DpadLeft", "◀", BUTTON_LEFT, 36f, 36f,
+            dpadX, dpadY, dark)
+        controls += button("DpadRight", "▶", BUTTON_RIGHT, 36f, 36f,
+            dpadX, dpadY, dark)
+    }
+
+    private fun button(
+        id: String, label: String, mask: Int, width: Float, height: Float,
+        centerX: Float, centerY: Float, fill: Int, darkText: Boolean = false,
+    ) = Control(id, label, Kind.BUTTON, mask, centerX, centerY, width, height, fill, darkText)
+
+    private fun layoutControls() {
+        val safe = RectF(
+            insetLeft.toFloat(), insetTop.toFloat(),
+            max(insetLeft.toFloat(), width - insetRight.toFloat()),
+            max(insetTop.toFloat(), height - insetBottom.toFloat()),
+        )
+        val baseScale = min(1f, min(safe.width() / dp(800f), safe.height() / dp(380f)))
+        controls.forEach { control ->
+            val controlWidth = dp(control.width) * baseScale
+            val controlHeight = dp(control.height) * baseScale
+            val centerX: Float
+            val centerY: Float
+            if (control.id == "A") {
+                val margin = max(dp(8f), dp(18f) * baseScale)
+                val camera = dp(86f) * baseScale
+                centerX = safe.right - margin - controlWidth * 0.5f
+                centerY = safe.bottom - margin - camera - controlHeight * 0.5f - dp(18f) * baseScale
+            } else {
+                centerX = safe.left + control.centerX * safe.width()
+                centerY = safe.top + control.centerY * safe.height()
+            }
+            val dpadCell = dp(36f) * baseScale
+            val adjustedCenterX = centerX + when (control.id) {
+                "DpadLeft" -> -dpadCell
+                "DpadRight" -> dpadCell
+                else -> 0f
+            }
+            val adjustedCenterY = centerY + when (control.id) {
+                "DpadUp" -> -dpadCell
+                "DpadDown" -> dpadCell
+                else -> 0f
+            }
+            control.frame.set(
+                adjustedCenterX - controlWidth * 0.5f,
+                adjustedCenterY - controlHeight * 0.5f,
+                adjustedCenterX + controlWidth * 0.5f,
+                adjustedCenterY + controlHeight * 0.5f,
+            )
+        }
+    }
+
+    private fun drawButton(canvas: Canvas, control: Control) {
+        val active = pointerOwners.containsValue(control.id)
+        fillPaint.style = Paint.Style.FILL
+        fillPaint.color = if (active) brighten(control.fill) else control.fill
+        val radius = min(control.frame.width(), control.frame.height()) * 0.5f
+        canvas.drawRoundRect(control.frame, radius, radius, fillPaint)
+        canvas.drawRoundRect(control.frame, radius, radius, strokePaint)
+        textPaint.color = if (control.darkText) Color.rgb(31, 31, 31) else Color.WHITE
+        textPaint.textSize = min(control.frame.height() * 0.39f, dp(18f))
+        val metrics = textPaint.fontMetrics
+        val baseline = control.frame.centerY() - (metrics.ascent + metrics.descent) * 0.5f
+        canvas.drawText(control.label, control.frame.centerX(), baseline, textPaint)
+    }
+
+    private fun drawStick(canvas: Canvas, control: Control, axisX: Float, axisY: Float) {
+        val radius = min(control.frame.width(), control.frame.height()) * 0.5f
+        fillPaint.style = Paint.Style.FILL
+        fillPaint.color = control.fill
+        canvas.drawCircle(control.frame.centerX(), control.frame.centerY(), radius, fillPaint)
+        canvas.drawCircle(control.frame.centerX(), control.frame.centerY(), radius, strokePaint)
+        val thumbRadius = radius * 0.42f
+        val travel = max(0f, radius - thumbRadius - dp(4f))
+        fillPaint.color = if (control.kind == Kind.LEFT_STICK) {
+            Color.argb(240, 148, 148, 148)
+        } else {
+            Color.argb(250, 255, 214, 64)
+        }
+        canvas.drawCircle(
+            control.frame.centerX() + axisX * travel,
+            control.frame.centerY() - axisY * travel,
+            thumbRadius, fillPaint,
+        )
+    }
+
+    private fun hitTest(x: Float, y: Float): Control? = controls.asReversed().firstOrNull {
+        if (!it.frame.contains(x, y)) return@firstOrNull false
+        if (it.kind == Kind.BUTTON && it.frame.width() != it.frame.height()) return@firstOrNull true
+        val radius = min(it.frame.width(), it.frame.height()) * 0.5f
+        hypot((x - it.frame.centerX()).toDouble(), (y - it.frame.centerY()).toDouble()) <= radius
+    }
+
+    private fun updateOwnedControl(control: Control, x: Float, y: Float) {
+        if (control.kind == Kind.BUTTON) return
+        val radius = max(1f, min(control.frame.width(), control.frame.height()) * 0.5f)
+        var axisX = (x - control.frame.centerX()) / radius
+        var axisY = -(y - control.frame.centerY()) / radius
+        val length = hypot(axisX.toDouble(), axisY.toDouble()).toFloat()
+        if (length > 1f) {
+            axisX /= length
+            axisY /= length
+        }
+        if (control.kind == Kind.LEFT_STICK) {
+            leftX = axisX
+            leftY = axisY
+        } else {
+            rightX = axisX
+            rightY = axisY
+        }
+    }
+
+    private fun releasePointer(pointerId: Int) {
+        val owner = pointerOwners.remove(pointerId) ?: return
+        when (controls.firstOrNull { it.id == owner }?.kind) {
+            Kind.LEFT_STICK -> { leftX = 0f; leftY = 0f }
+            Kind.RIGHT_STICK -> { rightX = 0f; rightY = 0f }
+            else -> Unit
+        }
+    }
+
+    private fun publishState(connected: Boolean) {
+        var buttons = 0
+        pointerOwners.values.forEach { owner ->
+            buttons = buttons or (controls.firstOrNull { it.id == owner }?.mask ?: 0)
+        }
+        nativePublishTouchState(buttons, leftX, leftY, rightX, rightY, connected)
+    }
+
+    private fun brighten(color: Int): Int = Color.argb(
+        Color.alpha(color), min(255, Color.red(color) + 34),
+        min(255, Color.green(color) + 34), min(255, Color.blue(color) + 34),
+    )
+
+    private fun dp(value: Float): Float = value * resources.displayMetrics.density
+
+    private external fun nativePublishTouchState(
+        buttons: Int, leftX: Float, leftY: Float, rightX: Float, rightY: Float,
+        connected: Boolean,
+    )
+
+    private external fun nativeClearTouchState()
+
+    private companion object {
+        const val BUTTON_UP = 0x00000001
+        const val BUTTON_LEFT = 0x00000002
+        const val BUTTON_ZR = 0x00000004
+        const val BUTTON_X = 0x00000008
+        const val BUTTON_A = 0x00000010
+        const val BUTTON_Y = 0x00000020
+        const val BUTTON_B = 0x00000040
+        const val BUTTON_R = 0x00000200
+        const val BUTTON_PLUS = 0x00000400
+        const val BUTTON_L = 0x00002000
+        const val BUTTON_DOWN = 0x00004000
+        const val BUTTON_RIGHT = 0x00008000
     }
 }

--- a/android/app/src/main/java/dev/kartpad/android/KartPadOverlayView.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadOverlayView.kt
@@ -5,6 +5,10 @@ import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.RectF
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.view.HapticFeedbackConstants
 import android.view.MotionEvent
 import android.view.View
 import android.view.WindowInsets
@@ -32,6 +36,7 @@ class KartPadOverlayView(context: Context) : View(context) {
 
     private val controls = mutableListOf<Control>()
     private val pointerOwners = mutableMapOf<Int, String>()
+    private val mainHandler = Handler(Looper.getMainLooper())
     private val fillPaint = Paint(Paint.ANTI_ALIAS_FLAG)
     private val strokePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         style = Paint.Style.STROKE
@@ -50,10 +55,13 @@ class KartPadOverlayView(context: Context) : View(context) {
     private var leftY = 0f
     private var rightX = 0f
     private var rightY = 0f
+    private var gasHoldGeneration = 0
+    private var gasLocked = false
 
     init {
         setWillNotDraw(false)
         isFocusable = true
+        isHapticFeedbackEnabled = true
         importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES
         contentDescription = "KartPad touch controls"
         buildControls()
@@ -103,6 +111,7 @@ class KartPadOverlayView(context: Context) : View(context) {
                     return event.actionMasked != MotionEvent.ACTION_DOWN && pointerOwners.isNotEmpty()
                 }
                 pointerOwners[pointerId] = control.id
+                if (control.id == "A") beginGasPress()
                 updateOwnedControl(control, event.getX(actionIndex), event.getY(actionIndex))
             }
             MotionEvent.ACTION_MOVE -> {
@@ -137,6 +146,9 @@ class KartPadOverlayView(context: Context) : View(context) {
         leftY = 0f
         rightX = 0f
         rightY = 0f
+        gasLocked = false
+        gasHoldGeneration += 1
+        updateGasAccessibility()
         nativeClearTouchState()
         invalidate()
     }
@@ -158,7 +170,7 @@ class KartPadOverlayView(context: Context) : View(context) {
             0.84525f, 0.5268581f, Color.argb(235, 184, 184, 184), true)
         controls += button("L", "L", BUTTON_L, 94f, 46f,
             0.09058333f, 0.25399774f, dark)
-        controls += button("R", "R", BUTTON_R, 210f, 46f,
+        controls += button("R", "R", BUTTON_R, 94f, 46f,
             0.86875f, 0.27291667f, dark)
         controls += button("Z", "Z", BUTTON_ZR, 46f, 46f,
             0.97125f, 0.43507883f, Color.argb(240, 97, 46, 148))
@@ -226,7 +238,11 @@ class KartPadOverlayView(context: Context) : View(context) {
     private fun drawButton(canvas: Canvas, control: Control) {
         val active = pointerOwners.containsValue(control.id)
         fillPaint.style = Paint.Style.FILL
-        fillPaint.color = if (active) brighten(control.fill) else control.fill
+        fillPaint.color = when {
+            control.id == "A" && gasLocked -> LOCKED_GAS_COLOR
+            active -> brighten(control.fill)
+            else -> control.fill
+        }
         val radius = min(control.frame.width(), control.frame.height()) * 0.5f
         canvas.drawRoundRect(control.frame, radius, radius, fillPaint)
         canvas.drawRoundRect(control.frame, radius, radius, strokePaint)
@@ -285,6 +301,7 @@ class KartPadOverlayView(context: Context) : View(context) {
 
     private fun releasePointer(pointerId: Int) {
         val owner = pointerOwners.remove(pointerId) ?: return
+        if (owner == "A") gasHoldGeneration += 1
         when (controls.firstOrNull { it.id == owner }?.kind) {
             Kind.LEFT_STICK -> { leftX = 0f; leftY = 0f }
             Kind.RIGHT_STICK -> { rightX = 0f; rightY = 0f }
@@ -293,11 +310,36 @@ class KartPadOverlayView(context: Context) : View(context) {
     }
 
     private fun publishState(connected: Boolean) {
-        var buttons = 0
+        var buttons = if (gasLocked) BUTTON_A else 0
         pointerOwners.values.forEach { owner ->
             buttons = buttons or (controls.firstOrNull { it.id == owner }?.mask ?: 0)
         }
         nativePublishTouchState(buttons, leftX, leftY, rightX, rightY, connected)
+    }
+
+    private fun beginGasPress() {
+        gasHoldGeneration += 1
+        if (gasLocked) {
+            gasLocked = false
+            updateGasAccessibility()
+            return
+        }
+        val generation = gasHoldGeneration
+        mainHandler.postDelayed({
+            if (generation != gasHoldGeneration ||
+                !pointerOwners.containsValue("A")) return@postDelayed
+            gasLocked = true
+            updateGasAccessibility()
+            performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+            publishState(connected = true)
+            invalidate()
+        }, GAS_LOCK_DELAY_MS)
+    }
+
+    private fun updateGasAccessibility() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            stateDescription = if (gasLocked) "Acceleration locked" else null
+        }
     }
 
     private fun brighten(color: Int): Int = Color.argb(
@@ -315,6 +357,8 @@ class KartPadOverlayView(context: Context) : View(context) {
     private external fun nativeClearTouchState()
 
     private companion object {
+        const val GAS_LOCK_DELAY_MS = 1_000L
+        val LOCKED_GAS_COLOR: Int = Color.argb(250, 15, 199, 235)
         const val BUTTON_UP = 0x00000001
         const val BUTTON_LEFT = 0x00000002
         const val BUTTON_ZR = 0x00000004

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -59,8 +59,12 @@ disabled. Two independent fresh redirected-NAND launches then created the
 exact format-valid empty RKSYS and reached the Retro title. From that empty
 state, the Android InputReader/SDL controller path created a KartPad license,
 and a cold production-chooser relaunch displayed the same license with the
-save byte-identical and CRC-valid. Touch parity and physical-device acceptance
-remain open.
+save byte-identical and CRC-valid. A4 now has its first live touch slice: the
+complete phone control set renders over the dual Retro runtime at a true
+`2400x1080`, and direct touchscreen A and D-pad Right events advance the guest
+through title and license selection. Persistent layout editing, acceleration
+lock/haptics, controller handoff, full accessibility, tablet/physical touch,
+motion, and physical-device acceptance remain open.
 
 The first independent A3 source slice extracted archive member-path validation
 into `runtime/src/retro_rewind/archive_path.cpp`. The existing iOS/tvOS installer

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -62,8 +62,10 @@ and a cold production-chooser relaunch displayed the same license with the
 save byte-identical and CRC-valid. A4 now has its first live touch slice: the
 complete phone control set renders over the dual Retro runtime at a true
 `2400x1080`, and direct touchscreen A and D-pad Right events advance the guest
-through title and license selection. Persistent layout editing, acceleration
-lock/haptics, controller handoff, full accessibility, tablet/physical touch,
+through title and license selection. R now matches L's compact digital pill,
+and a one-second A hold turns cyan, remains asserted after finger-up, invokes a
+light Android haptic, and unlocks on the next tap. Persistent layout editing,
+controller handoff, full accessibility, tablet/physical touch and haptic feel,
 motion, and physical-device acceptance remain open.
 
 The first independent A3 source slice extracted archive member-path validation

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -3023,3 +3023,30 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   The emulator was left visibly running; no application package, save, private
   input, or screenshot was published. Evidence:
   `docs/artifacts/2026-09-04/android/a3-fresh-save-offline-kd.md`.
+
+## 2026-09-04 — Android A4 touch overlay and guest input
+
+- Added a transparent Canvas-owned phone overlay with stable pointer ownership,
+  the complete Classic control set, lifecycle clearing, normalized stick state,
+  and a native rising-edge latch for short touchscreen button taps.
+- Added JNI publication and an Android runtime patch that merges channel-zero
+  touch buttons/left-stick state into KPAD without disturbing other physical
+  controller channels. Portable and source-contract tests pass.
+- Simulator execution exposed a base/dual build mismatch before touch ran: the
+  first APK linked only `WiiCompiled`, so the launcher-selected Retro profile
+  failed as not linked. Corrected the Android builder so preparation product and
+  native target both follow the selected shard graph, then rebuilt against the
+  validated dual Retro graph as `KartPadDual`.
+- Reset a stale emulator `1280x720` size override. Android then reported its
+  native `1080x2400` panel rotated into a real `2400x1080` logical/app frame,
+  and the visible production chooser filled the wider display.
+- The audited 119,090,830-byte dual APK at SHA-256 `0d39e63d...f268c`
+  reached the Retro title with the overlay visible. A touchscreen A tap advanced
+  to Select License, then D-pad Right moved the live selection to the adjacent
+  NEW slot; the process remained healthy with no fatal signature.
+- Classification: **Pass for initial Android emulator touch rendering and
+  A/D-pad guest input.** Layout editing, lock/haptics, controller handoff,
+  accessibility nodes, C-stick guest behavior, tablet/physical touch, motion,
+  and physical-device acceptance remain open. No APK, AAB, private content,
+  save, or screenshot was published. Evidence:
+  `docs/artifacts/2026-09-04/android/a4-touch-overlay-input.md`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -3040,13 +3040,19 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
 - Reset a stale emulator `1280x720` size override. Android then reported its
   native `1080x2400` panel rotated into a real `2400x1080` logical/app frame,
   and the visible production chooser filled the wider display.
-- The audited 119,090,830-byte dual APK at SHA-256 `0d39e63d...f268c`
+- The initial audited 119,090,830-byte dual APK at SHA-256 `0d39e63d...f268c`
   reached the Retro title with the overlay visible. A touchscreen A tap advanced
   to Select License, then D-pad Right moved the live selection to the adjacent
   NEW slot; the process remained healthy with no fatal signature.
+- Corrected R from the old wide pressure-trigger geometry to the same compact
+  digital pill as L. Added the iOS-parity A interaction: a one-second hold
+  turns cyan, confirms through Android haptics, remains asserted after lift,
+  and unlocks on the next tap. The exact final audited APK is
+  `258f8002...73b3b`; live hold/unlock screenshots and the retained process
+  confirm the state transition.
 - Classification: **Pass for initial Android emulator touch rendering and
-  A/D-pad guest input.** Layout editing, lock/haptics, controller handoff,
-  accessibility nodes, C-stick guest behavior, tablet/physical touch, motion,
-  and physical-device acceptance remain open. No APK, AAB, private content,
-  save, or screenshot was published. Evidence:
+  A/D-pad guest input plus R and A-lock parity.** Layout editing, controller
+  handoff, accessibility nodes, C-stick guest behavior, physical haptic feel,
+  tablet/physical touch, motion, and physical-device acceptance remain open.
+  No APK, AAB, private content, save, or screenshot was published. Evidence:
   `docs/artifacts/2026-09-04/android/a4-touch-overlay-input.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -623,11 +623,13 @@ selection to the adjacent NEW slot in the same live process. The fresh build
 also corrected game-runtime preparation so a dual shard graph prepares and
 builds the dual product instead of silently preparing a base-only runtime. The
 119,090,830-byte local APK has SHA-256
-`0d39e63d7650d06e548e0099e2c102d7a08d4db2a54d05bcda8366a934ef268c`
+`258f80025ad0b094e577d699d785c5cb4b36a72e30e268b1cfa17ff408473b3b`
 and passes the strict package audit. This closes only the first emulator
-touch/JNI/KPAD slice; persistent editing, acceleration lock/haptics, controller
-handoff, virtual accessibility nodes, right-stick guest behavior, tablet and
-physical touch, motion, and physical-device acceptance remain open. Evidence:
+touch/JNI/KPAD slice. R visibly matches L's compact digital pill; a 1.3-second
+A hold turns cyan and stays asserted after finger-up, and the next A tap
+restores green/unlocked state. Persistent editing, controller handoff, virtual
+accessibility nodes, right-stick guest behavior, physical haptic feel, tablet
+and physical touch, motion, and physical-device acceptance remain open. Evidence:
 [`docs/artifacts/2026-09-04/android/a4-touch-overlay-input.md`](artifacts/2026-09-04/android/a4-touch-overlay-input.md).
 
 ## Native tvOS work

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -612,6 +612,24 @@ physical controller/audio/rumble, physical hardware, and release acceptance
 remain open. Evidence:
 [`docs/artifacts/2026-09-04/android/a3-retro-controller-race-save.md`](artifacts/2026-09-04/android/a3-retro-controller-race-save.md).
 
+The first A4 touch slice now passes on the API 36 ARM64 emulator. A transparent
+Canvas overlay presents KartPad's accepted phone geometry with stable
+multitouch ownership, full Classic button coverage, two sticks, lifecycle
+clearing, and a native short-tap latch. After removing a stale emulator display
+override, Android reported a real rotated `2400x1080` application frame. The
+complete `KartPadDual` runtime reached the Retro Rewind title with the overlay
+visible; a touchscreen A tap advanced to Select License and D-pad Right moved
+selection to the adjacent NEW slot in the same live process. The fresh build
+also corrected game-runtime preparation so a dual shard graph prepares and
+builds the dual product instead of silently preparing a base-only runtime. The
+119,090,830-byte local APK has SHA-256
+`0d39e63d7650d06e548e0099e2c102d7a08d4db2a54d05bcda8366a934ef268c`
+and passes the strict package audit. This closes only the first emulator
+touch/JNI/KPAD slice; persistent editing, acceleration lock/haptics, controller
+handoff, virtual accessibility nodes, right-stick guest behavior, tablet and
+physical touch, motion, and physical-device acceptance remain open. Evidence:
+[`docs/artifacts/2026-09-04/android/a4-touch-overlay-input.md`](artifacts/2026-09-04/android/a4-touch-overlay-input.md).
+
 ## Native tvOS work
 
 The maintainer-owned `codex/tvos-retro-rewind` branch contains the first

--- a/docs/artifacts/2026-09-04/android/a4-touch-overlay-input.md
+++ b/docs/artifacts/2026-09-04/android/a4-touch-overlay-input.md
@@ -15,6 +15,13 @@ controller handoff, tablet, or physical-device acceptance result.
 - `KartPadOverlayView` owns a transparent Canvas overlay with stable
   pointer-ID ownership for multitouch, the left and C sticks, A/B/X/Y/Z,
   Start, L/R, and grouped D-pad controls.
+- KartPad's Classic R is a normal digital shoulder and uses the same compact
+  `94x46dp` pill as L, matching the accepted iOS override rather than SunPad's
+  wide pressure-trigger artwork.
+- Holding A uninterrupted for one second locks acceleration, changes A to the
+  accepted cyan state, invokes Android's light virtual-key haptic, keeps A
+  asserted after finger-up, and lets the next ordinary A tap unlock it. The
+  locked state is exposed through Android's accessibility state description.
 - A narrow JNI bridge publishes normalized axes and Classic button bits to a
   mutex-protected native state. Rising button edges remain latched for one
   guest sample so a short Android tap cannot disappear between KPAD polls.
@@ -46,7 +53,7 @@ and Gradle explicitly configured `buildCMakeDebug[arm64-v8a][KartPadDual]`.
   `1080x2400`, rotation 1, and a real logical/application frame of
   `2400x1080`; the production chooser visibly fills that wide surface.
 - The audited dual APK is 119,090,830 bytes with SHA-256
-  `0d39e63d7650d06e548e0099e2c102d7a08d4db2a54d05bcda8366a934ef268c`.
+  `258f80025ad0b094e577d699d785c5cb4b36a72e30e268b1cfa17ff408473b3b`.
 - Retro Rewind reached its title with the complete overlay visible. The
   ignored screenshot SHA-256 is
   `bfe80193d49bf6a234d65e9f80b639bfffd1f0ae7a67791d84bf5f76a283fd96`.
@@ -56,18 +63,27 @@ and Gradle explicitly configured `buildCMakeDebug[arm64-v8a][KartPadDual]`.
 - A second touchscreen tap on the visible D-pad Right control moved selection
   from the existing KartPad license to the upper-right NEW slot. Its ignored
   screenshot SHA-256 is
-  `7fa74b44ebd7dec8011d656aef35a4e3cddf9d150f43ccb291699b76d9aa9fbb`.
+  `63c34f61606ef15a4cf2a3434a7312a695b8ed267975b7e48b072bb0f7465d2a`.
+- In the exact final APK, R visibly matches L. Its ignored title screenshot is
+  `b1c2266a723962bbfa979273aae552ec3fe872adf66294bf1b1a7523fb93496d`.
+- A 1.3-second A hold advanced the guest, then left the A control cyan after
+  finger-up. The next A tap returned it to green without advancing or killing
+  the process. The ignored locked/unlocked screenshot hashes are
+  `e00fae029ea51010d0a4c7c507650be0fa8a1d73bbdadb7108463cda12dce62b`
+  and
+  `c297c5e655e2cebae441ddc588d77f439588a77ae54b5095454f8c010332d47f`.
 - The same process PID remained alive and logcat contained no fatal,
   `UnsatisfiedLinkError`, or profile-selection failure after both inputs.
 
 ## Classification
 
 **Pass for the first Android A4 emulator touch slice: correct native landscape
-geometry, visible full control set, JNI/KPAD A input, and JNI/KPAD D-pad input
-on the complete dual Retro runtime.**
+geometry, visible full control set, compact digital R parity, one-second cyan
+A lock/tap-to-unlock, JNI/KPAD A input, and JNI/KPAD D-pad input on the
+complete dual Retro runtime.**
 
-Still open: right-stick guest behavior, one-second acceleration lock and
-haptics, persistent editing/opacity/size/hide, controller hide/restore,
+Still open: right-stick guest behavior, persistent editing/opacity/size/hide,
+controller hide/restore, physical-device haptic feel,
 virtual accessibility nodes, screenshot goldens, tablet layout, physical
 touch ergonomics/latency, motion steering, and physical-device acceptance. No
 APK, AAB, screenshot, private graph, save, or game data was published.

--- a/docs/artifacts/2026-09-04/android/a4-touch-overlay-input.md
+++ b/docs/artifacts/2026-09-04/android/a4-touch-overlay-input.md
@@ -1,0 +1,73 @@
+# Android A4 touch-overlay input
+
+## Falsifiable subgoal
+
+Render KartPad's accepted phone control geometry over the complete Android
+dual runtime, then use Android touchscreen events to advance Retro Rewind with
+both A and D-pad input on the API 36 ARM64 emulator.
+
+This is an emulator touch/JNI/guest-input integration gate. It is not a
+physical-finger ergonomics, latency, haptics, accessibility, layout editing,
+controller handoff, tablet, or physical-device acceptance result.
+
+## Implementation
+
+- `KartPadOverlayView` owns a transparent Canvas overlay with stable
+  pointer-ID ownership for multitouch, the left and C sticks, A/B/X/Y/Z,
+  Start, L/R, and grouped D-pad controls.
+- A narrow JNI bridge publishes normalized axes and Classic button bits to a
+  mutex-protected native state. Rising button edges remain latched for one
+  guest sample so a short Android tap cannot disappear between KPAD polls.
+- The Android KPAD patch merges touch with channel-zero physical-controller
+  state while leaving other controller channels unchanged. Pause, focus loss,
+  detach, and cancellation clear held touch state.
+- The source-only fixture keeps the gameplay overlay hidden. Game-runtime
+  builds enable it through the generated `GAME_RUNTIME` flag.
+- The Android game builder now derives both preparation product and native
+  target from the selected translated shard graph. A dual graph prepares
+  `dual` and builds `KartPadDual`; a base-only graph prepares `base` and builds
+  `WiiCompiled`.
+
+## Failure found by simulator execution
+
+The first A4 APK had been prepared from the default base-only private graph
+while the launcher still offered an already-installed Retro Rewind choice.
+Selecting Retro therefore failed with `selected profile is not linked:
+retro_rewind`; the exception path then exposed a secondary pre-initialization
+ImGui shutdown assertion. The failure happened before touch input ran.
+
+The redundant base compile was stopped. A fresh build used the already-
+validated Retro Rewind self-build graph, whose manifest declares Retro shards,
+and Gradle explicitly configured `buildCMakeDebug[arm64-v8a][KartPadDual]`.
+
+## Emulator evidence
+
+- Removed a stale `wm size 1280x720` override. The AVD reports physical
+  `1080x2400`, rotation 1, and a real logical/application frame of
+  `2400x1080`; the production chooser visibly fills that wide surface.
+- The audited dual APK is 119,090,830 bytes with SHA-256
+  `0d39e63d7650d06e548e0099e2c102d7a08d4db2a54d05bcda8366a934ef268c`.
+- Retro Rewind reached its title with the complete overlay visible. The
+  ignored screenshot SHA-256 is
+  `bfe80193d49bf6a234d65e9f80b639bfffd1f0ae7a67791d84bf5f76a283fd96`.
+- An `adb shell input tap` at the visible green A control advanced from
+  `Press the A Button` to Select License. Its ignored screenshot SHA-256 is
+  `6b70191eebac4990472880f24fafec315e9b383bd28d3035ffbc916a5a9baf38`.
+- A second touchscreen tap on the visible D-pad Right control moved selection
+  from the existing KartPad license to the upper-right NEW slot. Its ignored
+  screenshot SHA-256 is
+  `7fa74b44ebd7dec8011d656aef35a4e3cddf9d150f43ccb291699b76d9aa9fbb`.
+- The same process PID remained alive and logcat contained no fatal,
+  `UnsatisfiedLinkError`, or profile-selection failure after both inputs.
+
+## Classification
+
+**Pass for the first Android A4 emulator touch slice: correct native landscape
+geometry, visible full control set, JNI/KPAD A input, and JNI/KPAD D-pad input
+on the complete dual Retro runtime.**
+
+Still open: right-stick guest behavior, one-second acceleration lock and
+haptics, persistent editing/opacity/size/hide, controller hide/restore,
+virtual accessibility nodes, screenshot goldens, tablet layout, physical
+touch ergonomics/latency, motion steering, and physical-device acceptance. No
+APK, AAB, screenshot, private graph, save, or game data was published.

--- a/patches/wiicompiled-android-touch-input.patch
+++ b/patches/wiicompiled-android-touch-input.patch
@@ -1,0 +1,94 @@
+--- a/src/hle/input/kpad.cpp
++++ b/src/hle/input/kpad.cpp
+@@ -9,6 +9,7 @@
+ #if defined(__ANDROID__)
+ #include <aurora/input.hpp>
+ #include "kartpad/android/gamepad_contract.h"
++#include "kartpad/android/touch_input.h"
+ #endif
+ 
+ #if defined(__APPLE__)
+@@ -708,6 +709,17 @@
+     raw.left_trigger = snapshot.leftTrigger;
+     raw.right_trigger = snapshot.rightTrigger;
+     return MapGamepadToClassic(raw);
++}
++
++kartpad::android::TouchInputState ReadAndroidTouchInput(uint32_t chan)
++{
++    return chan == 0 ? kartpad::android::ConsumeTouchInput() :
++                       kartpad::android::TouchInputState{};
++}
++
++float StrongerAxis(float first, float second)
++{
++    return std::abs(second) > std::abs(first) ? second : first;
+ }
+ #endif
+ 
+@@ -832,6 +844,7 @@
+     if (chan >= g_keyboardConnected.size()) return false;
+ #if defined(__ANDROID__)
+     if (ReadAndroidClassicInput(chan).connected) return true;
++    if (chan == 0 && kartpad::android::IsTouchInputConnected()) return true;
+ #endif
+     return chan == 0 ||
+            g_keyboardConnected[chan].load(std::memory_order_acquire);
+@@ -860,11 +873,14 @@
+ #if defined(__ANDROID__)
+     const auto androidInput = ReadAndroidClassicInput(chan);
+     const bool androidConnected = androidInput.connected;
++    const auto touchInput = ReadAndroidTouchInput(chan);
++    const bool touchConnected = touchInput.connected;
+ #else
+     const bool androidConnected = false;
++    const bool touchConnected = false;
+ #endif
+     const bool connected = chan == 0 || mobileConnected ||
+-        androidConnected ||
++        androidConnected || touchConnected ||
+         g_keyboardConnected[chan].load(std::memory_order_acquire) ||
+         g_previousButtons[chan] != 0 || g_previousClassicButtons[chan] != 0;
+     if (!connected) return 0;
+@@ -901,6 +917,12 @@
+         hold |= CoreButtonsForClassic(androidInput.buttons);
+         stick = {androidInput.left_stick_x, androidInput.left_stick_y};
+     }
++    if (!fixtureActive && touchConnected) {
++        classicHold |= touchInput.buttons;
++        hold |= CoreButtonsForClassic(touchInput.buttons);
++        stick = {StrongerAxis(stick[0], touchInput.left_stick_x),
++                 StrongerAxis(stick[1], touchInput.left_stick_y)};
++    }
+ #endif
+     const uint32_t previous = g_previousButtons[chan];
+     const uint32_t previousClassic = g_previousClassicButtons[chan];
+@@ -959,10 +981,13 @@
+ #if defined(__ANDROID__)
+     const auto androidInput = ReadAndroidClassicInput(chan);
+     const bool androidConnected = androidInput.connected;
++    const auto touchInput = ReadAndroidTouchInput(chan);
++    const bool touchConnected = touchInput.connected;
+ #else
+     const bool androidConnected = false;
++    const bool touchConnected = false;
+ #endif
+-    if (chan != 0 && !mobileConnected && !androidConnected &&
++    if (chan != 0 && !mobileConnected && !androidConnected && !touchConnected &&
+         !g_keyboardConnected[chan].load(std::memory_order_acquire) &&
+         g_previousButtons[chan] == 0 && g_previousClassicButtons[chan] == 0) {
+         return 0;
+@@ -996,6 +1021,12 @@
+             coreButtons |= CoreButtonsForClassic(androidInput.buttons);
+             stick = {androidInput.left_stick_x, androidInput.left_stick_y};
+         }
++        if (!fixtureActive && touchConnected) {
++            classicButtons |= touchInput.buttons;
++            coreButtons |= CoreButtonsForClassic(touchInput.buttons);
++            stick = {StrongerAxis(stick[0], touchInput.left_stick_x),
++                     StrongerAxis(stick[1], touchInput.left_stick_y)};
++        }
+ #endif
+         Memory::Write16(statusPtr + 0x00,
+                         static_cast<uint16_t>(coreButtons));
+

--- a/runtime/include/kartpad/android/touch_input.h
+++ b/runtime/include/kartpad/android/touch_input.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstdint>
+
+namespace kartpad::android {
+
+inline constexpr std::uint32_t kTouchButtonUp = 0x00000001;
+inline constexpr std::uint32_t kTouchButtonLeft = 0x00000002;
+inline constexpr std::uint32_t kTouchButtonZr = 0x00000004;
+inline constexpr std::uint32_t kTouchButtonX = 0x00000008;
+inline constexpr std::uint32_t kTouchButtonA = 0x00000010;
+inline constexpr std::uint32_t kTouchButtonY = 0x00000020;
+inline constexpr std::uint32_t kTouchButtonB = 0x00000040;
+inline constexpr std::uint32_t kTouchButtonZl = 0x00000080;
+inline constexpr std::uint32_t kTouchButtonR = 0x00000200;
+inline constexpr std::uint32_t kTouchButtonPlus = 0x00000400;
+inline constexpr std::uint32_t kTouchButtonMinus = 0x00001000;
+inline constexpr std::uint32_t kTouchButtonL = 0x00002000;
+inline constexpr std::uint32_t kTouchButtonDown = 0x00004000;
+inline constexpr std::uint32_t kTouchButtonRight = 0x00008000;
+inline constexpr std::uint32_t kTouchButtonMask = 0x0000f6ff;
+
+struct TouchInputState {
+    float left_stick_x = 0.0f;
+    float left_stick_y = 0.0f;
+    float right_stick_x = 0.0f;
+    float right_stick_y = 0.0f;
+    std::uint32_t buttons = 0;
+    bool connected = false;
+};
+
+// The Android UI thread publishes held state. Rising button edges are retained
+// until the guest scheduler consumes them, so a short tap cannot disappear
+// between KPAD samples.
+void PublishTouchInput(TouchInputState state) noexcept;
+[[nodiscard]] TouchInputState ConsumeTouchInput() noexcept;
+[[nodiscard]] bool IsTouchInputConnected() noexcept;
+void ClearTouchInput() noexcept;
+
+}  // namespace kartpad::android

--- a/runtime/src/android/touch_input.cpp
+++ b/runtime/src/android/touch_input.cpp
@@ -1,0 +1,54 @@
+#include "kartpad/android/touch_input.h"
+
+#include <algorithm>
+#include <cmath>
+#include <mutex>
+
+namespace kartpad::android {
+namespace {
+
+std::mutex g_touch_mutex;
+TouchInputState g_held;
+std::uint32_t g_latched_buttons = 0;
+
+float SanitizeAxis(float value) noexcept {
+    if (!std::isfinite(value)) {
+        return 0.0f;
+    }
+    return std::clamp(value, -1.0f, 1.0f);
+}
+
+}  // namespace
+
+void PublishTouchInput(TouchInputState state) noexcept {
+    state.left_stick_x = SanitizeAxis(state.left_stick_x);
+    state.left_stick_y = SanitizeAxis(state.left_stick_y);
+    state.right_stick_x = SanitizeAxis(state.right_stick_x);
+    state.right_stick_y = SanitizeAxis(state.right_stick_y);
+    state.buttons &= kTouchButtonMask;
+
+    std::scoped_lock lock(g_touch_mutex);
+    g_latched_buttons |= state.buttons & ~g_held.buttons;
+    g_held = state;
+}
+
+TouchInputState ConsumeTouchInput() noexcept {
+    std::scoped_lock lock(g_touch_mutex);
+    TouchInputState result = g_held;
+    result.buttons |= g_latched_buttons;
+    g_latched_buttons = 0;
+    return result;
+}
+
+bool IsTouchInputConnected() noexcept {
+    std::scoped_lock lock(g_touch_mutex);
+    return g_held.connected;
+}
+
+void ClearTouchInput() noexcept {
+    std::scoped_lock lock(g_touch_mutex);
+    g_held = {};
+    g_latched_buttons = 0;
+}
+
+}  // namespace kartpad::android

--- a/scripts/build-android-game-app.sh
+++ b/scripts/build-android-game-app.sh
@@ -16,6 +16,14 @@ translation_root="$(absolute_from_repo "${1:-private/g8-full-translation}")"
 runtime_source="$(absolute_from_repo "${2:-build/android-game-runtime-source}")"
 runtime_build="$(absolute_from_repo "${3:-build/android-game-runtime-build}")"
 
+native_target="WiiCompiled"
+runtime_product="base"
+if grep -Eq '^set\(MKW_HAVE_RETRO_REWIND_SHARDS ON\)' \
+  "$translation_root/build_shards/shards.cmake"; then
+  native_target="KartPadDual"
+  runtime_product="dual"
+fi
+
 "$repo_root/scripts/check-android-host.sh"
 prepare_output="$("$repo_root/scripts/prepare-android-dependencies.sh")"
 echo "$prepare_output"
@@ -27,17 +35,11 @@ if [[ -z "$dawn_root" || -z "$minizip_root" ]]; then
 fi
 if [[ ! -d "$runtime_source" ]]; then
   "$repo_root/scripts/prepare-android-game-runtime.sh" \
-    "$translation_root" "$runtime_source" "$runtime_build" base
+    "$translation_root" "$runtime_source" "$runtime_build" "$runtime_product"
 fi
 if [[ ! -f "$(dirname "$runtime_source")/generated/data_sections_init.cpp" ]]; then
   echo "ERROR: prepared runtime is not paired with its ignored generated graph" >&2
   exit 1
-fi
-
-native_target="WiiCompiled"
-if grep -Eq '^set\(MKW_HAVE_RETRO_REWIND_SHARDS ON\)' \
-  "$translation_root/build_shards/shards.cmake"; then
-  native_target="KartPadDual"
 fi
 
 export JAVA_HOME="$repo_root/.android-bootstrap/jdk-$KARTPAD_ANDROID_JDK_VERSION/Contents/Home"

--- a/scripts/prepare-android-game-runtime.sh
+++ b/scripts/prepare-android-game-runtime.sh
@@ -58,6 +58,8 @@ patch --batch -p1 -d "$runtime_source" < \
   "$repo_root/patches/wiicompiled-android-sdl-rumble.patch"
 patch --batch -p1 -d "$runtime_source" < \
   "$repo_root/patches/wiicompiled-android-sdl-fiber-poll.patch"
+patch --batch -p1 -d "$runtime_source" < \
+  "$repo_root/patches/wiicompiled-android-touch-input.patch"
 
 generated_link="$(dirname "$runtime_source")/generated"
 if [[ -e "$generated_link" && ! -L "$generated_link" ]]; then

--- a/scripts/test-android-touch-input.sh
+++ b/scripts/test-android-touch-input.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+test_dir="$(mktemp -d "${TMPDIR:-/tmp}/kartpad-android-touch.XXXXXX")"
+trap 'rm -rf "$test_dir"' EXIT
+
+"${CXX:-c++}" -std=c++20 -Wall -Wextra -Werror -pthread \
+  -I"$repo_root/runtime/include" \
+  "$repo_root/runtime/src/android/touch_input.cpp" \
+  "$repo_root/tests/android_touch_input_contract.cpp" \
+  -o "$test_dir/android-touch-input-contract"
+"$test_dir/android-touch-input-contract"

--- a/tests/android_touch_input_contract.cpp
+++ b/tests/android_touch_input_contract.cpp
@@ -1,0 +1,50 @@
+#include "kartpad/android/touch_input.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+
+int main() {
+    using namespace kartpad::android;
+
+    ClearTouchInput();
+    auto state = ConsumeTouchInput();
+    assert(!state.connected);
+    assert(state.buttons == 0);
+
+    PublishTouchInput({
+        2.0f,
+        -2.0f,
+        std::numeric_limits<float>::quiet_NaN(),
+        0.25f,
+        kTouchButtonA | kTouchButtonLeft | 0x40000000u,
+        true,
+    });
+    state = ConsumeTouchInput();
+    assert(state.connected);
+    assert(state.buttons == (kTouchButtonA | kTouchButtonLeft));
+    assert(state.left_stick_x == 1.0f);
+    assert(state.left_stick_y == -1.0f);
+    assert(state.right_stick_x == 0.0f);
+    assert(state.right_stick_y == 0.25f);
+
+    // A down/up pair between guest samples must survive exactly one consume.
+    PublishTouchInput({0, 0, 0, 0, kTouchButtonB, true});
+    PublishTouchInput({0, 0, 0, 0, 0, true});
+    state = ConsumeTouchInput();
+    assert(state.buttons == kTouchButtonB);
+    state = ConsumeTouchInput();
+    assert(state.buttons == 0);
+    assert(state.connected);
+
+    ClearTouchInput();
+    state = ConsumeTouchInput();
+    assert(!state.connected);
+    assert(state.buttons == 0);
+    assert(!IsTouchInputConnected());
+
+    std::cout << "Android touch input contract passed\n";
+    return 0;
+}

--- a/tests/test_android_touch_overlay_contract.py
+++ b/tests/test_android_touch_overlay_contract.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+class AndroidTouchOverlayContractTests(unittest.TestCase):
+    def test_overlay_exposes_complete_classic_control_set(self) -> None:
+        source = (REPO / "android/app/src/main/java/dev/kartpad/android/KartPadOverlayView.kt").read_text()
+        for control in (
+            '"move"', '"c"', '"A"', '"B"', '"X"', '"Y"', '"Z"',
+            '"Start"', '"L"', '"R"', '"DpadUp"', '"DpadDown"',
+            '"DpadLeft"', '"DpadRight"',
+        ):
+            self.assertIn(control, source)
+        self.assertIn("pointerOwners", source)
+        self.assertIn("nativePublishTouchState", source)
+
+    def test_lifecycle_clears_touch_state(self) -> None:
+        activity = (REPO / "android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt").read_text()
+        self.assertIn("override fun onPause()", activity)
+        self.assertIn("override fun onWindowFocusChanged(hasFocus: Boolean)", activity)
+        self.assertGreaterEqual(activity.count("kartPadOverlay.clearTouchInput()"), 2)
+
+    def test_runtime_preparation_applies_touch_bridge(self) -> None:
+        script = (REPO / "scripts/prepare-android-game-runtime.sh").read_text()
+        self.assertIn("wiicompiled-android-touch-input.patch", script)
+        patch = (REPO / "patches/wiicompiled-android-touch-input.patch").read_text()
+        self.assertIn('"kartpad/android/touch_input.h"', patch)
+        self.assertIn("ConsumeTouchInput()", patch)
+        self.assertIn("CoreButtonsForClassic(touchInput.buttons)", patch)
+
+    def test_game_build_selects_dual_preparation_for_a_dual_graph(self) -> None:
+        script = (REPO / "scripts/build-android-game-app.sh").read_text()
+        self.assertIn('runtime_product="base"', script)
+        self.assertIn('runtime_product="dual"', script)
+        self.assertIn('"$runtime_build" "$runtime_product"', script)
+        self.assertIn('native_target="KartPadDual"', script)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_android_touch_overlay_contract.py
+++ b/tests/test_android_touch_overlay_contract.py
@@ -25,6 +25,23 @@ class AndroidTouchOverlayContractTests(unittest.TestCase):
         self.assertIn("override fun onWindowFocusChanged(hasFocus: Boolean)", activity)
         self.assertGreaterEqual(activity.count("kartPadOverlay.clearTouchInput()"), 2)
 
+    def test_one_second_gas_lock_has_visual_haptic_and_accessibility_state(self) -> None:
+        source = (REPO / "android/app/src/main/java/dev/kartpad/android/KartPadOverlayView.kt").read_text()
+        self.assertIn("GAS_LOCK_DELAY_MS = 1_000L", source)
+        self.assertIn("gasLocked = true", source)
+        self.assertIn("LOCKED_GAS_COLOR", source)
+        self.assertIn("HapticFeedbackConstants.VIRTUAL_KEY", source)
+        self.assertIn("isHapticFeedbackEnabled = true", source)
+        self.assertIn('"Acceleration locked"', source)
+        self.assertIn("var buttons = if (gasLocked) BUTTON_A else 0", source)
+        self.assertIn("gasLocked = false", source)
+
+    def test_r_is_the_same_compact_digital_pill_as_l(self) -> None:
+        source = (REPO / "android/app/src/main/java/dev/kartpad/android/KartPadOverlayView.kt").read_text()
+        self.assertIn('button("L", "L", BUTTON_L, 94f, 46f', source)
+        self.assertIn('button("R", "R", BUTTON_R, 94f, 46f', source)
+        self.assertIn("const val BUTTON_R = 0x00000200", source)
+
     def test_runtime_preparation_applies_touch_bridge(self) -> None:
         script = (REPO / "scripts/prepare-android-game-runtime.sh").read_text()
         self.assertIn("wiicompiled-android-touch-input.patch", script)


### PR DESCRIPTION
## Summary
- render the accepted KartPad phone control geometry over Android gameplay with stable multitouch ownership
- match KartPad iOS with a compact digital R pill identical to L
- match KartPad iOS A behavior: one-second cyan acceleration lock, explicit Android haptic, held after finger-up, next-tap unlock
- publish touch state through JNI and merge channel-zero buttons/left stick into the native KPAD path
- select dual preparation and KartPadDual automatically for a translated graph containing Retro Rewind

## Verification
- exact 119,090,830-byte local APK SHA-256: `258f80025ad0b094e577d699d785c5cb4b36a72e30e268b1cfa17ff408473b3b`
- strict Android package/privacy audit passed
- Android touch contract and 12 Android/shared iOS unit contracts passed
- SunPad overlay snapshot remains byte-identical
- API 36 ARM64 emulator reports a true `2400x1080` app frame
- direct touchscreen A advanced Retro Rewind; D-pad Right moved license selection
- 1.3-second A hold left A cyan/asserted after finger-up; next tap restored green/unlocked state
- R visibly matches L and the process remained healthy

## Scope
This is the first A4 emulator touch slice. Persistent layout editing, controller handoff, virtual accessibility nodes, right-stick guest behavior, physical haptic feel, tablet/physical touch, motion, and physical-device acceptance remain open. No APK, AAB, private content, save, or screenshot is published.