### PR TITLE
Extend renderer diagnostics to indexed draws and queued updates

### DIFF
--- a/docs/artifacts/2026-09-08/android-renderer-investigation.md
+++ b/docs/artifacts/2026-09-08/android-renderer-investigation.md
@@ -92,3 +92,28 @@ KartPad itself is untouched. The latest game release remains `v0.4.11`.
 Reporters in #102 and #104 received the link and a Run/Share request. #102
 returned the passing Adreno results above; #104 is still pending. No issue was closed and no playable APK/IPA
 was released by this investigation.
+
+## Graphics-stage follow-up in source 0.2.0
+
+After #102's passing compute result, the separate diagnostic now adds four
+indexed-draw variants alongside the original four compute variants. Each draw
+variant compares 4,096 channel values over four queued frames, exercising packed
+vertex indices, signed positions, the current 80-byte uniform prefix, 20 indexed
+position matrices, dynamic uniform offsets, RGBA8 texture loads and shared
+buffer/texture updates. The detailed scope is in the probe README.
+
+- Mac M3 Max / Metal: all eight variants pass, 32,768 comparisons total.
+- API 36 ARM64 emulator / host Vulkan: the release-signed 0.2.0 candidate passes
+  all eight variants. Run and Share Results work; the sharesheet includes all
+  results and no destination was selected.
+- Negative control: a private copy deliberately flips one red-channel bit in
+  the fragment shader. All four draw variants fail with 1,024 mismatches each;
+  compute variants still pass, and the CLI exits 1.
+- Android CLI and release APK compile. Standalone APK audit passes. The physical
+  Pixel disconnected before this expanded probe could be run; the earlier
+  Pixel result applies only to version 0.1.0's compute tests.
+
+These are synthetic graphics stages, not a replay of GX-generated game shaders,
+compressed textures, actual staging-buffer use, multithreaded encoding or
+presentation. No renderer correction is claimed. Version 0.2.0 publication and
+affected-device results remain pending at this source checkpoint.

--- a/tools/renderer-probe/README.md
+++ b/tools/renderer-probe/README.md
@@ -19,15 +19,16 @@ Open **KartPad Renderer Check**, tap **Run GPU Check**, then **Share Results**.
 Keep the app open during the test. Post the text to the relevant issue after
 reviewing it. Include whether Original, Retro Rewind, or both show corruption.
 
-Four variants compare 4,096 values each against an independent CPU decoder:
+In source version 0.2.0, four compute variants and four indexed-draw variants
+compare 4,096 values each against independent CPU expectations (32,768 total):
 
 - Scalar uniform array, bounds protection disabled.
 - Vector-packed uniform array, bounds protection disabled.
 - Scalar uniform array, bounds protection enabled.
 - Vector-packed uniform array, bounds protection enabled.
 
-WebGPU validation remains enabled in every variant. Each uses a fresh adapter
-and device; the selected backend is Vulkan on Android and Metal on macOS.
+WebGPU validation remains enabled in every variant. Each robustness mode uses a
+fresh adapter and device; the selected backend is Vulkan on Android and Metal on macOS.
 Software adapters are rejected before device creation because the pinned Dawn
 library aborts in its SwiftShader device-toggle setup. There is no fallback
 to a different graphics backend. GPU callbacks have a
@@ -49,9 +50,18 @@ Field numbers in a mismatch report mean:
 | 12–14 | matrix transform components |
 | 15 | big-endian finite float |
 
-A pass only validates these synthetic compute cases. It does not validate the
-vertex/fragment stages, textures, actual GX draw streams, buffer reuse,
-presentation, frame pacing, or gameplay on that device. A mismatch is evidence
+The new draw variants issue indexed triangles through vertex and fragment stages.
+They use separate packed vertex-index and attribute storage buffers, signed
+big-endian positions, the current Aurora 80-byte uniform prefix, 20 indexed
+position matrices, dynamic uniform offsets, RGBA8 textures, and four queued
+updates of shared buffers/textures before readback. The CPU expects one
+independently computed RGBA pixel per quad. Reports distinguish compute lines
+from `draw` lines and include the failed phase/pixel/channel when applicable.
+
+A pass validates only these synthetic cases. It does not validate actual GX
+draw streams/generated game shaders, compressed textures, the renderer's
+staging buffers or multithreaded lifetime, presentation, frame pacing, or
+gameplay on that device. A mismatch is evidence
 for a smaller follow-up case, not automatic proof of a driver bug. Error reports
 are distinct from value mismatches.
 

