### PR TITLE
Record v0.4.4 release evidence

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -2,20 +2,19 @@
 
 ## Current state
 
-KartPad `v0.4.3` is published as the latest stable community release from
-`2075cacbadbc6053e8fedf6179ab525003bac181`. The iPhone/iPad app 0.4.3 build
-17 IPA has SHA-256
-`a8cfe67b068064a9379a88b99e5e15e9fb982b0ef079aac64622e6f4efea8f4d`;
-the experimental tvOS app 0.4.3 build 6 IPA has SHA-256
-`878f27afc6900c43e07cb3330f3fa811d0cdd074cbc2f14a7e11f99e574cff31`.
-Both exact-release-source builds and two independent packages per platform pass. Fresh
-hosted downloads match the local bytes, checksums, provenance, and audits.
-The release keeps iPhone/iPad as the accepted community path and carries the
-tvOS cache-root fix, generic AArch64 baseline, RCpc exclusion and binary audit.
-It adds profile-aware Retro Rewind dispatch, an installed-version iOS startup
-guard, lower-latency iOS audio buffering, and opt-in default-off shake tricks.
-Physical testing of the exact tvOS artifact remains open, so A12 compatibility
-and supported Apple TV operation are not claimed.
+KartPad `v0.4.4` is published as the latest stable community release from
+`3b857f9ae2b7933c6eb4f8f8f61a07df6b455624`. The iPhone/iPad app 0.4.4 build
+18 IPA has SHA-256
+`5d2428abe9e4e0a7736912669c05fe8b40d3d5b34fcf85d05f3d31f336c6ed11`;
+the experimental tvOS app 0.4.4 build 7 IPA has SHA-256
+`b508d45fc4426190e7c25c6f57c31ec838f71f02a666feb07b06ca379a976f66`.
+Both exact-source builds and two independent packages per platform pass. Fresh
+anonymous hosted downloads match the local bytes, checksums, provenance, and
+audits. The release advances the verified pack and AOT graph to Retro Rewind
+6.12.7. It also makes the daily watcher open one deduplicated compatibility
+issue and adds a resumable one-command profile updater. Retro WFC service
+recovery is verified; exact 0.4.4 production gameplay and physical-device
+acceptance remain open. Apple TV remains experimental.
 
 The Issue #17 reporter accepted the exact public `v0.4.1` tvOS storage hotfix on
 an Apple TV 4K (3rd generation) running tvOS 26.5/26.6. Config writes no longer
@@ -98,16 +97,16 @@ on the exact affected iPad and Files provider.
 The preview offers Original Mario Kart Wii or optional Retro Rewind 6.12.5.
 The preceding 6.12.4 build completed physical iPad pack download, verification,
 installation, launch, and a playable single-player match. General physical
-execution is accepted on iPad and iPhone. Retro WFC remains unavailable during
-external service maintenance; live public online play is not claimed and does
-not block offline Retro Rewind support.
+execution is accepted on iPad and iPhone. Retro WFC service recovery is now
+verified, but live public online play is not claimed for the exact 0.4.4
+artifact until its production and physical-device gates pass.
 
 ## Next executable work
 
 1. Begin Android A0 on the authorized second machine using
    `docs/ANDROID-GOAL-LOOP.md`: bootstrap pinned tools and prove the source-only
    ARM64 SDL/JNI/Vulkan fixture before private game integration.
-2. Collect a physical Apple TV report against the exact `v0.4.3` asset using
+2. Collect a physical Apple TV report against the exact `v0.4.4` asset using
    `docs/TVOS-TESTING.md`.
 3. Await the Issue #1 Feather-signed iPad import retest and the Issue #5 MacBook
    Air cursor/settings retest requested against Preview 5.
@@ -117,8 +116,8 @@ not block offline Retro Rewind support.
    the accepted 0.3.0 release baseline.
 6. Complete the remaining three- and four-player, touch, motion, controller,
    audio, thermal, lifecycle, and long-soak rows in `docs/PRD.md`.
-7. When Retro WFC returns, retest production login, matchmaking, a complete
-   race, results, reconnect, and physical-device online play.
+7. Retest production login, matchmaking, a complete race, results, reconnect,
+   and physical-device online play against the recovered Retro WFC service.
 8. Follow `docs/UPSTREAM_UPDATES.md` whenever WiiCompiled or Retro Rewind
    advances; never accept an unpinned pack or `Code.pul`.
 

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -29,11 +29,21 @@ limitations when its exact artifact passes every preview gate below.
 - [x] Add a resumable one-command latest-profile updater
 - [x] Pass full repository, source, patch, translator, and native tests
 - [x] Build and audit exact-source iOS 0.4.4 build 18 and tvOS build 7
