### PR TITLE
Record KartPad v0.4.3 release evidence

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -2,25 +2,26 @@
 
 ## Current state
 
-KartPad `v0.4.2` is published as the latest stable community release from
-`776a2a6a0e367b6d06f627c983f5da4a565ea104`. The iPhone/iPad app 0.4.2 build
-16 IPA has SHA-256
-`4c498de9a858bf9d59e6f082ebbe7a34e64935831601dc0981de42be8a8d473e`;
-the experimental tvOS app 0.4.2 build 5 IPA has SHA-256
-`0802f7e572da3df9b8daf5b09b45717584fad33c07d8be4ba5c6d8fadceaab3f`.
-Both exact-main builds and two independent packages per platform pass. Fresh
+KartPad `v0.4.3` is published as the latest stable community release from
+`2075cacbadbc6053e8fedf6179ab525003bac181`. The iPhone/iPad app 0.4.3 build
+17 IPA has SHA-256
+`a8cfe67b068064a9379a88b99e5e15e9fb982b0ef079aac64622e6f4efea8f4d`;
+the experimental tvOS app 0.4.3 build 6 IPA has SHA-256
+`878f27afc6900c43e07cb3330f3fa811d0cdd074cbc2f14a7e11f99e574cff31`.
+Both exact-release-source builds and two independent packages per platform pass. Fresh
 hosted downloads match the local bytes, checksums, provenance, and audits.
 The release keeps iPhone/iPad as the accepted community path and carries the
-tvOS cache-root fix, generic AArch64 baseline, RCpc exclusion and binary audit,
-plus shared aspect-state synchronization. Physical testing of the exact tvOS
-artifact remains open, so A12 compatibility and supported Apple TV operation
-are not claimed.
+tvOS cache-root fix, generic AArch64 baseline, RCpc exclusion and binary audit.
+It adds profile-aware Retro Rewind dispatch, an installed-version iOS startup
+guard, lower-latency iOS audio buffering, and opt-in default-off shake tricks.
+Physical testing of the exact tvOS artifact remains open, so A12 compatibility
+and supported Apple TV operation are not claimed.
 
 The Issue #17 reporter accepted the exact public `v0.4.1` tvOS storage hotfix on
 an Apple TV 4K (3rd generation) running tvOS 26.5/26.6. Config writes no longer
 raise error 513, both profiles launch, NAND/save and settings changes survive a
 normal relaunch, and the cache-root backup script succeeds. This resolves the
-reported storage defect without establishing the still-open 0.4.2, A12,
+reported storage defect without establishing the still-open 0.4.3, A12,
 sleep/wake, restore, multi-controller, purge-recovery, or sustained-performance
 gates.
 
@@ -106,7 +107,7 @@ not block offline Retro Rewind support.
 1. Begin Android A0 on the authorized second machine using
    `docs/ANDROID-GOAL-LOOP.md`: bootstrap pinned tools and prove the source-only
    ARM64 SDL/JNI/Vulkan fixture before private game integration.
-2. Collect a physical Apple TV report against the exact `v0.4.2` asset using
+2. Collect a physical Apple TV report against the exact `v0.4.3` asset using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook
    Air cursor/settings retest requested against Preview 5.

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -25,12 +25,22 @@ limitations when its exact artifact passes every preview gate below.
 - [x] Accept only source changes with a reproducible defect or bounded feature
 - [x] Preserve individual contributor attribution through separate merges
 - [x] Validate the combined translator, native tests, and unsigned iPhoneOS app
-- [ ] Build and audit exact merged-source iOS 0.4.3 build 17 and tvOS build 6
-- [ ] Package both IPAs twice byte-identically and pass fresh extraction audits
-- [ ] Publish the stable tag, both IPAs, and `SHA256SUMS`
-- [ ] Verify fresh hosted downloads byte-for-byte and re-audit them
+- [x] Build and audit exact merged-source iOS 0.4.3 build 17 and tvOS build 6
+- [x] Package both IPAs twice byte-identically and pass fresh extraction audits
+- [x] Publish the stable tag, both IPAs, and `SHA256SUMS`
+- [x] Verify fresh hosted downloads byte-for-byte and re-audit them
 - [ ] Receive physical acceptance for the exact tvOS artifact before claiming
       A12 compatibility or supported Apple TV functionality
