### PR TITLE
Add Android controller touch handoff

### DIFF
--- a/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
@@ -2,8 +2,10 @@ package dev.kartpad.android
 
 import android.os.Bundle
 import android.content.Context
+import android.hardware.input.InputManager
 import android.system.Os
 import android.util.Log
+import android.view.InputDevice
 import android.view.ViewGroup
 import java.io.ByteArrayInputStream
 import java.io.File
@@ -16,6 +18,13 @@ import org.libsdl.app.SDLSurface
 
 class KartPadActivity : SDLActivity() {
     private lateinit var kartPadOverlay: KartPadOverlayView
+    private lateinit var inputManager: InputManager
+    private var inputListenerRegistered = false
+    private val inputDeviceListener = object : InputManager.InputDeviceListener {
+        override fun onInputDeviceAdded(deviceId: Int) = refreshControllerHandoff()
+        override fun onInputDeviceRemoved(deviceId: Int) = refreshControllerHandoff()
+        override fun onInputDeviceChanged(deviceId: Int) = refreshControllerHandoff()
+    }
 
     override fun createSDLSurface(context: Context): SDLSurface = KartPadSurface(context)
 
@@ -30,6 +39,7 @@ class KartPadActivity : SDLActivity() {
             configureDebugStateTrace()
         }
         super.onCreate(savedInstanceState)
+        inputManager = getSystemService(InputManager::class.java)
         runDebugRetroRewindExtractionFixture()
         runDebugRetroRewindWorkerFixture()
         kartPadOverlay = KartPadOverlayView(this)
@@ -49,7 +59,20 @@ class KartPadActivity : SDLActivity() {
         Log.i(TAG, "A0 SDLActivity shell created")
     }
 
+    override fun onResume() {
+        super.onResume()
+        if (::inputManager.isInitialized && !inputListenerRegistered) {
+            inputManager.registerInputDeviceListener(inputDeviceListener, null)
+            inputListenerRegistered = true
+        }
+        refreshControllerHandoff()
+    }
+
     override fun onPause() {
+        if (::inputManager.isInitialized && inputListenerRegistered) {
+            inputManager.unregisterInputDeviceListener(inputDeviceListener)
+            inputListenerRegistered = false
+        }
         if (::kartPadOverlay.isInitialized) {
             kartPadOverlay.clearTouchInput()
         }
@@ -61,6 +84,23 @@ class KartPadActivity : SDLActivity() {
             kartPadOverlay.clearTouchInput()
         }
         super.onWindowFocusChanged(hasFocus)
+    }
+
+    private fun refreshControllerHandoff() {
+        if (!BuildConfig.GAME_RUNTIME || !::kartPadOverlay.isInitialized ||
+            !::inputManager.isInitialized
+        ) return
+        val controllerCount = inputManager.inputDeviceIds.count { deviceId ->
+            inputManager.getInputDevice(deviceId)?.let(::isGameController) == true
+        }
+        kartPadOverlay.setHiddenForController(controllerCount > 0)
+        Log.i(TAG, "A4 controller handoff count=$controllerCount")
+    }
+
+    private fun isGameController(device: InputDevice): Boolean {
+        val sources = device.sources
+        return sources and InputDevice.SOURCE_GAMEPAD == InputDevice.SOURCE_GAMEPAD ||
+            sources and InputDevice.SOURCE_JOYSTICK == InputDevice.SOURCE_JOYSTICK
     }
 
     private fun configureRuntimeProfile() {

--- a/android/app/src/main/java/dev/kartpad/android/KartPadOverlayView.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadOverlayView.kt
@@ -57,6 +57,7 @@ class KartPadOverlayView(context: Context) : View(context) {
     private var rightY = 0f
     private var gasHoldGeneration = 0
     private var gasLocked = false
+    private var hiddenForController = false
 
     init {
         setWillNotDraw(false)
@@ -151,6 +152,19 @@ class KartPadOverlayView(context: Context) : View(context) {
         updateGasAccessibility()
         nativeClearTouchState()
         invalidate()
+    }
+
+    fun setHiddenForController(hidden: Boolean) {
+        if (hiddenForController == hidden) return
+        hiddenForController = hidden
+        if (hidden) {
+            clearTouchInput()
+            visibility = INVISIBLE
+        } else {
+            visibility = VISIBLE
+            publishState(connected = true)
+            invalidate()
+        }
     }
 
     private fun buildControls() {

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -64,9 +64,12 @@ complete phone control set renders over the dual Retro runtime at a true
 `2400x1080`, and direct touchscreen A and D-pad Right events advance the guest
 through title and license selection. R now matches L's compact digital pill,
 and a one-second A hold turns cyan, remains asserted after finger-up, invokes a
-light Android haptic, and unlocks on the next tap. Persistent layout editing,
-controller handoff, full accessibility, tablet/physical touch and haptic feel,
-motion, and physical-device acceptance remain open.
+light Android haptic, and unlocks on the next tap. Android gamepad/joystick
+hotplug now clears and hides touch, then restores a neutral overlay after the
+last controller disconnects; an emulator test starting from cyan locked A
+proved that stale acceleration does not survive the handoff. Persistent layout
+editing, a configurable handoff policy, full accessibility, tablet/physical
+touch and haptic feel, motion, and physical-device acceptance remain open.
 
 The first independent A3 source slice extracted archive member-path validation
 into `runtime/src/retro_rewind/archive_path.cpp`. The existing iOS/tvOS installer

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -3056,3 +3056,27 @@ This file is append-only. Evidence paths refer to sanitized, publishable artifac
   tablet/physical touch, motion, and physical-device acceptance remain open.
   No APK, AAB, private content, save, or screenshot was published. Evidence:
   `docs/artifacts/2026-09-04/android/a4-touch-overlay-input.md`.
+
+## 2026-09-04 — Android A4 controller/touch handoff
+
+- Added an activity-scoped Android input-device listener that recognizes
+  gamepad and joystick sources, reconciles already-connected devices on resume,
+  and unregisters on pause.
+- Controller presence now clears the touch snapshot before hiding the overlay;
+  removal of the final controller restores a neutral visible overlay.
+- On the standalone API 36 ARM64 emulator, a temporary InputReader-visible Xbox
+  controller produced app counts `0 -> 1 -> 0`. The complete overlay visibly
+  hid and restored over the live Retro runtime.
+- Repeated the transition after a 1.4-second A hold left acceleration visibly
+  cyan and locked. Controller attach hid touch, and disconnect restored A green
+  and unlocked, directly proving stale held input was cleared.
+- The 119,090,830-byte local APK has SHA-256
+  `f777c271082b34a9896beda816ec85134cb3d7472a73d99607b311bcc10e994f`.
+  The virtual controller was disconnected after the test.
+- Native and source contracts, Android lint, strict APK and repository safety
+  audits, pinned source/input verification, and the Apple overlay snapshot pass.
+- Classification: **Pass for controller/touch hotplug and held-input clearing
+  on the emulator.** Configurable policy, physical controller/device behavior,
+  touch editing, accessibility, tablet layout, and physical acceptance remain
+  open. No package or private content was published. Evidence:
+  `docs/artifacts/2026-09-04/android/a4-controller-handoff.md`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -627,10 +627,16 @@ builds the dual product instead of silently preparing a base-only runtime. The
 and passes the strict package audit. This closes only the first emulator
 touch/JNI/KPAD slice. R visibly matches L's compact digital pill; a 1.3-second
 A hold turns cyan and stays asserted after finger-up, and the next A tap
-restores green/unlocked state. Persistent editing, controller handoff, virtual
-accessibility nodes, right-stick guest behavior, physical haptic feel, tablet
-and physical touch, motion, and physical-device acceptance remain open. Evidence:
+restores green/unlocked state. Android input-device hotplug now also clears all
+touch state and hides the overlay while a gamepad/joystick is present. A live
+emulator sequence proved visible touch, hidden-on-controller, and restored-on-
+disconnect states; a second sequence began with A cyan/locked and restored it
+green/unlocked after controller connect/disconnect. Persistent editing,
+configurable handoff policy, virtual accessibility nodes, right-stick guest
+behavior, physical haptic feel, tablet and physical touch, motion, and
+physical-device acceptance remain open. Evidence:
 [`docs/artifacts/2026-09-04/android/a4-touch-overlay-input.md`](artifacts/2026-09-04/android/a4-touch-overlay-input.md).
+[`docs/artifacts/2026-09-04/android/a4-controller-handoff.md`](artifacts/2026-09-04/android/a4-controller-handoff.md).
 
 ## Native tvOS work
 

--- a/docs/artifacts/2026-09-04/android/a4-controller-handoff.md
+++ b/docs/artifacts/2026-09-04/android/a4-controller-handoff.md
@@ -1,0 +1,63 @@
+# Android A4 controller/touch handoff
+
+## Falsifiable subgoal
+
+When an Android game controller appears, clear all held touch state and hide
+the touch overlay. When the last controller disappears, restore the overlay
+without restoring any touch button or stick state.
+
+This is an API 36 ARM64 emulator hotplug and state-clearing result. It is not
+physical-controller discovery, physical touch feel, accessibility, controller
+latency, or physical-device acceptance.
+
+## Implementation
+
+- `KartPadActivity` listens for Android input-device add, remove, and change
+  events while resumed.
+- Devices advertising either `SOURCE_GAMEPAD` or `SOURCE_JOYSTICK` participate
+  in the handoff count.
+- The first connected controller clears the native touch snapshot before the
+  overlay becomes invisible. Removal of the last controller restores the
+  overlay and publishes a neutral connected touch snapshot.
+- Pause unregisters the listener and retains the existing unconditional touch
+  clear. Resume registers once and immediately reconciles controllers that
+  were already connected.
+- The source contract covers discovery, listener lifecycle, touch clearing,
+  hiding, and restoration.
+
+## Emulator evidence
+
+- Baseline source commit: `0d85914`; branch:
+  `codex/android-a4-controller-handoff`.
+- Device: standalone `KartPad_API_36_ARM64`, API 36, arm64-v8a, 4 KiB pages,
+  logical landscape frame `2400x1080`.
+- The 119,090,830-byte local-only APK has SHA-256
+  `f777c271082b34a9896beda816ec85134cb3d7472a73d99607b311bcc10e994f`.
+- Android InputReader classified the temporary device as keyboard, gamepad,
+  joystick, external, and Xbox layout. The app logged controller counts
+  `0 -> 1 -> 0` while the same rendered Retro Rewind process stayed active.
+- With touch initially visible, controller connection hid every touch control;
+  disconnect restored the complete overlay. Ignored screenshot SHA-256 values
+  are `b7b3081f...fe10069`, `0a7f7fc7...71e055`, and
+  `e964616b...a12e8`, respectively.
+- A 1.4-second touchscreen hold first left A visibly cyan and locked. Connecting
+  the controller hid the overlay; disconnect restored A green and unlocked.
+  The ignored locked/hidden/restored screenshot SHA-256 values are
+  `1a391263...30ea67`, `2a2a128...b62757`, and
+  `bb4eaa2...fa5713`.
+- The temporary virtual controller was disconnected at the end, and InputReader
+  no longer listed it.
+- The native touch contract, 13 Android/iOS touch-parity tests, Android lint,
+  strict APK audit, repository safety audit, pinned source/input verification,
+  SunPad snapshot verification, and `git diff --check` pass.
+
+## Classification
+
+**Pass for Android A4 emulator controller/touch handoff, including clearing a
+latched A acceleration state across controller connect/disconnect.**
+
+Still open: configurable controller-hides-touch policy, persistent touch
+editing/opacity/size/hide, virtual accessibility nodes and hit maps,
+multi-pointer replay, tablet layout, motion steering, physical controller and
+touch behavior, and physical-device acceptance. No APK, AAB, screenshot,
+private graph, save, or game data was published.

--- a/tests/test_android_touch_overlay_contract.py
+++ b/tests/test_android_touch_overlay_contract.py
@@ -42,6 +42,20 @@ class AndroidTouchOverlayContractTests(unittest.TestCase):
         self.assertIn('button("R", "R", BUTTON_R, 94f, 46f', source)
         self.assertIn("const val BUTTON_R = 0x00000200", source)
 
+    def test_controller_handoff_clears_hides_and_restores_touch(self) -> None:
+        activity = (REPO / "android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt").read_text()
+        overlay = (REPO / "android/app/src/main/java/dev/kartpad/android/KartPadOverlayView.kt").read_text()
+        self.assertIn("InputManager.InputDeviceListener", activity)
+        self.assertIn("InputDevice.SOURCE_GAMEPAD", activity)
+        self.assertIn("InputDevice.SOURCE_JOYSTICK", activity)
+        self.assertIn("registerInputDeviceListener", activity)
+        self.assertIn("unregisterInputDeviceListener", activity)
+        self.assertIn("setHiddenForController(controllerCount > 0)", activity)
+        self.assertIn("fun setHiddenForController(hidden: Boolean)", overlay)
+        self.assertIn("clearTouchInput()", overlay)
+        self.assertIn("visibility = INVISIBLE", overlay)
+        self.assertIn("visibility = VISIBLE", overlay)
+
     def test_runtime_preparation_applies_touch_bridge(self) -> None:
         script = (REPO / "scripts/prepare-android-game-runtime.sh").read_text()
         self.assertIn("wiicompiled-android-touch-input.patch", script)


### PR DESCRIPTION
## Summary
- listen for Android gamepad and joystick hotplug while the runtime activity is resumed
- clear and hide touch when a controller is present, then restore a neutral overlay after the last disconnect
- cover the lifecycle and handoff contract and record live API 36 emulator evidence

## Live proof
- InputReader-visible virtual Xbox controller produced app handoff counts 0 -> 1 -> 0
- visible overlay hid on attach and restored on disconnect over the live Retro runtime
- starting from cyan locked A, attach/disconnect restored A green and unlocked, proving stale acceleration was cleared

## Verification
- native Android touch contract
- 13 Android/iOS touch parity contracts
- Android lint
- strict APK audit (SHA-256 f777c271082b34a9896beda816ec85134cb3d7472a73d99607b311bcc10e994f)
- repository safety and pinned source/input verification
- pinned SunPad overlay snapshot
- git diff check

Emulator evidence only; physical controller/device acceptance and configurable handoff policy remain open. No APK/AAB or private content was published.