-- [ ] Package each IPA twice byte-identically and audit exact packages
-- [ ] Publish `v0.4.4`, both IPAs, and `SHA256SUMS`
-- [ ] Download hosted assets, byte-compare, and re-audit them
+- [x] Package each IPA twice byte-identically and audit exact packages
+- [x] Publish `v0.4.4`, both IPAs, and `SHA256SUMS`
+- [x] Download hosted assets, byte-compare, and re-audit them
 - [ ] Keep production Retro WFC and physical-device acceptance separate until
       the exact candidate completes those gates
+
+Published source: `3b857f9ae2b7933c6eb4f8f8f61a07df6b455624`.
+iPhone/iPad executable SHA-256:
+`1e251b27a05411f4e03b9d6ff468cb49a7bb111d3648534d32184e2493c089c7`.
+iPhone/iPad IPA SHA-256:
+`5d2428abe9e4e0a7736912669c05fe8b40d3d5b34fcf85d05f3d31f336c6ed11`.
+tvOS executable SHA-256:
+`0bd0409e4cfb14fd4850ebae96b1cd5e85e6c6476dee94b872426a78c91c6d47`.
+tvOS IPA SHA-256:
+`b508d45fc4426190e7c25c6f57c31ec838f71f02a666feb07b06ca379a976f66`.
 
 ## 0.4.3 community maintenance candidate
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # KartPad status
 
-Updated: 2026-09-05
+Updated: 2026-09-06
 
 ## Native Android work
 
@@ -29,7 +29,7 @@ hotfix incorporates that path correction, and the reporter accepted its exact
 public IPA for config writes, both profile launches, normal-relaunch
 persistence, and cache-root backup. The 0.4.2 release adds a generic compiler
 baseline, explicitly disables RCpc instructions, and rejects those instructions
-during final-binary audit; physical testing of the exact 0.4.3 artifact, restore,
+during final-binary audit; physical testing of the exact 0.4.4 artifact, restore,
 sleep/wake, multi-controller, and sustained performance remain open. Apple TV
 support is therefore still experimental. The release includes
 an original three-layer tvOS icon and Top Shelf image compiled into its audited
@@ -40,20 +40,23 @@ gate are in
 
 ## Current goal
 
-**0.4.3 is published as the latest stable community release.** The `v0.4.3`
+**0.4.4 is published as the latest stable community release.** The `v0.4.4`
 tag dereferences to audited source commit
-`2075cacbadbc6053e8fedf6179ab525003bac181`. Four external contributions were
-reviewed at their exact heads and accepted individually: profile-aware Retro
-Rewind dispatch, an installed-version viewport startup guard, lower-latency iOS
-audio buffering, and opt-in default-off shake tricks. Exact merged-source iOS
-0.4.3 build 17 and tvOS build 6 builds and app audits passed. Two packages per
-platform were byte-identical, and fresh hosted downloads matched and re-audited.
-The iPhone/iPad IPA SHA-256 is
-`a8cfe67b068064a9379a88b99e5e15e9fb982b0ef079aac64622e6f4efea8f4d`;
-the experimental tvOS IPA SHA-256 is
-`878f27afc6900c43e07cb3330f3fa811d0cdd074cbc2f14a7e11f99e574cff31`.
-Android work is separate and unchanged. Exact tvOS physical acceptance and
-older-device audio monitoring remain open.
+`3b857f9ae2b7933c6eb4f8f8f61a07df6b455624`. It advances the verified full
+pack and ahead-of-time native graph to Retro Rewind 6.12.7, improves the future
+version-mismatch explanation, makes the daily watcher open one deduplicated
+maintenance issue, and adds a resumable one-command profile updater. Exact
+source iOS 0.4.4 build 18 and tvOS build 7 builds and app audits passed. Two
+packages per platform were byte-identical; anonymous hosted downloads matched,
+passed their checksums, and re-audited. The iPhone/iPad executable and IPA
+SHA-256 values are respectively
+`1e251b27a05411f4e03b9d6ff468cb49a7bb111d3648534d32184e2493c089c7`
+and `5d2428abe9e4e0a7736912669c05fe8b40d3d5b34fcf85d05f3d31f336c6ed11`.
+The experimental tvOS executable and IPA SHA-256 values are respectively
+`0bd0409e4cfb14fd4850ebae96b1cd5e85e6c6476dee94b872426a78c91c6d47`
+and `b508d45fc4426190e7c25c6f57c31ec838f71f02a666feb07b06ca379a976f66`.
+Android work is separate and unchanged. Exact Retro WFC production gameplay,
+0.4.4 physical-device acceptance, and broader tvOS gates remain open.
 
 **0.4.2 is retained as the preceding stable community release.** The `v0.4.2`
 tag dereferences to audited source commit
