### PR TITLE
Document verified Android, iPhone/iPad and Mac downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ retains the native Mac controls and data-management flows.
 
 ## What is available now?
 
+| Platform | Current corrected download | Installation |
+|---|---|---|
+| Android ARM64 | [0.4.10-android.1, code 21](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.10-android.1) | [APK guide](docs/INSTALL_ANDROID.md) |
+| iPhone / iPad | [0.4.11, build 26](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.11) | [Unsigned IPA guide](docs/INSTALL_IPA.md) |
+| Apple Silicon Mac | [0.4.11, build 26](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.11-macos.1) | [Mac ZIP guide](docs/INSTALL_MACOS.md) |
+
+All three contain the corrected online console-serial implementation. Platform
+release tags are independent; identical version strings are not required for
+the shared fix. Experimental tvOS remains offline-only pending its rebuild.
+
 ### Android: first community release
 
 [Download Android APK, notices and SHA-256 checksums](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.10-android.1)

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -18,6 +18,11 @@ maintainer response crediting patchzyy and linking verified fixed downloads.
 Source correction, new binary verification and historical server-CSNum cleanup
 remain distinct. Old experimental tvOS is still offline-only pending rebuild.
 
+Mac publication is complete from `0c70061`; the hosted ZIP matches the local
+audited bytes and its extracted ad-hoc signature passes. The isolated Original
+startup/title-screen run was around 60 FPS and quit normally without changing
+installed save/Mii/config hashes. See `docs/artifacts/2026-09-07/macos-v0411-release.md`.
+
 2026-09-07: the owner accepted Android Preview 15/code 20 with Razer Kishi in
 Original Grand Prix; touch controls hide on connection and gameplay works.
 Earlier that session they reported Retro Rewind 6.12.7 Retro WFC login,

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -16,12 +16,12 @@ online race or server-history cleanup is inferred from these checks.
 
 ## macOS 0.4.11 console-serial hotfix
 
-- [ ] Rebuild both executable profiles from freshly patched source.
-- [ ] Audit the signed app and inspect the linked corrected serial write.
-- [ ] Run bounded local launch/close checks without touching installed saves.
-- [ ] Merge metadata, package exact main twice and audit extracted signatures.
-- [ ] Publish only Mac ZIP/checksum, anonymously download and re-audit.
-- [ ] Update issue #94 and the current download documentation.
+- [x] Rebuild both executable profiles from freshly patched source.
+- [x] Audit the signed app and inspect the linked corrected serial write.
+- [x] Run bounded local launch/close checks without touching installed saves.
+- [x] Merge metadata, package exact main twice and audit extracted signatures.
+- [x] Publish only Mac ZIP/checksum, anonymously download and re-audit.
+- [x] Update issue #94 and the current download documentation.
 
 ## First Android community release (v0.4.10-android.1)
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -11,6 +11,10 @@ erroneous server CSNum history requires separate service-admin remediation.
 See [iPhone/iPad verification](artifacts/2026-09-07/ios-v0411-release.md) and
 [Mac release notes](releases/v0.4.11-macos.1.md).
 
+Mac publication and anonymous extracted-package verification are complete;
+see [the Mac evidence](artifacts/2026-09-07/macos-v0411-release.md). The isolated
+Original title-screen/normal-close smoke preserved installed save/config state.
+
 ## First Android community release — 2026-09-07
 
 `v0.4.10-android.1` promotes the Preview 15 native runtime accepted by the owner