+
+Published source: `2075cacbadbc6053e8fedf6179ab525003bac181`.
+iPhone/iPad executable SHA-256:
+`a1095e26d931768549c00213b5604f88506814c1b3badfa5f6c55a5072075b26`.
+iPhone/iPad IPA SHA-256:
+`a8cfe67b068064a9379a88b99e5e15e9fb982b0ef079aac64622e6f4efea8f4d`.
+tvOS executable SHA-256:
+`a365640bedfd81c779cd98fae9de443c1c81f42f02c19633479ecf77eaafd760`.
+tvOS IPA SHA-256:
+`878f27afc6900c43e07cb3330f3fa811d0cdd074cbc2f14a7e11f99e574cff31`.
 
 ## 0.4.2 maintenance candidate
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -29,7 +29,7 @@ hotfix incorporates that path correction, and the reporter accepted its exact
 public IPA for config writes, both profile launches, normal-relaunch
 persistence, and cache-root backup. The 0.4.2 release adds a generic compiler
 baseline, explicitly disables RCpc instructions, and rejects those instructions
-during final-binary audit; physical testing of the exact 0.4.2 artifact, restore,
+during final-binary audit; physical testing of the exact 0.4.3 artifact, restore,
 sleep/wake, multi-controller, and sustained performance remain open. Apple TV
 support is therefore still experimental. The release includes
 an original three-layer tvOS icon and Top Shelf image compiled into its audited
@@ -40,15 +40,22 @@ gate are in
 
 ## Current goal
 
-**0.4.3 is the current community maintenance candidate.** Four external
-contributions were reviewed at their exact heads and accepted individually:
-profile-aware Retro Rewind dispatch, an installed-version viewport startup
-guard, lower-latency iOS audio buffering, and opt-in default-off shake tricks.
-The combined source passes translator, native, unsigned iPhoneOS build, and app
-audit gates. Exact merged-source double packaging and hosted verification remain
-release gates. Android work is separate and unchanged.
+**0.4.3 is published as the latest stable community release.** The `v0.4.3`
+tag dereferences to audited source commit
+`2075cacbadbc6053e8fedf6179ab525003bac181`. Four external contributions were
+reviewed at their exact heads and accepted individually: profile-aware Retro
+Rewind dispatch, an installed-version viewport startup guard, lower-latency iOS
+audio buffering, and opt-in default-off shake tricks. Exact merged-source iOS
+0.4.3 build 17 and tvOS build 6 builds and app audits passed. Two packages per
+platform were byte-identical, and fresh hosted downloads matched and re-audited.
+The iPhone/iPad IPA SHA-256 is
+`a8cfe67b068064a9379a88b99e5e15e9fb982b0ef079aac64622e6f4efea8f4d`;
+the experimental tvOS IPA SHA-256 is
+`878f27afc6900c43e07cb3330f3fa811d0cdd074cbc2f14a7e11f99e574cff31`.
+Android work is separate and unchanged. Exact tvOS physical acceptance and
+older-device audio monitoring remain open.
 
-**0.4.2 is published as the latest stable community release.** The `v0.4.2`
+**0.4.2 is retained as the preceding stable community release.** The `v0.4.2`
 tag dereferences to audited source commit
 `776a2a6a0e367b6d06f627c983f5da4a565ea104`. It refreshes the accepted
 iPhone/iPad path as app 0.4.2 build 16 and the experimental tvOS path as app
@@ -83,7 +90,7 @@ accepted the exact signed hotfix artifact on an Apple TV 4K (3rd generation):
 `Config.toml` wrote without error 513, Original and Retro Rewind launched,
 NAND/save and settings changes survived normal termination and relaunch, and
 `backup-tvos-state.sh` succeeded. Issue #17 is resolved; broader tvOS and exact
-0.4.2 acceptance remain separate gates.
+0.4.3 acceptance remain separate gates.
 
 **0.4.0 is published as KartPad's second stable community release.** The
 `v0.4.0` tag points to source commit

--- a/docs/TVOS-TESTING.md
+++ b/docs/TVOS-TESTING.md
@@ -2,7 +2,7 @@
 
 An externally built cache-root candidate has reached playable Original Mario
 Kart Wii and Retro Rewind on physical Apple TV 4K hardware. The exact public
-`v0.4.2` compiler-hardened build still needs a signed-container retest. Treat it as an
+`v0.4.3` compiler-hardened build still needs a signed-container retest. Treat it as an
 engineering bring-up build, not a supported release, and do not rely on its
 purgeable local storage for valuable saves.
 

