### PR TITLE
Preserve macOS bundle signing in release archives

### DIFF
--- a/scripts/audit-macos-package.sh
+++ b/scripts/audit-macos-package.sh
@@ -27,12 +27,19 @@ test "$(plutil -extract NSBluetoothAlwaysUsageDescription raw "${plist}")" = \
   "KartPad uses Bluetooth to pair and connect an experimental Wii Remote and Nunchuk."
 test -x "${executable}"
 test -f "${contents}/Resources/${icon_name%.icns}.icns"
-test -f "${contents}/MacOS/dsp_coef.bin"
+test "$(readlink "${contents}/MacOS/dsp_coef.bin")" = \
+  "../Resources/Runtime/dsp_coef.bin"
+test "$(readlink "${contents}/MacOS/build-fingerprint.json")" = \
+  "../Resources/Runtime/build-fingerprint.json"
+test "$(readlink "${contents}/MacOS/wii_bootstrap")" = \
+  "../Resources/Runtime/wii_bootstrap"
+test -f "${contents}/Resources/Runtime/dsp_coef.bin"
+test -f "${contents}/Resources/Runtime/build-fingerprint.json"
 if [[ ! -f "${contents}/Resources/initial_pipeline_cache.db" ]]; then
   echo "package lacks its read-only initial pipeline cache resource" >&2
   exit 66
 fi
-test -d "${contents}/MacOS/wii_bootstrap/shared2/wc24"
+test -d "${contents}/Resources/Runtime/wii_bootstrap/shared2/wc24"
 if [[ "$(file -b "${executable}")" != *"Mach-O 64-bit executable arm64"* ]]; then
   echo "main executable is not arm64 Mach-O" >&2
   exit 65

--- a/scripts/audit-public-macos.py
+++ b/scripts/audit-public-macos.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
+import posixpath
 import plistlib
+import stat
 import subprocess
 import tempfile
 import zipfile
@@ -26,10 +29,42 @@ REQUIRED_ENTRIES = {
     "ThirdPartyLicenses/Aurora-MIT.txt",
     "ThirdPartyLicenses/WiiCompiled-GPL-3.0.txt",
 }
+EXPECTED_SYMLINKS = {
+    "KartPad.app/Contents/MacOS/build-fingerprint.json":
+        "../Resources/Runtime/build-fingerprint.json",
+    "KartPad.app/Contents/MacOS/dsp_coef.bin":
+        "../Resources/Runtime/dsp_coef.bin",
+    "KartPad.app/Contents/MacOS/wii_bootstrap":
+        "../Resources/Runtime/wii_bootstrap",
+}
 
 
 def fail(message: str) -> None:
     raise SystemExit(f"ERROR: public macOS audit failed: {message}")
+
+
+def extract_unix_archive(archive: zipfile.ZipFile, root: Path) -> None:
+    for info in archive.infolist():
+        destination = root / info.filename
+        unix_mode = info.external_attr >> 16
+        if info.is_dir():
+            destination.mkdir(parents=True, exist_ok=True)
+            destination.chmod(stat.S_IMODE(unix_mode))
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if stat.S_ISLNK(unix_mode):
+            target = archive.read(info).decode()
+            expected = EXPECTED_SYMLINKS.get(info.filename)
+            if target != expected:
+                fail(f"unexpected symlink: {info.filename} -> {target}")
+            normalized = posixpath.normpath(
+                posixpath.join(posixpath.dirname(info.filename), target))
+            if normalized.startswith("../") or normalized == "..":
+                fail(f"symlink escapes archive: {info.filename}")
+            os.symlink(target, destination)
+            continue
+        destination.write_bytes(archive.read(info))
+        destination.chmod(stat.S_IMODE(unix_mode))
 
 
 def main() -> int:
@@ -71,12 +106,9 @@ def main() -> int:
                 fail(f"unexpected provenance {key}: {provenance.get(key)!r}")
         with tempfile.TemporaryDirectory(prefix="kartpad-public-macos-audit.") as temp:
             root = Path(temp)
-            archive.extractall(root)
-            for info in archive.infolist():
-                mode = (info.external_attr >> 16) & 0o777
-                extracted = root / info.filename
-                if mode and extracted.is_file():
-                    extracted.chmod(mode)
+            extract_unix_archive(archive, root)
+            if set(EXPECTED_SYMLINKS) - set(names):
+                fail("archive lacks required runtime-resource symlinks")
             app = root / "KartPad.app"
             subprocess.run([str(repo / "scripts/audit-macos-package.sh"), str(app)], check=True)
             with (app / "Contents/Info.plist").open("rb") as handle:

--- a/scripts/package-macos-runtime.sh
+++ b/scripts/package-macos-runtime.sh
@@ -54,15 +54,18 @@ staged_app="${staging_root}/KartPad.app"
 contents="${staged_app}/Contents"
 macos="${contents}/MacOS"
 resources="${contents}/Resources"
+runtime_resources="${resources}/Runtime"
 frameworks="${contents}/Frameworks"
-mkdir -p "${macos}" "${resources}" "${frameworks}"
+mkdir -p "${macos}" "${runtime_resources}" "${frameworks}"
 
 cp "${runtime_binary}" "${macos}/KartPad"
 chmod 0755 "${macos}/KartPad"
-cp "${runtime_build}/dsp_coef.bin" "${macos}/dsp_coef.bin"
+cp "${runtime_build}/dsp_coef.bin" "${runtime_resources}/dsp_coef.bin"
 cp "${runtime_build}/initial_pipeline_cache.db" "${resources}/initial_pipeline_cache.db"
-cp -R "${runtime_build}/wii_bootstrap" "${macos}/wii_bootstrap"
+cp -R "${runtime_build}/wii_bootstrap" "${runtime_resources}/wii_bootstrap"
 cp "${icon_file}" "${resources}/KartPad.icns"