--- a/docs/artifacts/2026-09-07/macos-v0411-release.md
+++ b/docs/artifacts/2026-09-07/macos-v0411-release.md
@@ -1,0 +1,56 @@
+# macOS 0.4.11 release verification
+
+PR #98 merged at `0c700618e91eda0eac86cd134e3130c8f4fc37a0`. The annotated
+`v0.4.11-macos.1` tag records that exact source; existing iPhone/iPad and Android
+tags are unchanged. The Mac app is 0.4.11/build 26, ARM64, macOS 14+.
+
+## Native build and local smoke
+
+Fresh source preparation applied the pinned runtime patch stack and credited
+issue #94 backport, then compiled both Original and Retro Rewind profiles.
+The linked `SCGetProductSN_HLE` contains numeric byte reversal and a four-byte
+store, with the guarded slow-write path. All 140 Python tests, repository safety
+checks and the native Apple subsystem smoke passed. No dependency pin was
+blindly advanced.
+
+An isolated portable copy used the owner's existing authorized extracted data.
+Original reached the Wii startup and animated title screen. The on-screen
+counter read about 60 FPS; presentation samples were generally 59–60 FPS after
+initial pipeline work. Non-silent PCM reached playback; telemetry recorded
+zero empty-before-push checks and four startup-dropped blocks, not a claim of
+zero audio drops. Native Command-Q exited with status 0. Installed save, Mii
+database and configuration checksums were unchanged before/after the smoke.
+
+The first smoke invocation mistakenly supplied a command-line profile option;
+the runtime rejected it as unsupported. Retrying normally, with no arguments,
+passed. No application code or audit was weakened to accommodate the test.
+This was an Original startup/normal-close check, not a fresh Retro Rewind race,
+production-online acceptance, controller hardware acceptance or long soak.
+
+## Exact package
+
+The post-merge build required no native recompilation. Candidate and final
+unsigned packaged runtime hashes matched:
+`d9ea55be400904d9c3ca106810241b8d0e2693cf2e29f31a98cdf2c9d90e0f68`.
+The final signed executable hash is
+`592463af4105364af176ab677c3173cd2ddebee9a7cfc61ae4962ddfb83c8562`.
+Its ad-hoc signature also seals the updated exact-source build fingerprint.
+
+- ZIP: `KartPad-v0.4.11-macos.1-arm64.zip`, **40,807,721 bytes**.
+- SHA-256: `a20d7c3ea6afcfe63352d48ffad077cc5b4c2e86c0e210b26460e1213a71f383`.
+
+Two independently packaged ZIPs matched. The extracted-package audit preserved
+the required runtime symlinks and passed strict deep codesign verification.
+The package contains pinned dependency notices, GPL text and exact-source
+provenance, but not the portable smoke state, raw logs, user-owned data, saves,
+account state or private signing material. The existing compiled-translated-logic
+publication boundary is unchanged.
+
+## Published and anonymously verified
+
+Only the Mac ZIP and SHA256SUMS were uploaded. Fresh unauthenticated downloads
+matched the local files, passed SHA256SUMS, and passed the full extracted-ZIP
+audit against the tagged commit, including strict deep signature verification.
+No older tag or asset was replaced. README, installation instructions and the
+maintainer's #94 response identify the corrected platform downloads and retain
+the old-tvOS/server-history limitations.

--- a/docs/releases/v0.4.11.md
+++ b/docs/releases/v0.4.11.md
@@ -34,10 +34,12 @@ profiles may need service-admin cleanup and collateral-ban review; changed-IP
 login can also encounter server identity checks. Do not delete saves, regenerate
 identities or create replacement accounts as a workaround.
 
-Existing iPhone/iPad downloads through v0.4.10 and the currently published Mac/
-tvOS binaries lack this fix. Keep those binaries offline until updated. The
-source correction is shared by all platforms, but this release rebuilds the
-iPhone/iPad IPA only; it does not claim that old Mac/tvOS packages are fixed.
+Existing iPhone/iPad downloads through v0.4.10, Mac v0.4.9 and the old tvOS
+binary lack this fix. Keep those binaries offline until updated. The corrected
+Mac rebuild is now available in
+[v0.4.11-macos.1](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.11-macos.1).
+This release's IPA remains the original verified iPhone/iPad artifact; the
+follow-up Mac build has its own exact-source tag. Old tvOS still needs rebuilding.
 
 ## Content and validation boundary
 


### PR DESCRIPTION
Record completed Mac hosted-download, extracted-signature and isolated launch/close verification; link all three corrected platform packages prominently in README. Update the iPhone/iPad release notes with the now-published Mac follow-up and close the completed checklist rows. Preserve the explicit old-tvOS, existing server-history and fresh hardware-testing limits. Documentation only; release tags and packaged bytes remain unchanged. All 140 Python tests and repository safety audit pass.