--- a/tools/renderer-probe/android/build.gradle.kts
+++ b/tools/renderer-probe/android/build.gradle.kts
@@ -7,8 +7,8 @@ android {
         applicationId = "dev.kartpad.rendererprobe"
         minSdk = 28
         targetSdk = 36
-        versionCode = 1
-        versionName = "0.1.0"
+        versionCode = 2
+        versionName = "0.2.0"
         ndk { abiFilters += "arm64-v8a" }
         externalNativeBuild { cmake { arguments += listOf(
             "-DANDROID_STL=c++_static",

--- a/tools/renderer-probe/android/src/main/java/dev/kartpad/rendererprobe/ProbeActivity.java
+++ b/tools/renderer-probe/android/src/main/java/dev/kartpad/rendererprobe/ProbeActivity.java
@@ -23,7 +23,7 @@ public final class ProbeActivity extends Activity {
         int pad = Math.round(24 * getResources().getDisplayMetrics().density);
         content.setPadding(pad, pad, pad, pad);
         TextView explanation = new TextView(this);
-        explanation.setText("KartPad Renderer Check\n\nTests synthetic vertex data and matrix layouts. This separate app does not read KartPad, game files, saves, or identifiers. A pass does not prove gameplay works.\n");
+        explanation.setText("KartPad Renderer Check\n\nTests synthetic packed data, indexed draws, matrix layouts, textures, and queued buffer updates. This separate app does not read KartPad, game files, saves, or identifiers. A pass does not prove gameplay works.\n");
         content.addView(explanation);
         Button run = new Button(this); run.setText("Run GPU Check"); content.addView(run);
         Button share = new Button(this); share.setText("Share Results"); share.setEnabled(false); content.addView(share);

--- a/tools/renderer-probe/audit_apk.py
+++ b/tools/renderer-probe/audit_apk.py
@@ -14,7 +14,7 @@ a = p.parse_args()
 sdk = Path(os.environ.get('ANDROID_HOME', Path.home() / 'Library/Android/sdk'))
 bt = sdk / 'build-tools/36.0.0'
 badging = subprocess.check_output([bt/'aapt2', 'dump', 'badging', a.apk], text=True)
-assert "name='dev.kartpad.rendererprobe' versionCode='1' versionName='0.1.0'" in badging
+assert "name='dev.kartpad.rendererprobe' versionCode='2' versionName='0.2.0'" in badging
 assert "native-code: 'arm64-v8a'" in badging
 assert 'application-debuggable' not in badging and 'uses-permission' not in badging
 subprocess.run([bt/'zipalign', '-c', '-P', '16', '4', a.apk], check=True)

--- a/tools/renderer-probe/draw_probe.h
+++ b/tools/renderer-probe/draw_probe.h
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Synthetic graphics-stage companion. Included inside probe.cpp's anonymous namespace.
+void drawProbe(wgpu::Instance instance, wgpu::Device device, Errors& errors,
+               bool robustness, bool packed, std::ostringstream& report) {
+    constexpr unsigned width=16, vertices=width*width*4, phases=4, rowBytes=256;
+    constexpr unsigned attributeBlock=vertices*8, prefix=256;
+    constexpr unsigned uniformBytes=80+20*48;
+    wgpu::Limits limits{}; device.GetLimits(&limits);
+    const unsigned uniformStride=((uniformBytes+limits.minUniformBufferOffsetAlignment-1)/limits.minUniformBufferOffsetAlignment)*limits.minUniformBufferOffsetAlignment;
+    auto queue=device.GetQueue();
+    auto vertex=buffer(device,prefix+vertices*4,wgpu::BufferUsage::Storage|wgpu::BufferUsage::CopyDst);
+    auto attributes=buffer(device,prefix+12*attributeBlock,wgpu::BufferUsage::Storage|wgpu::BufferUsage::CopyDst);
+    auto uniform=buffer(device,2*uniformStride,wgpu::BufferUsage::Uniform|wgpu::BufferUsage::CopyDst);
+    auto indices=buffer(device,width*width*6*2,wgpu::BufferUsage::Index|wgpu::BufferUsage::CopyDst);
+    std::vector<uint8_t> vertexData(prefix+vertices*4), attributeData(prefix+12*attributeBlock);
+    std::vector<uint16_t> indexData;
+    std::array<uint32_t,uniformBytes/4> uniformData{};
+    uniformData[0]=prefix;
+    for(unsigned slot=0;slot<12;++slot) uniformData[8+slot]=prefix+slot*attributeBlock;
+    for(unsigned m=0;m<20;++m) {
+        // Match Aurora's vec4(position,1) * mat3x4 convention.
+        uniformData[20+m*12]=std::bit_cast<uint32_t>(1.f);
+        uniformData[20+m*12+3]=std::bit_cast<uint32_t>(float(m*32)/256.f);
+        uniformData[20+m*12+5]=std::bit_cast<uint32_t>(1.f);
+        uniformData[20+m*12+7]=std::bit_cast<uint32_t>(float(m*16)/256.f);
+    }
+    for(unsigned cell=0;cell<width*width;++cell) {
+        const unsigned v=cell*4;
+        for(unsigned n : {0u,1u,2u,2u,1u,3u}) indexData.push_back(uint16_t(v+n));
+        for(unsigned corner=0;corner<4;++corner) {
+            const unsigned index=v+corner, off=prefix+index*4;
+            vertexData[off]=uint8_t(index>>8); vertexData[off+1]=uint8_t(index);
+            vertexData[off+2]=uint8_t(cell%20);
+        }
+    }
+    queue.WriteBuffer(vertex,0,vertexData.data(),vertexData.size());
+    queue.WriteBuffer(indices,0,indexData.data(),indexData.size()*2);
+    wgpu::TextureDescriptor td{.usage=wgpu::TextureUsage::RenderAttachment|wgpu::TextureUsage::CopySrc,
+        .size={width,width,1},.format=wgpu::TextureFormat::RGBA8Unorm};
+    auto target=device.CreateTexture(&td);
+    td.usage=wgpu::TextureUsage::TextureBinding|wgpu::TextureUsage::CopyDst;
+    auto texture=device.CreateTexture(&td);
+    std::string code=kHelpers;
+    code+=R"WGSL(
+struct Uniform {
+ vtx_start: u32, current_pnmtx: u32,
+ render_viewport_size: vec2f, logical_viewport_size: vec2f, pad: vec2u,
+ array_start: )WGSL";
+    code+=packed ? "array<vec4u,3>" : "array<u32,12>";
+    code+=R"WGSL(, postex_mtx: array<mat3x4f,20>,
+};
+@group(0) @binding(0) var<storage,read> vbuf: array<u32>;
+@group(0) @binding(1) var<storage,read> abuf: array<u32>;
+@group(1) @binding(0) var<uniform> ubuf: Uniform;
+@group(2) @binding(0) var tex: texture_2d<f32>;
+struct VertexOutput {
+ @builtin(position) pos: vec4f,
+ @location(0) @interpolate(flat) color: vec4u,
+ @location(1) @interpolate(flat) cell: u32,
+};
+@vertex fn vs_main(@builtin(vertex_index) vidx: u32) -> VertexOutput {
+ let base = ubuf.vtx_start + vidx * 4u;
+ let idx = load_u16(&vbuf, base, false);
+ let matrix = load_u8(&vbuf, base+2u);
+ let cell = vidx/4u;
+ let slot = cell%12u;
+ let arrayOffset = )WGSL";
+    code+=packed ? "ubuf.array_start[slot/4u][slot%4u];\n" : "ubuf.array_start[slot];\n";
+    code+=R"WGSL(
+ let off = arrayOffset + idx*8u;
+ let pos = fetch_s16_2(&abuf, off, 8u, false);
+ let transformed = vec4f(pos, 0.0, 1.0) * ubuf.postex_mtx[(matrix + ubuf.current_pnmtx)%20u];
+ var out: VertexOutput;
+ out.pos = vec4f(transformed, 1.0);
+ out.color = vec4u(round(fetch_rgba8(&abuf, off+4u, false)*255.0));
+ out.cell = cell;
+ return out;
+}
+@fragment fn fs_main(in: VertexOutput) -> @location(0) vec4f {
+ let pixel = vec2i(i32(in.cell%16u), i32(in.cell/16u));
+ let sampled = vec4u(round(textureLoad(tex, pixel, 0)*255.0));
+ return vec4f(in.color ^ sampled)/255.0;
+}
+)WGSL";
+    wgpu::ShaderSourceWGSL wgsl{}; wgsl.code=code.c_str();
+    wgpu::ShaderModuleDescriptor md{.nextInChain=&wgsl}; auto module=device.CreateShaderModule(&md);
+    std::array<wgpu::BindGroupLayoutEntry,2> storageLayout{};
+    for(unsigned i=0;i<2;++i) {
+        storageLayout[i].binding=i; storageLayout[i].visibility=wgpu::ShaderStage::Vertex;
+        storageLayout[i].buffer.type=wgpu::BufferBindingType::ReadOnlyStorage;
+    }
+    wgpu::BindGroupLayoutDescriptor ld{.entryCount=2,.entries=storageLayout.data()};
+    auto storageBL=device.CreateBindGroupLayout(&ld);
+    wgpu::BindGroupLayoutEntry ul{}; ul.visibility=wgpu::ShaderStage::Vertex;
+    ul.buffer.type=wgpu::BufferBindingType::Uniform; ul.buffer.hasDynamicOffset=true; ul.buffer.minBindingSize=uniformBytes;
+    ld.entryCount=1; ld.entries=&ul; auto uniformBL=device.CreateBindGroupLayout(&ld);
+    wgpu::BindGroupLayoutEntry tl{}; tl.visibility=wgpu::ShaderStage::Fragment;
+    tl.texture.sampleType=wgpu::TextureSampleType::Float; tl.texture.viewDimension=wgpu::TextureViewDimension::e2D;
+    ld.entries=&tl; auto textureBL=device.CreateBindGroupLayout(&ld);
+    std::array<wgpu::BindGroupLayout,3> layouts{storageBL,uniformBL,textureBL};
+    wgpu::PipelineLayoutDescriptor pld{.bindGroupLayoutCount=3,.bindGroupLayouts=layouts.data()};
+    wgpu::ColorTargetState colorTarget{.format=wgpu::TextureFormat::RGBA8Unorm};
+    wgpu::FragmentState fragment{.module=module,.entryPoint="fs_main",.targetCount=1,.targets=&colorTarget};
+    wgpu::RenderPipelineDescriptor pd{}; pd.layout=device.CreatePipelineLayout(&pld);
+    pd.vertex.module=module; pd.vertex.entryPoint="vs_main"; pd.fragment=&fragment;
+    pd.primitive.topology=wgpu::PrimitiveTopology::TriangleList;
+    auto pipeline=device.CreateRenderPipeline(&pd); errors.check();
+    std::array<wgpu::BindGroupEntry,2> storageEntries{};
+    storageEntries[0].buffer=vertex; storageEntries[0].size=vertexData.size();
+    storageEntries[1].binding=1; storageEntries[1].buffer=attributes; storageEntries[1].size=attributeData.size();
+    wgpu::BindGroupDescriptor bd{.layout=storageBL,.entryCount=2,.entries=storageEntries.data()};
+    auto storageBind=device.CreateBindGroup(&bd);
+    wgpu::BindGroupEntry ue{}; ue.buffer=uniform; ue.size=uniformBytes;
+    bd.layout=uniformBL; bd.entryCount=1; bd.entries=&ue; auto uniformBind=device.CreateBindGroup(&bd);
+    wgpu::BindGroupEntry te{}; te.textureView=texture.CreateView();
+    bd.layout=textureBL; bd.entries=&te; auto textureBind=device.CreateBindGroup(&bd);
+    std::array<wgpu::Buffer,phases> readbacks;
+    std::array<std::vector<uint8_t>,phases> wanted;
+    for(unsigned phase=0;phase<phases;++phase) {
+        std::vector<uint8_t> textureData(width*width*4);
+        wanted[phase].resize(width*width*4);
+        for(unsigned cell=0;cell<width*width;++cell) {
+            const std::array<uint8_t,4> color{uint8_t(cell*17+phase*29),uint8_t(cell*37+phase*7),uint8_t(cell*73+phase*3),255};
+            for(unsigned channel=0;channel<4;++channel) {
+                const uint8_t texel=channel==3 ? 0 : uint8_t(cell*(channel+3)+phase*11);
+                textureData[cell*4+channel]=texel; wanted[phase][cell*4+channel]=color[channel]^texel;
+            }
+            for(unsigned corner=0;corner<4;++corner) {
+                const int x=int(cell%16)*32-256+int(corner%2)*32-int((cell+phase)%20)*32;
+                const int y=256-int(cell/16)*32-int(corner/2)*32-int((cell+phase)%20)*16;
+                const unsigned off=prefix+(cell%12)*attributeBlock+(cell*4+corner)*8;
+                attributeData[off]=uint8_t(x>>8); attributeData[off+1]=uint8_t(x);
+                attributeData[off+2]=uint8_t(y>>8); attributeData[off+3]=uint8_t(y);
+                std::memcpy(attributeData.data()+off+4,color.data(),4);
+            }
+        }
+        uniformData[1]=phase; // Different contents make a wrong dynamic offset observable.
+        const uint32_t dynamicOffset=(phase%2)*uniformStride;
+        queue.WriteBuffer(attributes,0,attributeData.data(),attributeData.size());
+        queue.WriteBuffer(uniform,dynamicOffset,uniformData.data(),sizeof(uniformData));
+        wgpu::TexelCopyTextureInfo textureDest{.texture=texture};
+        wgpu::TexelCopyBufferLayout textureLayout{.bytesPerRow=width*4,.rowsPerImage=width};
+        wgpu::Extent3D extent{width,width,1}; queue.WriteTexture(&textureDest,textureData.data(),textureData.size(),&textureLayout,&extent);
+        auto encoder=device.CreateCommandEncoder();
+        wgpu::RenderPassColorAttachment ca{}; ca.view=target.CreateView(); ca.loadOp=wgpu::LoadOp::Clear; ca.storeOp=wgpu::StoreOp::Store;
+        wgpu::RenderPassDescriptor rp{.colorAttachmentCount=1,.colorAttachments=&ca}; auto pass=encoder.BeginRenderPass(&rp);
+        pass.SetPipeline(pipeline); pass.SetBindGroup(0,storageBind); pass.SetBindGroup(1,uniformBind,1,&dynamicOffset); pass.SetBindGroup(2,textureBind);
+        pass.SetIndexBuffer(indices,wgpu::IndexFormat::Uint16); pass.DrawIndexed(width*width*6); pass.End();
+        readbacks[phase]=buffer(device,rowBytes*width,wgpu::BufferUsage::CopyDst|wgpu::BufferUsage::MapRead);
+        wgpu::TexelCopyTextureInfo source{.texture=target};
+        wgpu::TexelCopyBufferInfo destination{.layout={.bytesPerRow=rowBytes,.rowsPerImage=width},.buffer=readbacks[phase]};
+        encoder.CopyTextureToBuffer(&source,&destination,&extent);
+        auto commands=encoder.Finish(); queue.Submit(1,&commands); errors.check();
+    }
+    unsigned failures=0;
+    for(unsigned phase=0;phase<phases;++phase) {
+        auto mapped=std::make_shared<bool>(false);
+        wait(instance,readbacks[phase].MapAsync(wgpu::MapMode::Read,0,rowBytes*width,wgpu::CallbackMode::WaitAnyOnly,
+            [mapped](wgpu::MapAsyncStatus status,wgpu::StringView){*mapped=status==wgpu::MapAsyncStatus::Success;}));
+        errors.check(); require(*mapped,"Draw readback failed");
+        const auto* actual=static_cast<const uint8_t*>(readbacks[phase].GetConstMappedRange());
+        for(unsigned y=0;y<width;++y) for(unsigned x=0;x<width*4;++x) {
+            const auto expected=wanted[phase][y*width*4+x], got=actual[y*rowBytes+x];
+            if(expected!=got && failures++<8) report<<"Draw mismatch phase="<<phase<<" pixel="<<y*width+x/4<<" channel="<<x%4<<" expected="<<unsigned(expected)<<" actual="<<unsigned(got)<<"\n";
+        }
+        readbacks[phase].Unmap();
+    }
+    report<<(failures?"FAIL":"PASS")<<" draw robustness="<<robustness<<" uniform="<<(packed?"vec4":"scalar")
+          <<" frames="<<phases<<" checks="<<phases*width*width*4<<" mismatches="<<failures<<"\n";
+}

--- a/tools/renderer-probe/probe.cpp
+++ b/tools/renderer-probe/probe.cpp
@@ -37,6 +37,7 @@ wgpu::Buffer buffer(wgpu::Device device, size_t size, wgpu::BufferUsage usage) {
     wgpu::BufferDescriptor desc{.usage = usage, .size = size};
     return device.CreateBuffer(&desc);
 }
+#include "draw_probe.h"
 std::string shader(bool packed) {
     std::string s = kHelpers;
     s += "\nstruct Uniform { head: vec4u, offsets: ";
@@ -176,12 +177,16 @@ void run(wgpu::Instance instance, wgpu::Adapter adapter, bool robustness, std::o
         report<<"ERROR robustness="<<robustness<<" uniform="<<(packed?"vec4":"scalar")<<": "<<e.what()<<"\n";
       }
     }
+    for (bool packed : {false, true}) {
+        try { drawProbe(instance, device, *errors, robustness, packed, report); }
+        catch (const std::exception& e) { report<<"ERROR draw robustness="<<robustness<<" uniform="<<(packed?"vec4":"scalar")<<": "<<e.what()<<"\n"; }
+    }
     queue={}; device.Destroy();
 }
 std::string diagnose() {
     std::ostringstream report;
-    report<<"KartPad synthetic renderer probe 1\nHelper SHA256: "<<kHelperSha<<"\n";
-    report<<"No game data read. Validation enabled. Compute readback; not gameplay acceptance.\n";
+    report<<"KartPad synthetic renderer probe 2\nHelper SHA256: "<<kHelperSha<<"\n";
+    report<<"No game data read. Validation enabled. Compute and indexed-draw readback; not gameplay acceptance.\n";
     try {
         const auto feature=wgpu::InstanceFeatureName::TimedWaitAny;
         wgpu::InstanceDescriptor desc{.requiredFeatureCount=1,.requiredFeatures=&feature};


### PR DESCRIPTION
The affected Adreno in #102 passes the existing compute checks. Extend Renderer Check to cover indexed vertex/fragment draws, the current Aurora uniform prefix, phase-dependent indexed matrix transforms and aligned dynamic offsets, RGBA8 textures, and queued updates to shared GPU resources. Keep the original checks and report draw failures separately. Version the separate diagnostic app as 0.2.0/code 2.

Validation: eight variants pass on Mac Metal and the signed Android candidate on API 36 emulator Vulkan (32,768 comparisons each); a private negative control flipping one fragment red-channel bit fails every draw variant with 1,024 mismatches while compute stays passing; Android CLI/APK compile, APK contents/signature/alignment audit, Run/Share UI, and repository tests. Physical Pixel disconnected before the new test ran. No game files or identifiers are read.

This remains a synthetic investigation tool, with no graphics fix or actual GX/gameplay acceptance claim. Publication and affected-device results remain pending. References #102 and #104.