+ln -s ../Resources/Runtime/dsp_coef.bin "${macos}/dsp_coef.bin"
+ln -s ../Resources/Runtime/wii_bootstrap "${macos}/wii_bootstrap"
 
 plist="${contents}/Info.plist"
 plutil -create xml1 "${plist}"
@@ -158,9 +161,10 @@ done
 
 unsigned_runtime_hash="$(shasum -a 256 "${macos}/KartPad" | awk '{print $1}')"
 source_commit="$(git -C "${repo_root}" rev-parse HEAD)"
-fingerprint="${macos}/build-fingerprint.json"
+fingerprint="${runtime_resources}/build-fingerprint.json"
 printf '{\n  "SetupVersion": "%s",\n  "SourceCommit": "%s",\n  "UnsignedRuntimeSHA256": "%s"\n}\n' \
   "${KARTPAD_VERSION:-0.4.7}" "${source_commit}" "${unsigned_runtime_hash}" > "${fingerprint}"
+ln -s ../Resources/Runtime/build-fingerprint.json "${macos}/build-fingerprint.json"
 
 if find "${staged_app}" \( -name portable.txt -o -name UserData -o -name Config.toml \) -print -quit | rg -q .; then
   echo "package contains writable or developer-only runtime state" >&2

--- a/scripts/package-public-macos.py
+++ b/scripts/package-public-macos.py
@@ -79,23 +79,45 @@ def main() -> int:
     if missing:
         fail(f"missing release files: {', '.join(missing)}")
     entries: list[tuple[str, bytes, int]] = []
-    for path in sorted((item for item in app.rglob("*") if item.is_file())):
-        entries.append((f"KartPad.app/{path.relative_to(app).as_posix()}",
-                        path.read_bytes(), stat.S_IMODE(path.stat().st_mode)))
+    for root, directory_names, file_names in os.walk(app, followlinks=False):
+        root_path = Path(root)
+        relative_root = root_path.relative_to(app).as_posix()
+        directory_entry = "KartPad.app/" if relative_root == "." else \
+            f"KartPad.app/{relative_root}/"
+        entries.append((directory_entry, b"",
+                        stat.S_IFDIR | stat.S_IMODE(root_path.stat().st_mode)))
+        for directory_name in sorted(list(directory_names)):
+            path = root_path / directory_name
+            if path.is_symlink():
+                entries.append((f"KartPad.app/{path.relative_to(app).as_posix()}",
+                                os.readlink(path).encode(), stat.S_IFLNK | 0o777))
+                directory_names.remove(directory_name)
+        for file_name in sorted(file_names):
+            path = root_path / file_name
+            name = f"KartPad.app/{path.relative_to(app).as_posix()}"
+            if path.is_symlink():
+                entries.append((name, os.readlink(path).encode(),
+                                stat.S_IFLNK | 0o777))
+            else:
+                entries.append((name, path.read_bytes(),
+                                stat.S_IFREG | stat.S_IMODE(path.stat().st_mode)))
     for name, path in sorted(extras.items()):
-        entries.append((name, path.read_bytes(), stat.S_IMODE(path.stat().st_mode)))
+        entries.append((name, path.read_bytes(),
+                        stat.S_IFREG | stat.S_IMODE(path.stat().st_mode)))
     entries.append(("KartPadMacProvenance.json",
                     (json.dumps(provenance, indent=2, sort_keys=True) + "\n").encode(),
-                    0o644))
+                    stat.S_IFREG | 0o644))
     output.parent.mkdir(parents=True, exist_ok=True)
     temporary = output.with_name(output.name + ".partial")
     if temporary.exists():
         temporary.unlink()
     with zipfile.ZipFile(temporary, "w", zipfile.ZIP_DEFLATED, compresslevel=9) as archive:
-        for name, data, mode in sorted(entries):
+        for name, data, unix_mode in sorted(entries):
             info = zipfile.ZipInfo(name, ZIP_TIMESTAMP)
             info.create_system = 3
-            info.external_attr = (stat.S_IFREG | mode) << 16
+            info.external_attr = unix_mode << 16
+            if stat.S_ISDIR(unix_mode):
+                info.external_attr |= 0x10
             info.compress_type = zipfile.ZIP_DEFLATED
             archive.writestr(info, data, compresslevel=9)
     os.replace(temporary, output)

--- a/tests/test_macos_dual_mode_contract.py
+++ b/tests/test_macos_dual_mode_contract.py
@@ -47,6 +47,15 @@ class MacOSDualModeContractTests(unittest.TestCase):
         self.assertTrue((ROOT / "docs/INSTALL_MACOS.md").is_file())
         self.assertTrue((ROOT / "docs/releases/v0.4.7.md").is_file())
 
+    def test_macos_archive_preserves_signed_runtime_resource_links(self):
+        bundle = (ROOT / "scripts/package-macos-runtime.sh").read_text()
+        package = (ROOT / "scripts/package-public-macos.py").read_text()
+        audit = (ROOT / "scripts/audit-public-macos.py").read_text()
+        self.assertIn("../Resources/Runtime/dsp_coef.bin", bundle)
+        self.assertIn("stat.S_IFLNK", package)
+        self.assertIn("EXPECTED_SYMLINKS", audit)
+        self.assertIn("os.symlink(target, destination)", audit)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Follow-up to #80 discovered by the exact hosted-archive gate.

- moves non-code runtime support data under Contents/Resources and preserves the runtime paths with relative symlinks
- serializes those symlinks and empty bundle directories deterministically
- safely reconstructs and validates the exact expected links before the extracted-app code-sign audit

Evidence: the repackaged app passes strict code-sign and Mac bundle audits; repository tests pass.