### PR TITLE
Fix CSNum collisions with upstream numeric serial backport

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -33,3 +33,7 @@ software licenses do not grant rights in Nintendo-owned game content. This
 does not waive GPL obligations for the combined application or for GPL-covered
 code included in generated output. See [`RIGHTS_AND_LICENSES.md`](RIGHTS_AND_LICENSES.md)
 for the game-content boundary and complete Corresponding Source obligations.
+
+The CSNum runtime correction in `patches/wiicompiled-sc-serial.patch` is
+backported from [patchzyy/Wiicompiled commit e0e362b](https://github.com/patchzyy/Wiicompiled/commit/e0e362bd992e07784f8ce7fa795cdb496af7b075),
+by patchzyy, under the upstream GPLv3 license.

--- a/docs/iterations/issue94-csnum-hotfix.md
+++ b/docs/iterations/issue94-csnum-hotfix.md
@@ -1,0 +1,50 @@
+# Issue #94: numeric console serial backport
+
+KartPad's pinned WiiCompiled runtime (`1912292c804ff9b1b79938de89369ec4496f9fff`)
+contains the reported bug. `SCGetProductSN_HLE` copies a nine-digit string and
+its terminator into a guest output that is a four-byte integer. DWC reads the
+first four ASCII bytes as a big-endian number. For example, both `788600001`
+and `788699999` become `926431286` and consequently the same `LEH926431286`
+CSNum. The write can also overwrite six adjacent guest bytes.
+
+`patches/wiicompiled-sc-serial.patch` backports the helper and override from
+[patchzyy's upstream fix e0e362b](https://github.com/patchzyy/Wiicompiled/commit/e0e362bd992e07784f8ce7fa795cdb496af7b075).
+The upstream dependency pin stays unchanged; no translator regeneration or
+unrelated upstream changes are required. The patch parses the complete decimal
+serial, validates the four-byte output and writes through `Memory::Write32`.
+It preserves the existing stored console identity, MAC, saves and profiles.
+
+The iOS preparation applies the patch after the existing runtime patch stack,
+before the prepare-only exit. tvOS and Android inherit that stack. The macOS
+preparation applies it at the equivalent point. Existing prepared runtime
+sources and already compiled binaries do not acquire this change automatically:
+prepare fresh sources and rebuild the native library before packaging.
+
+## Evidence and limits
+
+- `python3 -m unittest discover -s tests -p test_sc_serial.py -v` compiles the
+  actual pinned override before and after patching with AddressSanitizer and
+  UndefinedBehaviorSanitizer. The old function fails; the fixed function passes.
+- The same harness reproduces the two colliding old outputs, verifies distinct
+  corrected outputs, leading zeros, guest byte order, adjacent-memory canaries,
+  malformed serials, null output and undersized output.
+- The full iOS dual runtime preparation accepts the backport on a fresh copy.
+- Server reference `Retro-Rewind-Team/wfc-server` at
+  `fbd30fa41a35fe8a407e3a49bc83fe4ff91fd35b`, `database/login.go`:
+  `SearchUserBan` matches overlapping CSNum arrays. This establishes the risk
+  of collateral bans; it does not establish that particular users were banned
+  or that the production server currently runs this exact revision.
+
+## Existing online profiles
+
+The server's `handleCsnum` appends a new serial to an existing profile and keeps
+historical values. Correcting the client therefore does not erase a previously
+stored, shared CSNum or reverse an existing ban. Its `SameIPAddress` policy can
+also reject an identity change from a different IP. Affected existing accounts
+may require service-admin correction of the erroneous historical CSNum and
+review of any collateral ban. Do not wipe saves, regenerate console identities,
+or create replacement accounts as a workaround.
+
+Host regression and patch replay are not a production-service login test or
+proof of corrected release binaries. Android release coordination is holding
+publication for a native rebuild and package verification with this backport.

--- a/patches/wiicompiled-sc-serial.patch
+++ b/patches/wiicompiled-sc-serial.patch
@@ -1,0 +1,57 @@
+diff --git a/include/sc_serial_contract.h b/include/sc_serial_contract.h
+--- /dev/null
++++ b/include/sc_serial_contract.h
+@@ -0,0 +1,26 @@
++#pragma once
++
++#include <charconv>
++#include <cstddef>
++#include <cstdint>
++#include <string_view>
++#include <system_error>
++
++namespace RuntimeScSerial {
++
++// SCGetProductSN's output is a u32, not a character buffer. DWC loads
++// that word and formats it with the product code to construct csnum.
++template <typename RangeValidator, typename WordWriter>
++uint32_t Write(std::string_view serial, uint32_t address,
++               RangeValidator&& contains, WordWriter&& write32) {
++    if (serial.empty() || serial.size() > 9 ||
++        serial.find_first_not_of("0123456789") != std::string_view::npos) return 0;
++    uint32_t number = 0;
++    const auto parsed = std::from_chars(serial.data(), serial.data() + serial.size(), number);
++    if (parsed.ec != std::errc{} || parsed.ptr != serial.data() + serial.size() ||
++        !address || !contains(address, sizeof(uint32_t))) return 0;
++    write32(address, number);
++    return 1;
++}
++
++} // namespace RuntimeScSerial
+diff --git a/src/hle/sc.cpp b/src/hle/sc.cpp
+--- a/src/hle/sc.cpp
++++ b/src/hle/sc.cpp
+@@ -1,6 +1,7 @@
+ #include "hle_stubs.h"
+ 
+ #include "console_identity.h"
++#include "sc_serial_contract.h"
+ #include <cstdlib>
+ #include <cstddef>
+ #include <cstdint>
+@@ -97,12 +98,9 @@ PPC_NATIVE_OVERRIDE(801B2424, SCGetProductCode_HLE, uint32_t, (), ());
+ extern "C" uint32_t SCGetProductSN_HLE(uint32_t serialAddress)
+ {
+     const std::string& serial = RuntimeConsoleIdentity::Current().serial;
+-    if (!serialAddress || !Memory::Contains(serialAddress, serial.size() + 1)) {
+-        return 0;
+-    }
+-    std::memcpy(Memory::GetPointer(serialAddress, serial.size() + 1),
+-                serial.c_str(), serial.size() + 1);
+-    return 1;
++    return RuntimeScSerial::Write(serial, serialAddress,
++        [](uint32_t address, size_t size) { return Memory::Contains(address, size); },
++        [](uint32_t address, uint32_t value) { Memory::Write32(address, value); });
+ }
+ 
+ PPC_NATIVE_OVERRIDE(801B2460, SCGetProductSN_HLE, uint32_t, (uint32_t serialAddress), (serialAddress));

--- a/scripts/prepare-g7-game-runtime.sh
+++ b/scripts/prepare-g7-game-runtime.sh
@@ -84,6 +84,10 @@ done
 patch --batch -p1 -d "${runtime_source}" < \
   "${repo_root}/patches/wiicompiled-present-telemetry.patch"
 
+# Backport upstream e0e362b: SCGetProductSN returns a guest u32 for DWC csnum.
+patch --batch -p1 -d "${runtime_source}" < \
+  "${repo_root}/patches/wiicompiled-sc-serial.patch"
+
 mkdir -p "${runtime_source}/third_party/sse2neon"
 cached_sse2neon="${repo_root}/build/dependency-cache/sse2neon-${sse2neon_sha256}.h"
 if [[ -f "${cached_sse2neon}" ]] &&

--- a/scripts/prepare-ios-game-runtime.sh
+++ b/scripts/prepare-ios-game-runtime.sh
@@ -123,6 +123,10 @@ for dual_patch in \
   patch --batch -p1 -d "${runtime_source}" < "${repo_root}/patches/${dual_patch}"
 done
 
+# Backport upstream e0e362b: SCGetProductSN returns a guest u32 for DWC csnum.
+patch --batch -p1 -d "${runtime_source}" < \
+  "${repo_root}/patches/wiicompiled-sc-serial.patch"
+
 mkdir -p "${runtime_source}/third_party/sse2neon"
 cached_sse2neon="${repo_root}/build/dependency-cache/sse2neon-${sse2neon_sha256}.h"
 if [[ -f "${cached_sse2neon}" ]] &&

--- a/tests/test_sc_serial.py
+++ b/tests/test_sc_serial.py
@@ -1,0 +1,125 @@
+"""Compile the actual SC override with bounded guest memory; no game data/network."""
+from pathlib import Path
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+REPO = Path(__file__).resolve().parents[1]
+
+HARNESS = r'''
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <iostream>
+#if __has_include("sc_serial_contract.h")
+#include "sc_serial_contract.h"
+#endif
+namespace RuntimeConsoleIdentity {
+struct Identity { std::string serial; } identity;
+const Identity& Current() { return identity; }
+}
+namespace Memory {
+std::array<unsigned char, 32> bytes;
+size_t available = 4;
+bool Contains(uint32_t address, size_t size) { return address == 8 && size <= available; }
+void* GetPointer(uint32_t address, size_t) { return bytes.data() + address; }
+void Write32(uint32_t address, uint32_t value) {
+    for (unsigned i = 0; i < 4; ++i) bytes[address+i] = value >> (24-8*i);
+}
+uint32_t Read32(uint32_t address) {
+    uint32_t value = 0;
+    for (unsigned i = 0; i < 4; ++i) value = (value << 8) | bytes[address+i];
+    return value;
+}
+}
+@OVERRIDE@
+void require(bool value, const char* message) { if (!value) throw std::runtime_error(message); }
+int main(int argc, char**) {
+ try {
+    if (argc > 1) {
+        Memory::available = 10;
+        for (const char* serial : {"788600001", "788699999"}) {
+            RuntimeConsoleIdentity::identity.serial = serial;
+            require(SCGetProductSN_HLE(8) == 1, "serial probe succeeds");
+            std::cout << Memory::Read32(8) << '\n';
+        }
+        return 0;
+    }
+    // The old override reduces both 7886xxxxx values to ASCII "7886".
+    require(0x37383836u == 926431286u, "reproduce old colliding csnum");
+    for (const char* serial : {"788600001", "788699999", "761800001", "761899999",
+                              "012345678", "000000001", "999999999"}) {
+        RuntimeConsoleIdentity::identity.serial = serial;
+        Memory::bytes.fill(0xa5);
+        require(SCGetProductSN_HLE(8) == 1, "accept exactly four-byte output");
+        require(Memory::Read32(8) == std::stoul(serial), "preserve full numeric serial in guest byte order");
+        for (size_t i = 0; i < Memory::bytes.size(); ++i)
+            if (i < 8 || i >= 12) require(Memory::bytes[i] == 0xa5, "preserve adjacent guest memory");
+    }
+    for (const char* serial : {"", "1234567890", "7886x1234", "-12345678", "+12345678"}) {
+        RuntimeConsoleIdentity::identity.serial = serial;
+        Memory::bytes.fill(0xa5);
+        require(SCGetProductSN_HLE(8) == 0, "reject malformed serial");
+        for (auto byte : Memory::bytes) require(byte == 0xa5, "invalid serial must not write");
+    }
+    RuntimeConsoleIdentity::identity.serial = "788600001";
+    require(SCGetProductSN_HLE(0) == 0, "reject null output");
+    Memory::available = 3;
+    require(SCGetProductSN_HLE(8) == 0, "reject undersized output");
+    for (auto byte : Memory::bytes) require(byte == 0xa5, "invalid address must not write");
+    std::cout << "SC override: numeric serial, collision, byte order and memory boundary checks passed\n";
+    return 0;
+ } catch (const std::exception& error) { std::cerr << error.what() << '\n'; return 1; }
+}
+'''
+
+
+class ScSerialTests(unittest.TestCase):
+    def test_preparation_covers_all_platforms(self):
+        for script in ('prepare-ios-game-runtime.sh', 'prepare-g7-game-runtime.sh'):
+            self.assertIn('wiicompiled-sc-serial.patch', (REPO / 'scripts' / script).read_text())
+        # Android's common preparation and tvOS both inherit the iOS patch stack.
+        android = REPO / 'scripts/prepare-android-game-runtime.sh'
+        if android.exists():
+            self.assertIn('prepare-ios-game-runtime.sh', android.read_text())
+        self.assertIn('prepare-ios-game-runtime.sh', (REPO / 'scripts/prepare-tvos-game-runtime.sh').read_text())
+
+    def test_actual_override_before_and_after_backport(self):
+        upstream = REPO / 'ref/upstream/Wiicompiled/runtime/src/hle/sc.cpp'
+        if not upstream.exists():
+            self.skipTest('pinned WiiCompiled reference required for compiled regression')
+        with tempfile.TemporaryDirectory() as directory:
+            stage = Path(directory)
+            (stage / 'src/hle').mkdir(parents=True)
+            shutil.copyfile(upstream, stage / 'src/hle/sc.cpp')
+
+            def run_override():
+                source = (stage / 'src/hle/sc.cpp').read_text()
+                override = re.search(r'extern "C" uint32_t SCGetProductSN_HLE\(uint32_t serialAddress\)\n\{.*?\n\}', source, re.S)
+                self.assertIsNotNone(override)
+                (stage / 'test.cpp').write_text(HARNESS.replace('@OVERRIDE@', override.group()))
+                subprocess.run([os.environ.get('CXX', 'c++'), '-std=c++17', '-Wall', '-Wextra', '-Werror',
+                                '-fsanitize=address,undefined', '-I', str(stage / 'include'),
+                                str(stage / 'test.cpp'), '-o', str(stage / 'test')], check=True, capture_output=True)
+                return subprocess.run([str(stage / 'test')], capture_output=True, text=True)
+
+            before = run_override()
+            self.assertNotEqual(before.returncode, 0, 'old override must fail regression')
+            self.assertIn('accept exactly four-byte output', before.stderr)
+            legacy = subprocess.check_output([str(stage / 'test'), '--probe'], text=True)
+            self.assertEqual(legacy.splitlines(), ['926431286', '926431286'])
+            subprocess.run(['patch', '--batch', '--fuzz=0', '-p1', '-d', str(stage),
+                            '-i', str(REPO / 'patches/wiicompiled-sc-serial.patch')], check=True, capture_output=True)
+            after = run_override()
+            self.assertEqual(after.returncode, 0, after.stdout + after.stderr)
+            fixed = subprocess.check_output([str(stage / 'test'), '--probe'], text=True)
+            self.assertEqual(fixed.splitlines(), ['788600001', '788699999'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
KartPad's pinned `SCGetProductSN_HLE` writes a serial string where DWC expects a guest u32. Distinct serials such as `788600001` and `788699999` therefore both produce `LEH926431286`, and the string write can overwrite adjacent guest memory. The WFC server reference matches CSNum overlap when checking bans, so the report describes a real collateral-ban risk.

Backport patchzyy's upstream fix [e0e362b](https://github.com/patchzyy/Wiicompiled/commit/e0e362bd992e07784f8ce7fa795cdb496af7b075) into the shared iOS/tvOS/Android and macOS preparation paths. Preserve existing identities and saves. Addresses #94.

Validation: compiled old/new override regression with ASan/UBSan; reproduced old collisions and verified corrected values, byte order and memory boundaries. Main host suite: 71 tests, one unrelated skip, no failures. Full iOS and Android dual runtime patch replay passed. Clean cherry-pick verified onto Android release checkpoint `b99c452` in an isolated checkout.

Release gate: rebuild native binaries with the patch before packaging; Android publication is held for this. Existing erroneous CSNums retained in server profile history may require server-admin cleanup and collateral-ban review. This change does not clear existing bans, and no production-service login or rebuilt release acceptance is claimed.