@@ -181,13 +184,13 @@ each direction per client and consumed the complete 5,001-frame fixture. The
 test-only finish trigger is documented in `docs/ONLINE.md`; public-service,
 physical-device online, impairment, and external-client rows remain open.
 
-The exact released dual-mode build also reaches production Retro WFC NAS
-authentication. It then receives `61070` because the public GameSpy
-gameplay-login endpoint times out. Retro Rewind's official documentation lists
-the service as in testing/maintenance mode, and its status page has no live
-room data. Production online acceptance is waiting on Retro WFC recovery. That
-external outage does not block the accepted Retro Rewind installation, launch,
-or offline-gameplay support in the current KartPad build.
+The previously tested dual-mode build reached production Retro WFC NAS
+authentication but then received `61070` while the public GameSpy gameplay
+login endpoint was unavailable. On 6 September 2026, Retro WFC's health and
+room endpoints were reachable and reported active service. Production service
+recovery is therefore verified, while login, matchmaking, complete race,
+results, reconnect, and physical-device acceptance of the exact 0.4.4 artifact
+remain open.
 
 The same source produced a fresh signed KartPad `0.3.0` physical-iOS build. It
 was installed over the existing app on the attached iPad without
@@ -211,8 +214,8 @@ in place without removing KartPad's data and carries the final iPad
 multiplayer-guidance polish, which is validated in the exact iPad Simulator
 candidate. This closes physical pack installation, Retro Rewind launch, and
 initial offline-gameplay acceptance. Production Retro WFC matchmaking and
-online gameplay remain unaccepted while the external service is in maintenance,
-but they are not a blocker for this build.
+online gameplay remain unaccepted for the exact current artifact, but they are
+not a blocker for offline support.
 
 ## Goal ledger
 

--- a/docs/releases/NEXT.md
+++ b/docs/releases/NEXT.md
@@ -63,8 +63,18 @@ tvOS remains experimental pending exact-artifact physical acceptance.
 - [x] Add automatic issue creation and the one-command profile updater.
 - [x] Pass full repository, source, patch, translator, and native tests.
 - [x] Build and audit exact-source iOS 0.4.4 build 18 and tvOS build 7.
-- [ ] Package each IPA twice byte-identically and audit exact packages.
-- [ ] Publish `v0.4.4`, both IPAs, and `SHA256SUMS`.
-- [ ] Download hosted assets, compare bytes, and re-audit them.
+- [x] Package each IPA twice byte-identically and audit exact packages.
+- [x] Publish `v0.4.4`, both IPAs, and `SHA256SUMS`.
+- [x] Download hosted assets, compare bytes, and re-audit them.
 - [ ] Receive physical acceptance before broadening device or production-online
       claims.
+
+Published source: `3b857f9ae2b7933c6eb4f8f8f61a07df6b455624`.
+iPhone/iPad executable SHA-256:
+`1e251b27a05411f4e03b9d6ff468cb49a7bb111d3648534d32184e2493c089c7`.
+iPhone/iPad IPA SHA-256:
+`5d2428abe9e4e0a7736912669c05fe8b40d3d5b34fcf85d05f3d31f336c6ed11`.
+Experimental tvOS executable SHA-256:
+`0bd0409e4cfb14fd4850ebae96b1cd5e85e6c6476dee94b872426a78c91c6d47`.
+Experimental tvOS IPA SHA-256:
+`b508d45fc4426190e7c25c6f57c31ec838f71f02a666feb07b06ca379a976f66`.


### PR DESCRIPTION
Records the published v0.4.4 source commit, deterministic package hashes, anonymous hosted-download comparison, and remaining physical/production-online acceptance boundaries.