### PR TITLE
Track confirmed Retro Rewind save-transfer request

### DIFF
--- a/docs/KNOWN-ISSUES.md
+++ b/docs/KNOWN-ISSUES.md
@@ -7,7 +7,7 @@ steps. Open reports are not treated as verified root causes.
 
 | Issue | Current boundary / next evidence |
 | --- | --- |
-| [#105](https://github.com/chrissotraidis/kartpad/issues/105) save location/transfer | Original save transfer already exists on Android; its guide incorrectly implied both profiles. Retro Rewind profile-aware backup/restore remains missing. Source app/region/profile requested. |
+| [#105](https://github.com/chrissotraidis/kartpad/issues/105) save location/transfer | Reporter confirmed PC WiiCompiled → Android KartPad, Retro Rewind/PAL on both. This needs profile-aware save import/export, including the separate-save option; no logs are needed to establish the missing feature. Current Android picker targets only Original. Implementation and transfer acceptance remain open. |
 | [#102](https://github.com/chrissotraidis/kartpad/issues/102), [#104](https://github.com/chrissotraidis/kartpad/issues/104) Android geometry/textures | Device/OS/build, repeat 1x/4:3 scene, renderer startup/errors requested. Working S25+ report prevents a blanket Adreno-failure conclusion. |
 | [#103](https://github.com/chrissotraidis/kartpad/issues/103) Android frame drops | Reporter improved behavior after changing Game Booster+ mode and resolution. Same-mode, same-scene resolution comparison and phase/thermal excerpts requested. |
 | [#101](https://github.com/chrissotraidis/kartpad/issues/101) Fill Screen distortion | 16:9/4:3 fallback; paired scene screenshots and technical report requested. Shared projection correction needs reproduction and cross-platform checks. |

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -26,9 +26,11 @@ Root access is not needed for the built-in Original save transfer:
 **Current limit:** Android `0.4.10-android.1` Manage Saves always targets the
 Original PAL save, even when opened while playing Retro Rewind. It does not
 export or restore Retro Rewind's separate save files. Do not use it expecting
-a Retro Rewind migration. If that is your goal, say so in
-[#105](https://github.com/chrissotraidis/kartpad/issues/105); explicit profile
-selection and separate-save backup/restore still need implementation and tests.
+a Retro Rewind migration. The confirmed PC WiiCompiled → Android KartPad
+Retro Rewind/PAL transfer is tracked in
+[#105](https://github.com/chrissotraidis/kartpad/issues/105). Explicit profile
+selection and separate-save backup/restore still need implementation and tests;
+there is no supported Retro Rewind transfer route in the current APK.
 
 The importer accepts a raw 2,867,200-byte `RKSD0006` save with a valid core
 checksum. That validation does not prove cross-region, cross-mod, or online


### PR DESCRIPTION
The reporter in #105 confirmed a PAL Retro Rewind save transfer from WiiCompiled on PC to KartPad on Android. Update the support guide and issue ledger so this is tracked as missing profile-aware save import/export rather than awaiting source/profile clarification or logs.

The existing Android picker still targets Original only. No feature build or transfer compatibility is claimed. Documentation-only change; checked the implementation paths and `git diff --check`.
