### PR TITLE
Record v0.4.10 hosted release verification

### DIFF
--- a/docs/artifacts/2026-09-07/apple/v0410-release-verification.md
+++ b/docs/artifacts/2026-09-07/apple/v0410-release-verification.md
@@ -1,0 +1,47 @@
+# iPhone/iPad v0.4.10 release verification
+
+- Implementation and documentation PR: https://github.com/chrissotraidis/kartpad/pull/88
+- Merged source and release tag: `33d828350fc4812391d00ff692771b52a80db956`.
+- Version: 0.4.10, iPhone/iPad build 25.
+- Published release: https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.10
+
+| Artifact | Bytes | SHA-256 |
+| --- | ---: | --- |
+| KartPad-v0.4.10-ios-unsigned.ipa | 40,800,315 | `b99283c24fd9c5a9a244c7075ca87321edc2a0e3d50dfbd96372c47757eb55cc` |
+
+The maintainer accepted build 25 on physical iPad after checking Retro Rewind
+launch, Game Data & Saves, and navigation to Friends inside the Retro WFC menu.
+Earlier checks covered license deletion/creation, chooser navigation, and
+reopening to switch games. The maintainer accepted the current Mac, iPhone and
+iPad builds for general use and authorized this merge and publication.
+
+The app was rebuilt from the exact merged source. All 21 files in the unsigned
+app bundle match the physically accepted build byte-for-byte, including its
+executable SHA-256 `249ac741997fc7e9fd22171d5e9d239f35b6f01d415ed3d57837ad29a20ea38b`.
+No runtime or device-state changes were made during release preparation.
+The release IPA differs from the earlier local candidate because it includes
+updated installation/release documentation and merged-source provenance.
+
+Two release packages were byte-identical. The exact IPA passed the complete
+unsigned audit, including version, source provenance, ZIP integrity, required
+notices, private-data exclusion, signing-material exclusion, private-path
+exclusion, and the extracted iOS app audit. Uploaded asset sizes and SHA-256
+values matched locally. Fresh anonymous downloads of the IPA and SHA256SUMS
+matched their local files byte-for-byte; the downloaded IPA passed the same
+complete audit. The release tag resolves to the merged source above. The
+maintainer's Downloads copy was updated to the verified published IPA.
+
+The 68 Python checks passed before merge, and the existing 17 native tests
+passed for build 25. Fresh runtime preparation reproduced the build source.
+Simulator checks verified the identity labels, name editor, and scheduled-edit
+confirmation. Prior chooser/resume checks are recorded in the iteration notes.
+
+The accepted Mac ZIP remains in v0.4.9, as does the experimental Apple TV IPA.
+Android remains paused at `0d8d19f` on `codex/android-a4-touch-settings`, with no
+source changes, build, or device installation in this release. Native private
+room transport, safe in-process game switching, and complete production-online
+race verification remain separate work. Navigating to Friends is not evidence
+of a completed online race.
+
+This evidence note follows the release source and does not alter the source
+identity or provenance embedded in the published IPA.

--- a/docs/iterations/ipad-identity-build25.md
+++ b/docs/iterations/ipad-identity-build25.md
@@ -54,3 +54,11 @@ check was build 25 on iPad: Retro Rewind launched, Game Data & Saves was clear,
 and the Retro WFC menu allowed scrolling to Friends. This observation does
 not establish a completed production-online race. The accepted app behavior
 is frozen for the release; only documentation and release provenance change.
+
+## Published release
+
+The accepted app was released from merged main as v0.4.10. The release package
+updates documentation and provenance while preserving every app file from the
+accepted build. See [hosted release verification](../artifacts/2026-09-07/apple/v0410-release-verification.md)
+for its final checksum and anonymous-download audit. The earlier IPA evidence
+above describes the pre-merge local candidate.


### PR DESCRIPTION
Records the published 0.4.10 build 25 IPA, exact merged-source provenance, and maintainer acceptance. All 21 rebuilt app files match the accepted device candidate. Repeated packaging was byte-identical, and fresh anonymous downloads matched and passed the complete unsigned IPA audit.

Documentation only. The release tag and embedded source provenance remain at `33d828350fc4812391d00ff692771b52a80db956`. Mac stays at 0.4.9; tvOS remains experimental and Android remains paused.