--- a/docs/TVOS.md
+++ b/docs/TVOS.md
@@ -10,10 +10,10 @@ Application Support. The `v0.4.1` hotfix moves all filesystem-backed tvOS state
 to Caches, matching the successful physical workaround. The reporter then
 accepted the exact public `v0.4.1` IPA on the same hardware: error 513 was gone,
 both modes launched, save/config changes survived a normal relaunch, and the
-backup script succeeded. The 0.4.2 candidate also uses a generic compiler
+backup script succeeded. The 0.4.3 release also uses a generic compiler
 baseline, disables RCpc instructions, and rejects them during final-binary
 audit. Until the remaining physical acceptance matrix passes on the exact
-0.4.2 artifact, the correct
+0.4.3 artifact, the correct
 claim is **public experimental tvOS build**, not supported Apple TV
 functionality.
 
@@ -181,7 +181,7 @@ IPA in place. Config writes produced no error 513, Original and Retro Rewind
 both launched, NAND/save and settings changes survived normal termination and
 relaunch, and `backup-tvos-state.sh` captured the cache-root state. This closes
 the storage defect in Issue #17. Sleep/wake, forced termination, restore,
-multi-controller, purge recovery, sustained performance, and the exact 0.4.2
+multi-controller, purge recovery, sustained performance, and the exact 0.4.3
 artifact remain open. This is still a hardware bring-up build, not a supported
 release. The acceptance record is in
 [`docs/artifacts/2026-09-04/tvos-v0.4.1-storage-acceptance.md`](artifacts/2026-09-04/tvos-v0.4.1-storage-acceptance.md).

--- a/docs/releases/NEXT.md
+++ b/docs/releases/NEXT.md
@@ -32,10 +32,20 @@ Physical acceptance of the exact tvOS artifact remains open.
 - [x] Review each external pull request at its exact head.
 - [x] Merge accepted contributions individually with contributor attribution.
 - [x] Validate the combined source, translator, native tests, and iPhoneOS app.
-- [ ] Merge and verify the complete release source on `main`.
-- [ ] Rebuild exact merged source as iOS 0.4.3 build 17 and tvOS build 6.
-- [ ] Package each IPA twice deterministically and compare bytes.
-- [ ] Audit exact IPAs and embedded provenance/notices.
-- [ ] Tag the audited source and publish both IPAs plus `SHA256SUMS`.
-- [ ] Download hosted assets, byte-compare, checksum-verify, and re-audit.
-- [ ] Verify remote `main` and the dereferenced tag.
+- [x] Merge and verify the complete release source on `main`.
+- [x] Rebuild exact merged source as iOS 0.4.3 build 17 and tvOS build 6.
+- [x] Package each IPA twice deterministically and compare bytes.
+- [x] Audit exact IPAs and embedded provenance/notices.
+- [x] Tag the audited source and publish both IPAs plus `SHA256SUMS`.
+- [x] Download hosted assets, byte-compare, checksum-verify, and re-audit.
+- [x] Verify remote `main` and the dereferenced tag.
+
+Published source: `2075cacbadbc6053e8fedf6179ab525003bac181`.
+iPhone/iPad executable SHA-256:
+`a1095e26d931768549c00213b5604f88506814c1b3badfa5f6c55a5072075b26`.
+iPhone/iPad IPA SHA-256:
+`a8cfe67b068064a9379a88b99e5e15e9fb982b0ef079aac64622e6f4efea8f4d`.
+Experimental tvOS executable SHA-256:
+`a365640bedfd81c779cd98fae9de443c1c81f42f02c19633479ecf77eaafd760`.
+Experimental tvOS IPA SHA-256:
+`878f27afc6900c43e07cb3330f3fa811d0cdd074cbc2f14a7e11f99e574cff31`.


### PR DESCRIPTION
## Summary

- record the exact v0.4.3 release source and executable/IPA hashes
- close deterministic packaging and hosted verification gates
- point tvOS testers at the exact v0.4.3 artifact while preserving the experimental boundary

## Verified

- exact-source iOS 0.4.3 build 17 and tvOS build 6 app audits
- two byte-identical packages per platform
- fresh hosted checksum, byte comparison, and full IPA re-audits
- remote main and dereferenced v0.4.3 tag at 2075cacbadbc6053e8fedf6179ab525003bac181
- repository safety, pinned SunPad snapshot, and 57 Python tests