### PR TITLE
Make Retro Rewind first-class on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # KartPad
 
+KartPad is an Apple-platform fork and productization of
+[WiiCompiled](https://github.com/patchzyy/Wiicompiled), the original static-
+recompilation project for Mario Kart Wii. KartPad adds a first-class dual-game
+Original Mario Kart Wii / Retro Rewind runtime, native Apple controls, data
+management, packaging, and release workflows.
+
 <p align="center">
   <strong>Mario Kart Wii and Retro Rewind, native for iOS, iPadOS, macOS, and tvOS.</strong><br>
   Native static recompilation through Metal, with touch controls, motion steering, controllers, and optional Retro Rewind content. tvOS is currently an experimental preview.
@@ -19,10 +25,13 @@
 
 > [!IMPORTANT]
 > **The latest release includes KartPad's dual-mode Mario Kart Wii and Retro
-> Rewind build for iPhone and iPad.** It must be re-signed before installation
+> Rewind builds for Apple Silicon Mac, iPhone, and iPad.** The IPA must be
+> re-signed before installation
 > and requires your own legally obtained supported game image. Retro Rewind is
 > optional and installs through KartPad from the official version-locked pack.
-> KartPad 0.4.6 adds direct existing-license management for online names and
+> KartPad 0.4.7 makes the Mac build dual-mode, moves Mac actions into the
+> standard menu bar, and documents keyboard, controller, and data setup. It
+> retains direct existing-license management for online names and
 > duplicate cleanup, restores the persistent three-dot button after iPadOS
 > screenshots, retains Retro Rewind 6.12.7, and keeps the automatic upstream update issue
 > plus one-command maintainer repin flow. It retains the universal
@@ -39,11 +48,11 @@
 | Question | Answer |
 |---|---|
 | Is this Dolphin or streaming? | No. WiiCompiled translates the game's PowerPC code ahead of time, then KartPad compiles it for ARM64 and presents it through Metal. |
-| Is an IPA included in the GitHub release? | **Yes.** `v0.4.6` includes an audited unsigned ARM64 IPA for iPhone/iPad. The experimental Apple TV hardware-bring-up IPA remains available from `v0.4.4`. Both require local re-signing and user-supplied supported game data. |
+| Are release downloads included? | **Yes.** `v0.4.7` includes an ad-hoc-signed Apple Silicon Mac ZIP and an audited unsigned ARM64 IPA for iPhone/iPad. The experimental Apple TV hardware-bring-up IPA remains available from `v0.4.4`. They require user-supplied supported game data; the IPA also requires local re-signing. |
 | Can the source create an IPA? | Yes. The Personal IPA Builder can also translate a supported user-owned game executable and create a separate private unsigned IPA on an Apple Silicon Mac. |
 | Does it include Mario Kart Wii? | No. You must provide your own legally obtained supported PAL `RMCP01` revision 0 WBFS/ISO. |
 | Does it support Retro Rewind? | **Yes.** Choose Original Mario Kart Wii or Retro Rewind when KartPad opens. KartPad can download, verify, and install the official Retro Rewind 6.12.7 pack. The 6.12.7 graph and package are current; physical acceptance remains separate. |
-| Does online play work? | The online-capable build passes login, matchmaking, a two-player race, results, ratings, and lobby return against a compatible isolated WFC server. Retro WFC is active again as of 6 September 2026. Production compatibility of the exact 0.4.6 KartPad artifact still needs end-to-end and physical-device acceptance. |
+| Does online play work? | The online-capable build passes login, matchmaking, a two-player race, results, ratings, and lobby return against a compatible isolated WFC server. Retro WFC is active again as of 6 September 2026. Production compatibility of the exact 0.4.7 KartPad artifacts still needs end-to-end and physical-device acceptance. |
 | Do touch, tilt, and controllers work? | Touch, motion steering, and ordinary GameController-compatible pads are implemented, with general physical acceptance on iPhone and iPad. Direct Wii Remote/Nunchuk pairing is a separate experimental, macOS-only path that still needs external hardware testing. |
 | Can I rename or delete a license? | **Yes on iPhone and iPad.** Open **Game Data & Saves → Player Identity… → Manage Existing Licenses…**, choose the exact game profile and slot, then rename it without losing its friend code/progress or delete only that slot after a second warning. Restart KartPad to apply the backed-up change. |
 | Can I choose a Mii appearance? | **Appearance import remains experimental.** Open **Game Data & Saves → Player Identity… → Import Mii Appearance…** and choose a standard 74-byte `.mii` file. **Remove Mii Appearance…** never means delete a game license and refuses to remove a Mii that is still linked to one. |
@@ -78,7 +87,7 @@ Retro WFC is Retro Rewind's online service. KartPad's online-capable graph
 passes login, matchmaking, a complete two-player race, results, ratings, and
 lobby return against a compatible isolated WFC service. Retro WFC's public
 health and room feeds are active again as of 6 September 2026. That service
-recovery does not by itself prove the exact 0.4.6 KartPad artifact's production
+recovery does not by itself prove the exact 0.4.7 KartPad artifacts' production
 login, matchmaking, complete-race, results, reconnect, or physical-device gates.
 
 KartPad packages a native Apple ARM64 app around a
@@ -99,7 +108,7 @@ retail game data.
 
 | Area | Current result |
 |---|---|
-| macOS runtime | Native arm64 title, menus, races, saves, ghosts, Battle, and split-screen gameplay through Metal |
+| macOS runtime | Native arm64 dual-game Original / Retro Rewind app with standard Game, Data, Controls, and Help menus; races, saves, ghosts, Battle, and split-screen gameplay render through Metal |
 | Track coverage | All 32 retail tracks have exact native completion evidence |
 | Correctness | Darwin memory, scheduler, ABI, integer, scalar-FP, and paired-single gates pass against their defined oracles |
 | Input | Keyboard, touch, motion steering, and four independent Classic-controller slots; two-player full-race evidence passes. Direct macOS Wii Remote/Nunchuk pairing and its preset are experimental and await reporter hardware acceptance |
@@ -108,8 +117,8 @@ retail game data.
 | Packaging | The K-circuit iPhone/iPad icon and branded package pass structural audit; installed-storage, configured gameplay, save-preservation, and normal-close evidence applies to the previously accepted app candidate, while the native first-run/settings/data-management shell remains open |
 | iPhone/iPad | The full 29,065-function ARM64 retail app has been packaged as an unsigned IPA; locally signed builds have been installed and physically accepted on both iPhone and iPad, reaching live races, importing a supported private WBFS, and preserving saves |
 | Game content | Version-locked dual-mode Original Mario Kart Wii / Retro Rewind 6.12.7 flow without bundling either game's private data; exact 6.12.7 physical acceptance remains open while the preceding physical iPad install, launch, and initial single-player gameplay result remains accepted only for its tested version |
-| Online multiplayer | Local Mac-to-iPad-Simulator login, matchmaking, room, race, native results, ratings, and lobby return pass; public Retro WFC service recovery is verified, while exact 0.4.6 production and physical-device acceptance remain open |
-| Distribution | `v0.4.6` provides source plus an unsigned iPhone/iPad community IPA containing translated game logic; the experimental tvOS IPA remains at `v0.4.4`. They contain no disc image, extracted game assets, Retro Rewind pack, saves, signing identity, or provisioning profile |
+| Online multiplayer | Local Mac-to-iPad-Simulator login, matchmaking, room, race, native results, ratings, and lobby return pass; public Retro WFC service recovery is verified, while exact 0.4.7 production and physical-device acceptance remain open |
+| Distribution | `v0.4.7` provides source, an Apple Silicon Mac ZIP, and an unsigned iPhone/iPad community IPA containing translated game logic; the experimental tvOS IPA remains at `v0.4.4`. They contain no disc image, extracted game assets, Retro Rewind pack, saves, signing identity, or provisioning profile |
 
 The evidence ledger, exact open rows, and known risks live in
 [`docs/STATUS.md`](docs/STATUS.md). The 67-row release matrix is in
@@ -168,7 +177,7 @@ distributed.
 
 ## Player identity, experimental Mii appearances, and Wii Remote controls
 
-License and player-name editing is supported on iPhone and iPad in 0.4.6.
+License and player-name editing is supported on iPhone and iPad in 0.4.7.
 Imported Mii appearances and direct Wii Remote controls remain opt-in features for community
 testing until users with real exported Miis and original Wii hardware complete
 the remaining acceptance checks.
@@ -229,10 +238,19 @@ provide the required direct Wii Remote HID pairing path.
 
 ## Install or build
 
+### Download the Apple Silicon Mac app
+
+Download `KartPad-v0.4.7-macos-arm64.zip` and `SHA256SUMS` from the
+[latest release](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.7).
+The app is ad-hoc signed, requires macOS 14 or newer on Apple Silicon, and does
+not include Mario Kart Wii or Retro Rewind data. Follow
+[`docs/INSTALL_MACOS.md`](docs/INSTALL_MACOS.md) for checksum, Gatekeeper, game
+data, game switching, keyboard, controller, and mouse guidance.
+
 ### Download the unsigned iPhone/iPad IPA
 
-Download `KartPad-v0.4.6-ios-unsigned.ipa` and `SHA256SUMS` from the
-[latest release](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.6).
+Download `KartPad-v0.4.7-ios-unsigned.ipa` and `SHA256SUMS` from the
+[latest release](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.7).
 Verify the checksum, re-sign the IPA with AltStore Classic plus AltServer or
 another compatible personal-signing workflow, and select your own supported
 PAL `RMCP01` revision 0 image on first launch. See
@@ -307,17 +325,18 @@ Build from the pinned supported image in one fail-closed local workflow:
 ./scripts/self-build-macos.sh /path/to/your/Mario-Kart-Wii.wbfs
 ```
 
-The workflow verifies the complete supported image hash, extracts it read-only
-with pinned `nodtool`, validates `RMCP01` revision 0 plus the DOL/REL hashes,
-translates the full private title graph with bounded parallelism, builds the
-patched Apple runtime, and audits the signed local app. All extracted and
-translated outputs stay under ignored `private/`; the app stays under ignored
-`build/`. Existing valid extraction/translation work can be resumed.
+The workflow bootstraps and verifies the pinned public sources plus the exact
+Retro Rewind 6.12.7 pack, verifies the complete supported image hash, extracts
+it read-only with pinned `nodtool`, validates `RMCP01` revision 0 plus the
+DOL/REL hashes, translates the dual private title graph with bounded
+parallelism, builds the patched Apple runtime, and audits the ad-hoc-signed
+local app. All extracted and translated outputs stay under ignored `private/`;
+the app stays under ignored `build/`. Existing valid work can be resumed.
 
 The initial translation and native build are substantial. The workflow reuses
-validated extraction and translation outputs after an interruption. It does
-not yet clone every pinned reference automatically; the source references
-checked by `verify-sources.sh` must already be present and clean.
+validated extraction and translation outputs after an interruption. Bootstrap
+fetches missing pinned dependencies and fails closed if a source checkout,
+Retro Rewind file, or Retro-WFC payload has the wrong identity.
 
 Launch the audited local app:
 
@@ -392,10 +411,19 @@ extracted `RMCP01` folder containing `sys/` and `files/`. KartPad validates the
 identity before starting the runtime and preserves the previous valid setting
 if a replacement is rejected.
 
-The **KartPad** application menu provides **Choose Game Data…**, **Show Game
-Data**, **Show Cache**, **Save Diagnostics Report…**, **Controller Settings…**,
-**Controls…**, and the standard **Settings…** and **Quit** actions. Settings
-exposes the supported display, audio, and FPS-counter controls. Durable saves
+Use the normal Mac menu bar instead of a three-dot overlay:
+
+- **Game → Original Mario Kart Wii** or **Game → Retro Rewind** selects the
+  game for the next launch. Switching preserves the other profile's saves and
+  settings.
+- **Data** chooses or replaces the validated Mario Kart Wii and Retro Rewind
+  folders, manages Miis, and opens KartPad's data and cache locations.
+- **Controls** opens controller mapping, shows the complete keyboard reference,
+  and contains the experimental direct Wii Remote pairing controls.
+- **Help → Save Diagnostics Report…** creates a bounded report for an issue.
+
+The Mac defaults fresh configurations to 2× rendering; **KartPad → Settings…**
+can change resolution, display mode, audio, and the FPS counter. Durable saves
 and configuration live in `~/Library/Application Support/KartPad`;
 regenerable graphics data lives in `~/Library/Caches/KartPad`.
 
@@ -407,6 +435,9 @@ Left Shift to L/item, arrows to the D-pad/tricks, Space to Start/pause, and Tab
 to Select/minus. The native **Controls…** panel (`Command-/`) keeps the full
 mapping visible in the app. Native controller discovery, remapping, and four
 stable local slots are implemented separately from the keyboard fallback.
+The mouse or trackpad operates native menus and settings and the cursor remains
+visible; gameplay itself uses the keyboard or a mapped controller because
+Mario Kart Wii has no mouse-driving input.
 
 The iPhone/iPad app compiles a byte-identical pinned snapshot of SunPad's GPLv3
 touch-control component and persistent **•••** menu directly. It preserves the
@@ -437,7 +468,7 @@ available without a separate controller:
   held touch input, and hides touch controls by default. Disconnecting it
   restores touch; additional controllers keep stable Player 2–4 slots.
 - **Menu:** the persistent **•••** opens display, controls, game data,
-  diagnostics, multiplayer access, and motion steering. On iPhone/iPad 0.4.6,
+  diagnostics, multiplayer access, and motion steering. On iPhone/iPad 0.4.7,
   taking a screenshot reasserts the button immediately and again on the next
   main-loop pass if iPadOS temporarily changes the menu presentation state.
 - **Player identity:** **Game Data & Saves → Player Identity…** sets the
@@ -505,7 +536,7 @@ binary is part of this repository.
 
 ## Diagnostics and privacy
 
-On Mac, choose **KartPad → Save Diagnostics Report…** after a failure or slow
+On Mac, choose **Help → Save Diagnostics Report…** after a failure or slow
 session. The schema-3 report contains bounded build/runtime identifiers,
 selected safe settings, storage health, clean-versus-unclean shutdown state,
 and capped current/previous log tails. User-directory prefixes and usernames
@@ -537,8 +568,9 @@ Useful starting points:
 
 ### Can I download an IPA or playable app?
 
-Yes. `v0.4.6` provides an unsigned iPhone/iPad IPA that must be re-signed before
-installation. The experimental Apple TV IPA remains available from `v0.4.4`.
+Yes. `v0.4.7` provides an Apple Silicon Mac ZIP and an unsigned iPhone/iPad IPA
+that must be re-signed before installation. The experimental Apple TV IPA
+remains available from `v0.4.4`.
 They contain
 KartPad's compiled ARM64 translation but no disc image or extracted game assets,
 so you must supply your own legally obtained supported game data. The Personal
@@ -556,7 +588,7 @@ Public Retro WFC compatibility, Wiimmfi, physical-device online play, and
 external-client interoperability remain separate acceptance gates. As of 6
 September 2026, Retro WFC's health endpoint reports its external API healthy
 and the public room feed reports active rooms. The earlier maintenance outage
-is over, so the exact 0.4.6 build can now be evaluated against production; the
+is over, so the exact 0.4.7 builds can now be evaluated against production; the
 service status alone is not that gameplay proof.
 
 - [Retro Rewind service notice](https://mkwiiki.org/wiki/Retro_Rewind)
@@ -564,7 +596,7 @@ service status alone is not that gameplay proof.
 
 ### Does KartPad support Retro Rewind?
 
-Yes. The 0.4.6 iPhone/iPad release opens with an Original / Retro Rewind chooser and
+Yes. The 0.4.7 Mac, iPhone, and iPad release supports Original / Retro Rewind and
 installs a separately downloaded,
 hash-verified Retro Rewind 6.12.7 pack. KartPad does not bundle Mario Kart Wii
 or Retro Rewind content. Physical iPad build 7 completes the pack download,

--- a/apple/macos/KartPadMacShell.mm
+++ b/apple/macos/KartPadMacShell.mm
@@ -13,8 +13,14 @@
 #include <cstdlib>
 
 #include "runtime_config.h"
+#if defined(KARTPAD_RUNTIME_PRODUCT_DUAL)
+#include "kartpad_retro_rewind_release.h"
+#endif
 
 static constexpr NSInteger kKartPadMenuTag = 0x4b505344;
+static NSString *const kKartPadRuntimeProfileDefaultsKey = @"KartPadRuntimeProfile";
+static NSString *const kKartPadBaseProfile = @"base";
+static NSString *const kKartPadRetroProfile = @"retro_rewind";
 
 static NSURL *DirectoryURL(const std::filesystem::path &path) {
   const std::string value = path.lexically_normal().string();
@@ -31,6 +37,12 @@ static NSURL *CacheURL() {
 }
 
 static NSString *YesNo(BOOL value) { return value ? @"yes" : @"no"; }
+
+static NSString *ActiveRuntimeProfileLabel() {
+  const char *profile = std::getenv("KARTPAD_RUNTIME_PROFILE");
+  return profile != nullptr && strcmp(profile, "retro_rewind") == 0
+      ? @"RMCP01-r0-retro-rewind" : @"RMCP01-r0-base";
+}
 
 static NSURL *SessionLogsURL() {
   return [ApplicationSupportURL() URLByAppendingPathComponent:@"Logs"
@@ -103,13 +115,13 @@ static void BeginSession() {
       @"KartPad bounded session log\n"
        "schema=1\n"
        "started=%@\n"
-       "productProfile=RMCP01-r0-base\n"
+       "productProfile=%@\n"
        "rendererBackend=Metal\n"
        "guestMemoryStrategy=flat-mach-vm\n"
        "schedulerStrategy=cooperative-fibers\n"
        "previousSessionClean=%@\n"
        "currentSessionState=active\n",
-      SessionTimestamp(), previousClean];
+      SessionTimestamp(), ActiveRuntimeProfileLabel(), previousClean];
   [manifest writeToURL:CurrentSessionURL()
             atomically:YES
               encoding:NSUTF8StringEncoding
@@ -253,6 +265,83 @@ static BOOL WriteGameDataRoot(NSString *root) {
   return wrote;
 }
 
+#if defined(KARTPAD_RUNTIME_PRODUCT_DUAL)
+static NSString *ConfiguredRetroRewindRoot() {
+  const RuntimeUserConfig config = RuntimeConfigFile::LoadConfigFile();
+  if (!config.retroRewindRoot || config.retroRewindRoot->empty()) return nil;
+  std::filesystem::path root(*config.retroRewindRoot);
+  if (root.is_relative()) root = RuntimeConfigFile::ResolveConfigPath().parent_path() / root;
+  return [NSString stringWithUTF8String:root.lexically_normal().string().c_str()];
+}
+
+static NSString *ValidateRetroRewindRoot(NSString *root, NSError **error) {
+  if (root.length == 0) {
+    return [NSString stringWithFormat:
+        @"Choose the RetroRewind6 folder from Retro Rewind %@.", @KARTPAD_RR_VERSION];
+  }
+  NSDictionary<NSString *, NSDictionary<NSString *, id> *> *required = @{
+    @KARTPAD_RR_CODE_PUL_PATH: @{
+      @"bytes": @(KARTPAD_RR_CODE_PUL_BYTES), @"sha256": @KARTPAD_RR_CODE_PUL_SHA256},
+    @KARTPAD_RR_XML_PATH: @{
+      @"bytes": @(KARTPAD_RR_XML_BYTES), @"sha256": @KARTPAD_RR_XML_SHA256},
+  };
+  NSFileManager *files = NSFileManager.defaultManager;
+  for (NSString *relative in required) {
+    NSString *path = [root stringByAppendingPathComponent:relative];
+    NSDictionary *attributes = [files attributesOfItemAtPath:path error:error];
+    if (attributes == nil) {
+      return [NSString stringWithFormat:@"The Retro Rewind folder is missing %@.", relative];
+    }
+    if ([attributes fileSize] != [required[relative][@"bytes"] unsignedLongLongValue]) {
+      return [NSString stringWithFormat:@"%@ is not from Retro Rewind %@.", relative,
+                                        @KARTPAD_RR_VERSION];
+    }
+    NSString *hash = SHA256ForFile(path, error);
+    if (hash == nil || ![hash isEqualToString:required[relative][@"sha256"]]) {
+      return [NSString stringWithFormat:@"%@ failed the Retro Rewind %@ integrity check.",
+                                        relative, @KARTPAD_RR_VERSION];
+    }
+  }
+  return nil;
+}
+
+static BOOL WriteRetroRewindRoot(NSString *root) {
+  if (root.length == 0) return NO;
+  const bool wrote = RuntimeConfigFile::WriteSetting(
+      "paths", "retro_rewind_root",
+      RuntimeConfigFile::FormatString(root.fileSystemRepresentation));
+  if (wrote) RuntimeConfigFile::Reload();
+  return wrote;
+}
+
+static NSString *ChooseAndValidateRetroRewindData() {
+  NSOpenPanel *panel = NSOpenPanel.openPanel;
+  panel.title = @"Choose Retro Rewind";
+  panel.message = [NSString stringWithFormat:
+      @"Choose the RetroRewind6 folder from the exact supported %@ pack.",
+      @KARTPAD_RR_VERSION];
+  panel.prompt = @"Choose Retro Rewind";
+  panel.canChooseFiles = NO;
+  panel.canChooseDirectories = YES;
+  panel.allowsMultipleSelection = NO;
+  if ([panel runModal] != NSModalResponseOK || panel.URL == nil) return nil;
+
+  NSString *root = panel.URL.path;
+  if ([[root lastPathComponent] isEqualToString:@"riivolution"]) {
+    root = [root stringByAppendingPathComponent:@KARTPAD_RR_ROOT];
+  }
+  NSError *error = nil;
+  NSString *validation = ValidateRetroRewindRoot(root, &error);
+  if (validation == nil && error == nil) return root;
+  NSAlert *alert = [NSAlert new];
+  alert.messageText = @"Unsupported Retro Rewind Data";
+  alert.informativeText = error.localizedDescription.length > 0
+      ? error.localizedDescription : validation;
+  [alert runModal];
+  return @"";
+}
+#endif
+
 static NSString *ChooseAndValidateGameData() {
   NSOpenPanel *panel = NSOpenPanel.openPanel;
   panel.title = @"Choose Extracted Mario Kart Wii Data";
@@ -343,7 +432,7 @@ static NSString *DiagnosticsReport() {
        "unsignedRuntimeSHA256=%@\n"
        "os=%@\n"
        "architecture=arm64\n"
-       "productProfile=RMCP01-r0-base\n"
+       "productProfile=%@\n"
        "rendererBackend=Metal\n"
        "guestMemoryStrategy=flat-mach-vm\n"
        "schedulerStrategy=cooperative-fibers\n"
@@ -368,7 +457,8 @@ static NSString *DiagnosticsReport() {
        "reviewWarning=Review this report before sharing. Arbitrary runtime text may still require review.\n"
        "privacy=personal paths are replaced; game data, translated code, save contents, credentials, device identifiers, signing material, and unbounded logs are omitted\n",
       generated, version, build, sourceCommit, runtimeHash,
-      NSProcessInfo.processInfo.operatingSystemVersionString, displayMode, resolution,
+      NSProcessInfo.processInfo.operatingSystemVersionString,
+      ActiveRuntimeProfileLabel(), displayMode, resolution,
       interpolation, (long)volume, YesNo(runtime.audioMuted.value_or(false)),
       YesNo(runtime.networkEnabled.value_or(true)), (unsigned long)mappingCount,
       YesNo(gameDataRoot.length > 0), YesNo(gameDataValid),
@@ -433,6 +523,52 @@ static NSString *DiagnosticsReport() {
       @"KartPad validated the RMCP01 data. Quit and reopen KartPad to use it.";
   [alert runModal];
 }
+
+#if defined(KARTPAD_RUNTIME_PRODUCT_DUAL)
+- (void)chooseRetroRewindData:(id)sender {
+  (void)sender;
+  NSString *root = ChooseAndValidateRetroRewindData();
+  if (root == nil || root.length == 0) return;
+  if (!WriteRetroRewindRoot(root)) {
+    [self showSimpleAlert:@"Retro Rewind Data Could Not Be Saved"
+                  message:@"KartPad could not update Config.toml."];
+    return;
+  }
+  [self showSimpleAlert:@"Retro Rewind Ready"
+                message:@"KartPad validated the exact supported pack. Choose Retro Rewind from the Game menu, then reopen KartPad."];
+}
+
+- (void)selectRuntimeProfile:(NSString *)profile title:(NSString *)title {
+  [NSUserDefaults.standardUserDefaults setObject:profile
+                                           forKey:kKartPadRuntimeProfileDefaultsKey];
+  [self showSimpleAlert:[NSString stringWithFormat:@"%@ Selected", title]
+                message:@"Quit and reopen KartPad to switch games. Your saves and settings are preserved."];
+}
+
+- (void)useOriginalGame:(id)sender {
+  (void)sender;
+  [self selectRuntimeProfile:kKartPadBaseProfile title:@"Original Mario Kart Wii"];
+}
+
+- (void)useRetroRewind:(id)sender {
+  (void)sender;
+  NSError *error = nil;
+  NSString *validation = ValidateRetroRewindRoot(ConfiguredRetroRewindRoot(), &error);
+  if (validation != nil || error != nil) {
+    NSAlert *required = [NSAlert new];
+    required.messageText = @"Retro Rewind Data Required";
+    required.informativeText = [NSString stringWithFormat:
+        @"KartPad needs the exact Retro Rewind %@ RetroRewind6 folder before it can switch games.",
+        @KARTPAD_RR_VERSION];
+    [required addButtonWithTitle:@"Choose Folder…"];
+    [required addButtonWithTitle:@"Cancel"];
+    if ([required runModal] != NSAlertFirstButtonReturn) return;
+    NSString *root = ChooseAndValidateRetroRewindData();
+    if (root == nil || root.length == 0 || !WriteRetroRewindRoot(root)) return;
+  }
+  [self selectRuntimeProfile:kKartPadRetroProfile title:@"Retro Rewind"];
+}
+#endif
 
 - (void)showMiiManager:(id)sender {
   (void)sender;
@@ -921,7 +1057,7 @@ static void InstallMenu() {
     appMenu = [[NSMenu alloc] initWithTitle:@"KartPad"];
     appItem.submenu = appMenu;
   }
-  if ([appMenu itemWithTag:kKartPadMenuTag] != nil) return;
+  if ([mainMenu itemWithTag:kKartPadMenuTag] != nil) return;
 
   bool hasStandardApplicationMenu = false;
   for (NSMenuItem *item in appMenu.itemArray) {
@@ -997,44 +1133,79 @@ static void InstallMenu() {
     }
   }
 
-  NSInteger insertIndex = appMenu.numberOfItems;
-  for (NSInteger index = 0; index < appMenu.numberOfItems; ++index) {
-    if ([appMenu itemAtIndex:index].action == @selector(hide:)) {
-      insertIndex = index;
+  NSInteger productMenuIndex = mainMenu.numberOfItems;
+  for (NSInteger index = 0; index < mainMenu.numberOfItems; ++index) {
+    if ([[mainMenu itemAtIndex:index].title isEqualToString:@"Window"]) {
+      productMenuIndex = index;
       break;
     }
   }
-  [appMenu insertItem:NSMenuItem.separatorItem atIndex:insertIndex++];
-  NSMenuItem *data = [[NSMenuItem alloc]
-      initWithTitle:@"Show KartPad Data"
-             action:@selector(showApplicationSupport:)
+  NSMenuItem *gameMenuItem = [[NSMenuItem alloc]
+      initWithTitle:@"Game" action:nil keyEquivalent:@""];
+  gameMenuItem.tag = kKartPadMenuTag;
+  NSMenu *gameMenu = [[NSMenu alloc] initWithTitle:@"Game"];
+#if defined(KARTPAD_RUNTIME_PRODUCT_DUAL)
+  NSString *activeProfile = NSUserDefaults.standardUserDefaults
+      ? [NSUserDefaults.standardUserDefaults stringForKey:kKartPadRuntimeProfileDefaultsKey]
+      : nil;
+  if (activeProfile.length == 0) activeProfile = kKartPadBaseProfile;
+  NSMenuItem *original = [[NSMenuItem alloc]
+      initWithTitle:@"Original Mario Kart Wii"
+             action:@selector(useOriginalGame:) keyEquivalent:@"1"];
+  original.target = Controller();
+  original.state = [activeProfile isEqualToString:kKartPadBaseProfile]
+      ? NSControlStateValueOn : NSControlStateValueOff;
+  [gameMenu addItem:original];
+  NSMenuItem *retro = [[NSMenuItem alloc]
+      initWithTitle:@"Retro Rewind"
+             action:@selector(useRetroRewind:) keyEquivalent:@"2"];
+  retro.target = Controller();
+  retro.state = [activeProfile isEqualToString:kKartPadRetroProfile]
+      ? NSControlStateValueOn : NSControlStateValueOff;
+  [gameMenu addItem:retro];
+  [gameMenu addItem:NSMenuItem.separatorItem];
+#endif
+  NSMenuItem *settings = [[NSMenuItem alloc]
+      initWithTitle:@"Game Settings…" action:@selector(showSettings:)
       keyEquivalent:@""];
-  data.target = Controller();
-  data.tag = kKartPadMenuTag;
-  [appMenu insertItem:data atIndex:insertIndex++];
+  settings.target = Controller();
+  [gameMenu addItem:settings];
+  gameMenuItem.submenu = gameMenu;
+  [mainMenu insertItem:gameMenuItem atIndex:productMenuIndex++];
 
-  NSMenuItem *cache = [[NSMenuItem alloc]
-      initWithTitle:@"Show KartPad Cache"
-             action:@selector(showCache:)
-      keyEquivalent:@""];
-  cache.target = Controller();
-  [appMenu insertItem:cache atIndex:insertIndex++];
-
-  NSMenuItem *gameDataAndSaves = [[NSMenuItem alloc]
-      initWithTitle:@"Game Data & Saves" action:nil keyEquivalent:@""];
-  NSMenu *gameDataMenu = [[NSMenu alloc] initWithTitle:@"Game Data & Saves"];
+  NSMenuItem *dataMenuItem = [[NSMenuItem alloc]
+      initWithTitle:@"Data" action:nil keyEquivalent:@""];
+  NSMenu *dataMenu = [[NSMenu alloc] initWithTitle:@"Data"];
   NSMenuItem *gameData = [[NSMenuItem alloc]
-      initWithTitle:@"Choose Game Data…" action:@selector(chooseGameData:)
+      initWithTitle:@"Choose Mario Kart Wii Data…" action:@selector(chooseGameData:)
       keyEquivalent:@""];
   gameData.target = Controller();
-  [gameDataMenu addItem:gameData];
+  [dataMenu addItem:gameData];
+#if defined(KARTPAD_RUNTIME_PRODUCT_DUAL)
+  NSMenuItem *retroData = [[NSMenuItem alloc]
+      initWithTitle:@"Choose Retro Rewind Data…"
+             action:@selector(chooseRetroRewindData:) keyEquivalent:@""];
+  retroData.target = Controller();
+  [dataMenu addItem:retroData];
+#endif
   NSMenuItem *miis = [[NSMenuItem alloc]
       initWithTitle:@"Manage Miis…" action:@selector(showMiiManager:)
       keyEquivalent:@""];
   miis.target = Controller();
-  [gameDataMenu addItem:miis];
-  gameDataAndSaves.submenu = gameDataMenu;
-  [appMenu insertItem:gameDataAndSaves atIndex:insertIndex++];
+  [dataMenu addItem:miis];
+  [dataMenu addItem:NSMenuItem.separatorItem];
+  NSMenuItem *data = [[NSMenuItem alloc]
+      initWithTitle:@"Show KartPad Data"
+             action:@selector(showApplicationSupport:) keyEquivalent:@""];
+  data.target = Controller();
+  [dataMenu addItem:data];
+  NSMenuItem *cache = [[NSMenuItem alloc]
+      initWithTitle:@"Show KartPad Cache"
+             action:@selector(showCache:) keyEquivalent:@""];
+  cache.target = Controller();
+  [dataMenu addItem:cache];
+  dataMenuItem.submenu = dataMenu;
+  [mainMenu insertItem:dataMenuItem atIndex:productMenuIndex++];
 
   NSMenuItem *controlsMenuItem = [[NSMenuItem alloc]
       initWithTitle:@"Controls" action:nil keyEquivalent:@""];
@@ -1065,8 +1236,11 @@ static void InstallMenu() {
   pairWiimote.target = Controller();
   [controlsMenu addItem:pairWiimote];
   controlsMenuItem.submenu = controlsMenu;
-  [appMenu insertItem:controlsMenuItem atIndex:insertIndex++];
+  [mainMenu insertItem:controlsMenuItem atIndex:productMenuIndex];
 
+  NSMenuItem *helpMenuItem = [[NSMenuItem alloc]
+      initWithTitle:@"Help" action:nil keyEquivalent:@""];
+  NSMenu *helpMenu = [[NSMenu alloc] initWithTitle:@"Help"];
   NSString *diagnosticsTitle =
       [@"Save Diagnostics Report" stringByAppendingString:@"…"];
   NSMenuItem *diagnostics = [[NSMenuItem alloc]
@@ -1074,7 +1248,9 @@ static void InstallMenu() {
              action:@selector(saveDiagnostics:)
       keyEquivalent:@""];
   diagnostics.target = Controller();
-  [appMenu insertItem:diagnostics atIndex:insertIndex];
+  [helpMenu addItem:diagnostics];
+  helpMenuItem.submenu = helpMenu;
+  [mainMenu addItem:helpMenuItem];
 }
 
 void KartPadMacShellInstall(void) {
@@ -1086,14 +1262,39 @@ void KartPadMacShellInstall(void) {
 
 bool KartPadMacShellPrepareGameData(void) {
   @autoreleasepool {
+    const std::filesystem::path configPath = RuntimeConfigFile::ResolveConfigPath();
+    const bool hadConfig = std::filesystem::exists(configPath);
     NSError *miiError = nil;
     if (!KartPadApplyPendingMiiDatabase(&miiError)) {
       NSLog(@"[KartPad] pending Mii changes were not applied: %@",
             miiError.localizedDescription);
     }
     KartPadApplyExperimentalWiimotePreference();
-    BeginSession();
     RuntimeConfigFile::EnsureConfigFile();
+    const RuntimeUserConfig initialConfig = RuntimeConfigFile::LoadConfigFile();
+    const bool unconfigured = !initialConfig.dvdRoot && !initialConfig.retroRewindRoot;
+    if (!hadConfig || unconfigured) {
+      RuntimeConfigFile::WriteSetting("video", "resolution_multiplier", "2.0");
+      RuntimeConfigFile::Reload();
+    }
+#if defined(KARTPAD_RUNTIME_PRODUCT_DUAL)
+    NSString *selectedProfile = [NSUserDefaults.standardUserDefaults
+        stringForKey:kKartPadRuntimeProfileDefaultsKey];
+    if (![selectedProfile isEqualToString:kKartPadRetroProfile]) {
+      selectedProfile = kKartPadBaseProfile;
+    }
+    if ([selectedProfile isEqualToString:kKartPadRetroProfile]) {
+      NSError *retroError = nil;
+      if (ValidateRetroRewindRoot(ConfiguredRetroRewindRoot(), &retroError) != nil ||
+          retroError != nil) {
+        selectedProfile = kKartPadBaseProfile;
+        [NSUserDefaults.standardUserDefaults setObject:selectedProfile
+                                                 forKey:kKartPadRuntimeProfileDefaultsKey];
+      }
+    }
+    setenv("KARTPAD_RUNTIME_PROFILE", selectedProfile.UTF8String, 1);
+#endif
+    BeginSession();
 
     // The command-line self-build has already extracted and validated the
     // supplied WBFS. Let it hand that private tree to the app without forcing
@@ -1103,8 +1304,19 @@ bool KartPadMacShellPrepareGameData(void) {
       NSString *root = [NSString stringWithUTF8String:prepared];
       NSError *preparedError = nil;
       NSString *validation = ValidateExtractedRoot(root, &preparedError);
-      const BOOL configured = validation == nil && preparedError == nil &&
-                              WriteGameDataRoot(root);
+      BOOL configured = validation == nil && preparedError == nil &&
+                        WriteGameDataRoot(root);
+#if defined(KARTPAD_RUNTIME_PRODUCT_DUAL)
+      const char *preparedRetro =
+          std::getenv("KARTPAD_SELF_BUILD_RETRO_REWIND_ROOT");
+      if (configured && preparedRetro != nullptr && *preparedRetro != '\0') {
+        NSString *retroRoot = [NSString stringWithUTF8String:preparedRetro];
+        NSError *retroError = nil;
+        NSString *retroValidation = ValidateRetroRewindRoot(retroRoot, &retroError);
+        configured = retroValidation == nil && retroError == nil &&
+                     WriteRetroRewindRoot(retroRoot);
+      }
+#endif
       if (configured) {
         std::cout << "[kartpad-macos] Configured validated self-build game data."
                   << std::endl;

--- a/docs/INSTALL_IPA.md
+++ b/docs/INSTALL_IPA.md
@@ -1,12 +1,12 @@
 # Install the KartPad unsigned IPA
 
-KartPad `v0.4.6` is an unsigned ARM64 IPA for iPhone and iPad. It is a free
+KartPad `v0.4.7` is an unsigned ARM64 IPA for iPhone and iPad. It is a free
 community release, not an App Store or TestFlight build, and it will not
 install until it is re-signed with your own Apple identity or compatible
 personal sideloading tool.
 
-1. Download `KartPad-v0.4.6-ios-unsigned.ipa` and `SHA256SUMS` from the
-   [0.4.6 release](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.6).
+1. Download `KartPad-v0.4.7-ios-unsigned.ipa` and `SHA256SUMS` from the
+   [0.4.7 release](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.7).
 2. Verify the IPA with `shasum -a 256 -c SHA256SUMS` on a Mac.
 3. Re-sign and install it with AltStore Classic plus AltServer or another
    compatible IPA-signing workflow. AltStore PAL cannot import arbitrary

--- a/docs/INSTALL_MACOS.md
+++ b/docs/INSTALL_MACOS.md
@@ -1,0 +1,59 @@
+# Install KartPad on Apple Silicon Mac
+
+KartPad 0.4.7 is an ad-hoc-signed native arm64 app for Apple Silicon Macs
+running macOS 14 or newer. It contains the Original Mario Kart Wii and Retro
+Rewind executable profiles but no disc image, extracted game assets, Retro
+Rewind pack, saves, account data, or Apple signing identity.
+
+1. Download `KartPad-v0.4.7-macos-arm64.zip` and `SHA256SUMS` from the
+   [0.4.7 release](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.7).
+2. Run `shasum -a 256 -c SHA256SUMS`, then extract the ZIP and move
+   `KartPad.app` to Applications.
+3. Open KartPad. If Gatekeeper blocks the ad-hoc-signed community app,
+   Control-click it, choose **Open**, review the warning, and choose **Open**
+   again. Do not disable Gatekeeper system-wide.
+4. Choose your own extracted PAL `RMCP01` revision-0 `DATA` folder when asked.
+   It must contain both `sys/` and `files/`; KartPad validates the disc identity
+   and executable hash before launching.
+5. To use Retro Rewind, choose **Data → Choose Retro Rewind Data…** and select
+   the `RetroRewind6` folder from the exact supported 6.12.7 full pack. Then
+   choose **Game → Retro Rewind**, quit, and reopen KartPad. Use **Game →
+   Original Mario Kart Wii** and reopen to switch back. Saves and settings are
+   kept separately from the selected game-data folders.
+
+## Menus and input
+
+- **Game** switches the game for the next launch and opens display/audio
+  settings.
+- **Data** changes validated data folders, manages Miis, and opens data/cache
+  locations.
+- **Controls → Controller Settings…** detects and maps ordinary SDL-compatible
+  controllers for up to four local players. **Control Reference…** shows every
+  keyboard binding.
+- Keyboard defaults are `WASD` steering, `U`/Return accelerate and confirm,
+  `M`/Delete brake/back, `E` drift, Left Shift item, arrows tricks, Space
+  pause, and Tab select.
+- The mouse or trackpad operates native menus and settings. The cursor remains
+  visible, but Mario Kart Wii has no mouse-driving control; use the keyboard or
+  a mapped controller during gameplay.
+- Direct Wii Remote/Nunchuk pairing is experimental and macOS-only.
+
+Configuration and saves live under `~/Library/Application Support/KartPad`.
+Regenerable graphics caches live under `~/Library/Caches/KartPad`. Replacing
+the app does not remove either folder, but back up important saves before
+manually deleting application data.
+
+## Build it yourself
+
+Install the prerequisites listed in the README, then run:
+
+```sh
+./scripts/self-build-macos.sh /path/to/your/Mario-Kart-Wii.wbfs
+open build/KartPad-self-built.app
+```
+
+The workflow fetches and verifies pinned public dependencies and the exact
+Retro Rewind inputs, translates both executable profiles from the supported
+user-owned image, builds the dual app, configures both private data roots, and
+audits the result. Generated inputs and the resulting personalized app remain
+ignored local files and must not be redistributed.

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -19,6 +19,22 @@ The exact 67-row matrix in `docs/PRD.md` remains the authority for full
 engineering completion. A community preview may ship with narrower, explicit
 limitations when its exact artifact passes every preview gate below.
 
+## 0.4.7 macOS first-class candidate
+
+- [ ] Build the one-command Mac workflow as dual Original / Retro Rewind
+- [ ] Validate the exact Retro Rewind folder before selecting that profile
+- [ ] Verify standard Game, Data, Controls, and Help menus in the built app
+- [ ] Verify original-game and Retro Rewind launch separately on macOS
+- [ ] Exercise keyboard gameplay input and the visible mouse/menu path
+- [ ] Verify controller mapping contracts; keep untested physical hardware
+      claims explicit
+- [ ] Build and audit exact-source macOS 0.4.7 build 21
+- [ ] Build and audit exact-source iOS 0.4.7 build 21
+- [ ] Package each artifact twice byte-identically and audit the exact files
+- [ ] Publish `v0.4.7`, both artifacts, and `SHA256SUMS`
+- [ ] Download hosted assets, byte-compare, and re-audit them
+- [ ] Respond to and close issue #79 with the exact commands and evidence
+
 ## 0.4.6 license-management hotfix candidate
 
 - [x] Enumerate active Original and Retro Rewind licenses by profile and slot

--- a/docs/releases/v0.4.7.md
+++ b/docs/releases/v0.4.7.md
@@ -1,0 +1,38 @@
+# KartPad v0.4.7
+
+KartPad 0.4.7 makes Retro Rewind a first-class part of the Apple Silicon Mac
+build while retaining the iPhone/iPad player-identity and screenshot fixes
+from 0.4.6.
+
+## macOS
+
+- App version 0.4.7 build 21.
+- The one-command Mac self-build now provisions the exact pinned Retro Rewind
+  6.12.7 pack and Retro-WFC payload, translates both profiles, and builds the
+  dual `KartPadDual` target instead of the original-game-only target.
+- Adds standard **Game**, **Data**, **Controls**, and **Help** menus. The Game
+  menu selects Original Mario Kart Wii or Retro Rewind for the next launch;
+  the Data menu validates both user-owned data roots.
+- Keeps the existing keyboard bridge, four SDL controller slots, remapping,
+  visible mouse cursor, and experimental macOS Wii Remote/Nunchuk path.
+- Fresh Mac configurations default to 2× rendering. Existing display, audio,
+  controller, data, and save settings are not overwritten.
+- Adds an audited, deterministic Apple Silicon Mac ZIP and a complete Mac
+  install/build/input guide.
+
+## iPhone and iPad
+
+- Retains the dual Original / Retro Rewind 6.12.7 chooser, existing-license
+  rename/delete controls, safe Mii handling, persistent three-dot menu recovery,
+  touch, motion, and GameController support from 0.4.6.
+- Ships a newly versioned unsigned arm64 IPA built from the same exact release
+  source. It must be re-signed before installation.
+
+## Distribution boundary
+
+The Mac ZIP and IPA include ahead-of-time translated executable code. They do
+not include a Mario Kart Wii disc image, extracted game assets, the Retro
+Rewind pack, saves, Mii databases, account data, signing identity, provisioning
+profile, or device identifier. Supply your own legally obtained supported PAL
+`RMCP01` revision-0 data. The community release does not resolve upstream or
+game-code rights.

--- a/patches/wiicompiled-dual-product-target.patch
+++ b/patches/wiicompiled-dual-product-target.patch
@@ -18,7 +18,7 @@ diff --git a/cmake/PublicProducts.cmake b/cmake/PublicProducts.cmake
 index 111d354..366d43e 100644
 --- a/cmake/PublicProducts.cmake
 +++ b/cmake/PublicProducts.cmake
-@@ -282,9 +282,80 @@ else()
+@@ -282,9 +282,82 @@ else()
      message(STATUS "RetroRewind target disabled (run translate-mod and emit-build-shards)")
  endif()
  
@@ -44,7 +44,9 @@ index 111d354..366d43e 100644
 +        target_sources(KartPadDual PRIVATE ${MKW_KARTPAD_MACOS_SOURCES})
 +        target_include_directories(KartPadDual PRIVATE
 +            "${MKW_KARTPAD_MACOS_DIR}" "${MKW_KARTPAD_REPO_ROOT}/apple/shared"
-+            "${MKW_KARTPAD_REPO_ROOT}/runtime/include")
++            "${MKW_KARTPAD_REPO_ROOT}/runtime/include"
++            "${CMAKE_CURRENT_LIST_DIR}/../third_party/kartpad-profile")
++        target_compile_definitions(KartPadDual PRIVATE KARTPAD_RUNTIME_PRODUCT_DUAL=1)
 +        target_link_libraries(KartPadDual PRIVATE
 +            "-framework AppKit" "-framework UniformTypeIdentifiers"
 +            "-framework IOBluetooth" "-framework IOKit")
@@ -81,10 +83,10 @@ index 111d354..366d43e 100644
 +            XCODE_ATTRIBUTE_ARCHS arm64
 +            XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME AppIcon
 +            XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++20"
-+            XCODE_ATTRIBUTE_CURRENT_PROJECT_VERSION 20
++            XCODE_ATTRIBUTE_CURRENT_PROJECT_VERSION 21
 +            XCODE_ATTRIBUTE_GENERATE_INFOPLIST_FILE NO
 +            XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET 16.0
-+            XCODE_ATTRIBUTE_MARKETING_VERSION 0.4.6
++            XCODE_ATTRIBUTE_MARKETING_VERSION 0.4.7
 +            XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER dev.kartpad.app
 +            XCODE_ATTRIBUTE_SUPPORTED_PLATFORMS "iphonesimulator iphoneos"
 +            XCODE_ATTRIBUTE_SUPPORTS_MACCATALYST NO

--- a/scripts/audit-macos-package.sh
+++ b/scripts/audit-macos-package.sh
@@ -21,6 +21,8 @@ icon_name="$(plutil -extract CFBundleIconFile raw "${plist}")"
 executable="${contents}/MacOS/${executable_name}"
 
 test "${bundle_identifier}" = "dev.kartpad.app"
+test "$(plutil -extract CFBundleShortVersionString raw "${plist}")" = "0.4.7"
+test "$(plutil -extract CFBundleVersion raw "${plist}")" = "21"
 test "$(plutil -extract NSBluetoothAlwaysUsageDescription raw "${plist}")" = \
   "KartPad uses Bluetooth to pair and connect an experimental Wii Remote and Nunchuk."
 test -x "${executable}"
@@ -91,6 +93,12 @@ executable_strings="$(strings "${executable}")"
 for shell_contract in \
   "KartPad Settings" \
   "KartPad Controls" \
+  "Original Mario Kart Wii" \
+  "Retro Rewind" \
+  "chooseRetroRewindData:" \
+  "RMCP01-r0-retro-rewind" \
+  "KartPadRuntimeProfile" \
+  "Quit and reopen KartPad to switch games. Your saves and settings are preserved." \
   "Manage Miis (Experimental)" \
   "Experimental Wii Remote + Nunchuk" \
   "Wii Remote + Nunchuk (Experimental)" \

--- a/scripts/audit-public-macos.py
+++ b/scripts/audit-public-macos.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import plistlib
+import subprocess
+import tempfile
+import zipfile
+from pathlib import Path, PurePosixPath
+
+
+RELEASE_TAG = "v0.4.7"
+APP_VERSION = "0.4.7"
+APP_BUILD = "21"
+FORBIDDEN_SUFFIXES = {".iso", ".wbfs", ".rvz", ".wia", ".gcz", ".gcm", ".ciso",
+                      ".sav", ".p12", ".p8", ".pem", ".key", ".cer"}
+REQUIRED_ENTRIES = {
+    "KartPad.app/Contents/Info.plist",
+    "KartPad.app/Contents/MacOS/KartPad",
+    "KartPadMacProvenance.json",
+    "INSTALL_MACOS.md",
+    "RELEASE_NOTES.md",
+    "RIGHTS_AND_LICENSES.md",
+    "ThirdPartyLicenses/Aurora-MIT.txt",
+    "ThirdPartyLicenses/WiiCompiled-GPL-3.0.txt",
+}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"ERROR: public macOS audit failed: {message}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Audit the exact public KartPad macOS ZIP.")
+    parser.add_argument("archive", type=Path)
+    parser.add_argument("--source-commit")
+    args = parser.parse_args()
+    repo = Path(__file__).resolve().parents[1]
+    archive_path = args.archive.resolve()
+    expected_commit = args.source_commit or subprocess.check_output(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True
+    ).strip()
+    with zipfile.ZipFile(archive_path) as archive:
+        if archive.testzip() is not None:
+            fail("ZIP integrity failure")
+        names = archive.namelist()
+        missing = REQUIRED_ENTRIES - set(names)
+        if missing:
+            fail(f"missing required entries: {', '.join(sorted(missing))}")
+        for name in names:
+            path = PurePosixPath(name)
+            if path.is_absolute() or ".." in path.parts or "__MACOSX" in path.parts:
+                fail(f"unsafe archive path: {name}")
+            if Path(name.lower()).suffix in FORBIDDEN_SUFFIXES:
+                fail(f"forbidden private or signing file: {name}")
+            if "UserData" in path.parts or path.name in {"portable.txt", "Config.toml"}:
+                fail(f"writable runtime state found: {name}")
+        provenance = json.loads(archive.read("KartPadMacProvenance.json"))
+        expected = {
+            "releaseTag": RELEASE_TAG, "sourceCommit": expected_commit,
+            "appVersion": APP_VERSION, "appBuild": APP_BUILD,
+            "containsTranslatedGameCode": True, "containsGameData": False,
+            "containsSigningMaterial": False, "signing": "ad-hoc",
+            "maintainerAuthorizedFreeCommunityRelease": True,
+            "upstreamRightsConfirmed": False,
+        }
+        for key, value in expected.items():
+            if provenance.get(key) != value:
+                fail(f"unexpected provenance {key}: {provenance.get(key)!r}")
+        with tempfile.TemporaryDirectory(prefix="kartpad-public-macos-audit.") as temp:
+            root = Path(temp)
+            archive.extractall(root)
+            for info in archive.infolist():
+                mode = (info.external_attr >> 16) & 0o777
+                extracted = root / info.filename
+                if mode and extracted.is_file():
+                    extracted.chmod(mode)
+            app = root / "KartPad.app"
+            subprocess.run([str(repo / "scripts/audit-macos-package.sh"), str(app)], check=True)
+            with (app / "Contents/Info.plist").open("rb") as handle:
+                plist = plistlib.load(handle)
+            if plist.get("CFBundleShortVersionString") != APP_VERSION or str(plist.get("CFBundleVersion")) != APP_BUILD:
+                fail("unexpected app version")
+            executable = app / "Contents/MacOS/KartPad"
+            if hashlib.sha256(executable.read_bytes()).hexdigest() != provenance["executableSHA256"]:
+                fail("executable hash does not match provenance")
+    digest = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+    print(f"Public macOS ZIP audit passed: {archive_path}")
+    print(f"Release: {RELEASE_TAG}; app: {APP_VERSION} ({APP_BUILD}); source: {expected_commit}")
+    print(f"SHA-256: {digest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit-public-unsigned-ipa.py
+++ b/scripts/audit-public-unsigned-ipa.py
@@ -11,9 +11,9 @@ import zipfile
 from pathlib import Path, PurePosixPath
 
 
-RELEASE_TAG = "v0.4.6"
-APP_VERSION = "0.4.6"
-APP_BUILD = "20"
+RELEASE_TAG = "v0.4.7"
+APP_VERSION = "0.4.7"
+APP_BUILD = "21"
 FORBIDDEN_SUFFIXES = {
     ".iso", ".gcm", ".gcz", ".ciso", ".wbfs", ".wia", ".rvz",
     ".gci", ".sav", ".log", ".mobileprovision", ".p12", ".p8",

--- a/scripts/package-macos-runtime.sh
+++ b/scripts/package-macos-runtime.sh
@@ -74,8 +74,8 @@ plutil -insert CFBundleIdentifier -string dev.kartpad.app "${plist}"
 plutil -insert CFBundleInfoDictionaryVersion -string 6.0 "${plist}"
 plutil -insert CFBundleName -string KartPad "${plist}"
 plutil -insert CFBundlePackageType -string APPL "${plist}"
-plutil -insert CFBundleShortVersionString -string "${KARTPAD_VERSION:-0.2.0}" "${plist}"
-plutil -insert CFBundleVersion -string "${KARTPAD_BUILD_NUMBER:-3}" "${plist}"
+plutil -insert CFBundleShortVersionString -string "${KARTPAD_VERSION:-0.4.7}" "${plist}"
+plutil -insert CFBundleVersion -string "${KARTPAD_BUILD_NUMBER:-21}" "${plist}"
 plutil -insert LSApplicationCategoryType -string public.app-category.games "${plist}"
 plutil -insert LSMinimumSystemVersion -string 14.0 "${plist}"
 plutil -insert NSHighResolutionCapable -bool true "${plist}"
@@ -160,7 +160,7 @@ unsigned_runtime_hash="$(shasum -a 256 "${macos}/KartPad" | awk '{print $1}')"
 source_commit="$(git -C "${repo_root}" rev-parse HEAD)"
 fingerprint="${macos}/build-fingerprint.json"
 printf '{\n  "SetupVersion": "%s",\n  "SourceCommit": "%s",\n  "UnsignedRuntimeSHA256": "%s"\n}\n' \
-  "${KARTPAD_VERSION:-0.2.0}" "${source_commit}" "${unsigned_runtime_hash}" > "${fingerprint}"
+  "${KARTPAD_VERSION:-0.4.7}" "${source_commit}" "${unsigned_runtime_hash}" > "${fingerprint}"
 
 if find "${staged_app}" \( -name portable.txt -o -name UserData -o -name Config.toml \) -print -quit | rg -q .; then
   echo "package contains writable or developer-only runtime state" >&2

--- a/scripts/package-public-macos.py
+++ b/scripts/package-public-macos.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import plistlib
+import stat
+import subprocess
+import zipfile
+from pathlib import Path
+
+
+RELEASE_TAG = "v0.4.7"
+APP_VERSION = "0.4.7"
+APP_BUILD = "21"
+ZIP_TIMESTAMP = (2020, 1, 1, 0, 0, 0)
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"ERROR: {message}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Package the public KartPad macOS app.")
+    parser.add_argument("app", type=Path)
+    parser.add_argument("output", type=Path, nargs="?")
+    args = parser.parse_args()
+    repo = Path(__file__).resolve().parents[1]
+    app = args.app.resolve()
+    output = (args.output.resolve() if args.output else
+              repo / "artifacts/KartPad-v0.4.7-macos-arm64.zip")
+    if subprocess.check_output(
+        ["git", "-C", str(repo), "status", "--porcelain", "--untracked-files=all"],
+        text=True,
+    ).strip():
+        fail("public macOS packaging requires a clean tracked source tree")
+    subprocess.run([str(repo / "scripts/audit-macos-package.sh"), str(app)], check=True)
+    with (app / "Contents/Info.plist").open("rb") as handle:
+        plist = plistlib.load(handle)
+    if plist.get("CFBundleShortVersionString") != APP_VERSION:
+        fail(f"expected app version {APP_VERSION}")
+    if str(plist.get("CFBundleVersion")) != APP_BUILD:
+        fail(f"expected app build {APP_BUILD}")
+    source_commit = subprocess.check_output(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True
+    ).strip()
+    executable = app / "Contents/MacOS/KartPad"
+    provenance = {
+        "schemaVersion": 1,
+        "releaseTag": RELEASE_TAG,
+        "sourceCommit": source_commit,
+        "appVersion": APP_VERSION,
+        "appBuild": APP_BUILD,
+        "bundleIdentifier": "dev.kartpad.app",
+        "executableSHA256": hashlib.sha256(executable.read_bytes()).hexdigest(),
+        "containsTranslatedGameCode": True,
+        "containsGameData": False,
+        "containsSigningMaterial": False,
+        "signing": "ad-hoc",
+        "maintainerAuthorizedFreeCommunityRelease": True,
+        "upstreamRightsConfirmed": False,
+        "rightsStatus": "community release; upstream and game-code rights unresolved",
+    }
+    extras = {
+        "INSTALL_MACOS.md": repo / "docs/INSTALL_MACOS.md",
+        "RELEASE_NOTES.md": repo / "docs/releases/v0.4.7.md",
+        "LICENSES/GPL-3.0.txt": repo / "LICENSES/GPL-3.0.txt",
+        "RIGHTS_AND_LICENSES.md": repo / "RIGHTS_AND_LICENSES.md",
+        "THIRD_PARTY_NOTICES.md": repo / "THIRD_PARTY_NOTICES.md",
+        "ThirdPartyLicenses/Aurora-MIT.txt": repo / "ref/upstream/Wiicompiled/aurora-main/LICENSE",
+        "ThirdPartyLicenses/CryptoPP.txt": repo / "ref/upstream/Wiicompiled/runtime/third_party/cryptopp/License.txt",
+        "ThirdPartyLicenses/PugiXML-MIT.txt": repo / "ref/upstream/Wiicompiled/runtime/third_party/pugixml/LICENSE.md",
+        "ThirdPartyLicenses/TOML11-MIT.txt": repo / "ref/upstream/Wiicompiled/runtime/third_party/toml11/LICENSE",
+        "ThirdPartyLicenses/WiiCompiled-GPL-3.0.txt": repo / "ref/upstream/Wiicompiled/LICENSE",
+    }
+    missing = [name for name, path in extras.items() if not path.is_file()]
+    if missing:
+        fail(f"missing release files: {', '.join(missing)}")
+    entries: list[tuple[str, bytes, int]] = []
+    for path in sorted((item for item in app.rglob("*") if item.is_file())):
+        entries.append((f"KartPad.app/{path.relative_to(app).as_posix()}",
+                        path.read_bytes(), stat.S_IMODE(path.stat().st_mode)))
+    for name, path in sorted(extras.items()):
+        entries.append((name, path.read_bytes(), stat.S_IMODE(path.stat().st_mode)))
+    entries.append(("KartPadMacProvenance.json",
+                    (json.dumps(provenance, indent=2, sort_keys=True) + "\n").encode(),
+                    0o644))
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_name(output.name + ".partial")
+    if temporary.exists():
+        temporary.unlink()
+    with zipfile.ZipFile(temporary, "w", zipfile.ZIP_DEFLATED, compresslevel=9) as archive:
+        for name, data, mode in sorted(entries):
+            info = zipfile.ZipInfo(name, ZIP_TIMESTAMP)
+            info.create_system = 3
+            info.external_attr = (stat.S_IFREG | mode) << 16
+            info.compress_type = zipfile.ZIP_DEFLATED
+            archive.writestr(info, data, compresslevel=9)
+    os.replace(temporary, output)
+    digest = hashlib.sha256(output.read_bytes()).hexdigest()
+    with zipfile.ZipFile(output) as archive:
+        if archive.testzip() is not None:
+            fail("ZIP integrity check failed")
+    print(f"Public macOS ZIP: {output}")
+    print(f"SHA-256: {digest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/package-public-unsigned-ipa.py
+++ b/scripts/package-public-unsigned-ipa.py
@@ -8,9 +8,9 @@ import sys
 from pathlib import Path
 
 
-RELEASE_TAG = "v0.4.6"
-APP_VERSION = "0.4.6"
-APP_BUILD = "20"
+RELEASE_TAG = "v0.4.7"
+APP_VERSION = "0.4.7"
+APP_BUILD = "21"
 
 
 def fail(message: str) -> None:
@@ -26,7 +26,7 @@ def main() -> int:
         "output",
         type=Path,
         nargs="?",
-        help="Output IPA path (defaults to artifacts/KartPad-v0.4.6-ios-unsigned.ipa)",
+        help="Output IPA path (defaults to artifacts/KartPad-v0.4.7-ios-unsigned.ipa)",
     )
     args = parser.parse_args()
 
@@ -38,7 +38,7 @@ def main() -> int:
     output = (
         args.output.resolve()
         if args.output
-        else repo / "artifacts/KartPad-v0.4.6-ios-unsigned.ipa"
+        else repo / "artifacts/KartPad-v0.4.7-ios-unsigned.ipa"
     )
     if subprocess.check_output(
         ["git", "-C", str(repo), "status", "--porcelain", "--untracked-files=all"],
@@ -70,7 +70,7 @@ def main() -> int:
     xcode_build = app.parents[1]
     additional_entries = {
         "INSTALL_IPA.md": repo / "docs/INSTALL_IPA.md",
-        "RELEASE_NOTES.md": repo / "docs/releases/v0.4.6.md",
+        "RELEASE_NOTES.md": repo / "docs/releases/v0.4.7.md",
         "LICENSES/GPL-3.0.txt": repo / "LICENSES/GPL-3.0.txt",
         "RIGHTS_AND_LICENSES.md": repo / "RIGHTS_AND_LICENSES.md",
         "THIRD_PARTY_NOTICES.md": repo / "THIRD_PARTY_NOTICES.md",

--- a/scripts/prepare-g7-game-runtime.sh
+++ b/scripts/prepare-g7-game-runtime.sh
@@ -47,6 +47,9 @@ cp -R "${runtime_ref}" "${runtime_source}"
 # mutates the immutable pinned reference checkout.
 cp -R "${repo_root}/ref/upstream/Wiicompiled/aurora-main" \
   "${runtime_source}/aurora-main"
+PYTHONPATH="${repo_root}/builder" python3 -m kartpad_builder.release_header \
+  "${repo_root}/builder/profiles/mkwii-rmcp01-rev0.json" \
+  "${runtime_source}/third_party/kartpad-profile/kartpad_retro_rewind_release.h"
 patch --batch -p1 -d "${runtime_source}/aurora-main" < \
   "${repo_root}/patches/aurora-present-telemetry.patch"
 patch --batch -p1 -d "${runtime_source}/aurora-main" < \

--- a/scripts/self-build-macos.sh
+++ b/scripts/self-build-macos.sh
@@ -3,15 +3,28 @@ set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
 image="${1:-${repo_root}/ref/Mario Kart Wii.wbfs}"
+profile="${repo_root}/builder/profiles/mkwii-rmcp01-rev0.json"
+retro_version="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["retroRewind"]["version"])' "${profile}")"
+retro_directory="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["retroRewind"]["root"])' "${profile}")"
+retro_cache="${repo_root}/private/builder/retro-rewind-downloads"
+retro_root="${retro_cache}/${retro_version}-extracted/${retro_directory}"
+payload="${retro_cache}/payload.RMCPD00.bin"
 
+"${repo_root}/scripts/build-user-ipa.sh" bootstrap
 KARTPAD_DISC_PATH="${image}" "${repo_root}/scripts/verify-sources.sh"
 "${repo_root}/scripts/check-repo-safety.sh"
-"${repo_root}/scripts/translate-base.sh" "${image}"
-"${repo_root}/scripts/build-macos-app.sh"
+"${repo_root}/scripts/translate-retro-rewind.sh" \
+  --image "${image}" --retro-root "${retro_root}" --payload "${payload}"
+"${repo_root}/scripts/build-macos-app.sh" \
+  "${repo_root}/private/self-build/retro-rewind/translation" \
+  "${repo_root}/build/self-build-macos-source" \
+  "${repo_root}/build/self-build-macos-build" \
+  "${repo_root}/build/KartPad-self-built.app" dual
 
 app="${repo_root}/build/KartPad-self-built.app"
 prepared_data="${repo_root}/private/self-build/disc"
 KARTPAD_SELF_BUILD_GAME_DATA_ROOT="${prepared_data}" \
+KARTPAD_SELF_BUILD_RETRO_REWIND_ROOT="${retro_root}" \
   "${app}/Contents/MacOS/KartPad"
 
 config="${HOME}/Library/Application Support/KartPad/Config.toml"
@@ -20,5 +33,10 @@ if [[ ! -f "${config}" ]] || ! rg -F -q "${expected_setting}" "${config}"; then
   echo "ERROR: self-build did not configure the validated game-data root" >&2
   exit 70
 fi
+expected_retro_setting="retro_rewind_root = \"${retro_root}\""
+if ! rg -F -q "${expected_retro_setting}" "${config}"; then
+  echo "ERROR: self-build did not configure the validated Retro Rewind root" >&2
+  exit 70
+fi
 
-echo "KartPad macOS self-build complete and configured: ${app}"
+echo "KartPad dual-game macOS self-build complete and configured: ${app}"

--- a/scripts/translate-retro-rewind.sh
+++ b/scripts/translate-retro-rewind.sh
@@ -14,6 +14,7 @@ profile_input="${repo_root}/private/self-build/retro-rewind/input"
 default_retro_root="${repo_root}/ref/upstream/rr-pulsar/PulsarPackCreator/Resources"
 retro_root="${default_retro_root}"
 payload=""
+image="${repo_root}/ref/Mario Kart Wii.wbfs"
 skip_retro_wfc=false
 dotnet_bin="/opt/homebrew/opt/dotnet@8/bin/dotnet"
 translator="${repo_root}/build/wiicompiled-fpscr/translator/src/Translator.Cli/bin/Release/net8.0/Translator.Cli.dll"
@@ -21,7 +22,7 @@ translation_jobs="${KARTPAD_TRANSLATION_JOBS:-2}"
 
 usage() {
   cat >&2 <<'USAGE'
-Usage: scripts/translate-retro-rewind.sh (--payload FILE | --skip-retro-wfc) [--retro-root DIR]
+Usage: scripts/translate-retro-rewind.sh (--payload FILE | --skip-retro-wfc) [--image FILE] [--retro-root DIR]
 
 Retranslates the user-owned RMCP01 base with awareness of KartPad's pinned
 Retro Rewind Code.pul, translates the static mod profile, and emits a separate
@@ -32,6 +33,11 @@ USAGE
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --image)
+      [[ $# -ge 2 ]] || { usage; exit 64; }
+      image="$2"
+      shift 2
+      ;;
     --payload)
       [[ $# -ge 2 ]] || { usage; exit 64; }
       payload="$2"
@@ -72,6 +78,11 @@ fi
 }
 
 retro_root="$(cd "${retro_root}" && pwd)"
+image="$(cd "$(dirname "${image}")" && pwd)/$(basename "${image}")"
+[[ -f "${image}" ]] || {
+  echo "ERROR: missing disc image at ${image}" >&2
+  exit 66
+}
 if [[ "${retro_root}" == "${default_retro_root}" ]]; then
   code_pul="${retro_root}/Code.pul"
 else
@@ -105,7 +116,7 @@ cmp -s "${code_pul}" "${staged_code_partial}" || {
 mv -f "${staged_code_partial}" "${staged_code}"
 trap - EXIT
 
-"${repo_root}/scripts/prepare-disc.sh"
+"${repo_root}/scripts/prepare-disc.sh" "${image}"
 "${repo_root}/scripts/prepare-patched-translator.sh"
 mkdir -p "${output}" "${base_manifest_dir}"
 

--- a/tests/test_macos_dual_mode_contract.py
+++ b/tests/test_macos_dual_mode_contract.py
@@ -1,0 +1,52 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class MacOSDualModeContractTests(unittest.TestCase):
+    def test_self_build_translates_and_packages_dual_runtime(self):
+        script = (ROOT / "scripts/self-build-macos.sh").read_text()
+        self.assertIn('"${repo_root}/scripts/build-user-ipa.sh" bootstrap', script)
+        self.assertIn('"${repo_root}/scripts/translate-retro-rewind.sh"', script)
+        self.assertIn('--image "${image}"', script)
+        self.assertIn('"${repo_root}/build/KartPad-self-built.app" dual', script)
+        self.assertIn("KARTPAD_SELF_BUILD_RETRO_REWIND_ROOT", script)
+
+    def test_translation_honors_caller_disc_image(self):
+        script = (ROOT / "scripts/translate-retro-rewind.sh").read_text()
+        self.assertIn("--image)", script)
+        self.assertIn('prepare-disc.sh" "${image}"', script)
+
+    def test_runtime_generates_exact_retro_release_contract(self):
+        script = (ROOT / "scripts/prepare-g7-game-runtime.sh").read_text()
+        target = (ROOT / "patches/wiicompiled-dual-product-target.patch").read_text()
+        self.assertIn("kartpad_builder.release_header", script)
+        self.assertIn("third_party/kartpad-profile", target)
+        self.assertIn("KARTPAD_RUNTIME_PRODUCT_DUAL=1", target)
+
+    def test_native_shell_exposes_first_class_macos_controls(self):
+        shell = (ROOT / "apple/macos/KartPadMacShell.mm").read_text()
+        for marker in (
+            '@"Game"', '@"Data"', '@"Controls"', '@"Help"',
+            '@"Original Mario Kart Wii"', '@"Retro Rewind"',
+            '@"Choose Retro Rewind Data…"', "KARTPAD_RR_CODE_PUL_SHA256",
+            'setenv("KARTPAD_RUNTIME_PROFILE"',
+            'WriteSetting("video", "resolution_multiplier", "2.0")',
+        ):
+            self.assertIn(marker, shell)
+
+    def test_public_macos_release_contract_is_versioned(self):
+        package = (ROOT / "scripts/package-public-macos.py").read_text()
+        audit = (ROOT / "scripts/audit-public-macos.py").read_text()
+        for script in (package, audit):
+            self.assertIn('RELEASE_TAG = "v0.4.7"', script)
+            self.assertIn('APP_VERSION = "0.4.7"', script)
+            self.assertIn('APP_BUILD = "21"', script)
+        self.assertTrue((ROOT / "docs/INSTALL_MACOS.md").is_file())
+        self.assertTrue((ROOT / "docs/releases/v0.4.7.md").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tvos_contract.py
+++ b/tests/test_tvos_contract.py
@@ -174,20 +174,20 @@ class TvOSContractTests(unittest.TestCase):
         ).read_text()
         tvos_audit = (ROOT / "scripts/audit-public-unsigned-tvos-ipa.py").read_text()
         for script in (ios_package, ios_audit):
-            self.assertIn('RELEASE_TAG = "v0.4.6"', script)
-            self.assertIn('APP_VERSION = "0.4.6"', script)
+            self.assertIn('RELEASE_TAG = "v0.4.7"', script)
+            self.assertIn('APP_VERSION = "0.4.7"', script)
         for script in (tvos_package, tvos_audit):
             self.assertIn('RELEASE_TAG = "v0.4.4"', script)
             self.assertIn('APP_VERSION = "0.4.4"', script)
-        self.assertIn('APP_BUILD = "20"', ios_package)
-        self.assertIn('APP_BUILD = "20"', ios_audit)
+        self.assertIn('APP_BUILD = "21"', ios_package)
+        self.assertIn('APP_BUILD = "21"', ios_audit)
         self.assertIn('APP_BUILD = "7"', tvos_package)
         self.assertIn('APP_BUILD = "7"', tvos_audit)
         self.assertIn('"physicalAppleTVAcceptance": False', tvos_package)
         self.assertIn('"physicalAppleTVAcceptance": False', tvos_audit)
         self.assertTrue((ROOT / "docs/INSTALL_TVOS.md").is_file())
         self.assertTrue((ROOT / "docs/releases/v0.4.4.md").is_file())
-        self.assertTrue((ROOT / "docs/releases/v0.4.6.md").is_file())
+        self.assertTrue((ROOT / "docs/releases/v0.4.7.md").is_file())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #79.

## What changed
- makes the one-command macOS self-build translate and compile the dual Original / Retro Rewind runtime
- adds native Game, Data, Controls, and Help menus, persisted game switching, and exact Retro Rewind data validation
- documents Mac installation, keyboard/controller/mouse behavior, and the WiiCompiled project lineage
- adds deterministic audited macOS ZIP packaging and prepares the 0.4.7 Mac + iOS release

## Evidence
- native dual Mac build and app package audit pass
- Original and Retro Rewind profiles each launch in the built app
- keyboard input reached the translated core; native controller mapping UI and four-slot contracts pass
- portability suites pass 15/15 plus memory, scheduler, PPC-semantics, and 585 translator tests
- Python repository suite: 65 passed, 1 platform-gated skip

Physical controller hardware acceptance remains explicitly open; no unsupported claim is made.