### PR TITLE
Verify stripped DiscIO library for Android release packaging

### DIFF
--- a/docs/artifacts/2026-09-08/android-import-storage-errors.md
+++ b/docs/artifacts/2026-09-08/android-import-storage-errors.md
@@ -44,3 +44,11 @@ with its extraction-failure message and removed the new staging tree. The
 entire prior GameData tar digest remained identical before and after both
 failed replacements. The injected filler was removed immediately afterward.
 All 140 Python tests and the repository safety audit pass.
+
+Release packaging distinguishes the JNI build output from the stripped APK
+library. Applying the pinned NDK's `llvm-strip --strip-unneeded` to the tested
+JNI output reproduces the packaged library SHA-256
+`0e5bd27501b1aee71db63364f0673682e0cca3c0234d560d4c54ac87e01c0d0b`.
+The notices packager checks that APK hash. The merged-source APK is byte-identical
+to the import-fixed emulator candidate and to a second signed derivation:
+`ce42a501c9e14d616e096511fc17329541fbc6e31dc2ab9e6d0f9066094b0c56`.

--- a/scripts/package-android-release-notices.py
+++ b/scripts/package-android-release-notices.py
@@ -16,7 +16,8 @@ VERSION = "0.4.12-android.1"
 CODE = 22
 # Exact rebuilt native libraries validated for this testing release.
 APPROVED_MAIN_SHA256 = "68af841be72ea90c1c9d43ae276afd0d3a2a150cee46906e6201c1ab1daf4b37"
-APPROVED_DISCIO_SHA256 = "694b9e41e7df429c060f0fbd740ecfe6bad987a3b77bc4f207bc180c9952370c"
+# APK libraries have Gradle release stripping applied.
+APPROVED_DISCIO_SHA256 = "0e5bd27501b1aee71db63364f0673682e0cca3c0234d560d4c54ac87e01c0d0b"
 REPO = Path(__file__).resolve().parents[1]
 
 


### PR DESCRIPTION
Correct the release packaging guard to compare the stripped APK DiscIO library, rather than its unstripped JNI build output. The guard correctly stopped packaging on that mismatch; no playable release had been published.

Applying the pinned NDK's `llvm-strip --strip-unneeded` to the tested JNI output reproduces the APK hash exactly. The merged-source signed APK matches both the validated emulator candidate and a second derivation byte-for-byte. This changes packaging metadata and evidence only.
