### PR TITLE
Clarify Retro save migration and record community follow-up evidence

### DIFF
--- a/docs/KNOWN-ISSUES.md
+++ b/docs/KNOWN-ISSUES.md
@@ -7,7 +7,7 @@ steps. Open reports are not treated as verified root causes.
 
 | Issue | Current boundary / next evidence |
 | --- | --- |
-| [#105](https://github.com/chrissotraidis/kartpad/issues/105) save location/transfer | Reporter confirmed PC WiiCompiled → Android KartPad, Retro Rewind/PAL on both. Profile-aware import/export is implemented in source for all three profiles, with isolated backups and recreation-safe picker targeting. Host fault/recovery tests and Android synthetic storage tests pass. [Android 0.4.12-android.1 testing APK](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.12-android.1) contains the fix; reporter transfer acceptance remains open. No further logs needed. |
+| [#105](https://github.com/chrissotraidis/kartpad/issues/105) save location/transfer | The [Android 0.4.12-android.1 testing APK](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.12-android.1) adds profile-aware raw-save transfer. Reporter restored the license but saw a missing Mii and online rating 5000. The picker omits Retro's separate `RRRating.pul` and the Mii database; login also synchronizes ratings. Source versions, companion-file existence and local same/different friend-code comparison requested. Complete migration is not accepted; companion transfer needs backups and profile matching. |
 | [#102](https://github.com/chrissotraidis/kartpad/issues/102), [#104](https://github.com/chrissotraidis/kartpad/issues/104) Android geometry/textures | Fold #102 supplied Vulkan/Adreno 840 driver 512.842.19 logs confirming 1x/4:3, both screen states, Retro Rewind 6.12.7. A [synthetic renderer probe](../tools/renderer-probe/README.md) tests packed decoding and uniform layouts; Mac Metal and physical Pixel Vulkan baselines pass. Adreno 840 (512.842.19) and Adreno 750 (512.762.39 / 512.762.41) all pass the compute checks; the reporter confirms matching Original corruption and no logged GPU errors. The expanded [0.2.0 diagnostic](https://github.com/chrissotraidis/kartpad/releases/tag/renderer-probe-v0.2.0) now tests synthetic indexed draws, textures and queued updates; the #104 reporter also passes all eight compute/draw checks on Adreno 750 / 512.762.41. Adreno 840 draw results remain open. #104 confirmed corruption at 1x/4:3 affecting drivers only, with vehicles/tracks correct; no more repeat logs are requested from that reporter. Character transforms and generated shaders need a failing-draw reproduction; #102’s road-texture symptom remains separate. No verified renderer correction. |
 | [#103](https://github.com/chrissotraidis/kartpad/issues/103) Android frame drops | Reporter improved behavior after changing Game Booster+ mode and resolution. Same-mode, same-scene resolution comparison and phase/thermal excerpts requested. |
 | [#101](https://github.com/chrissotraidis/kartpad/issues/101) Fill Screen distortion | 16:9/4:3 fallback; paired scene screenshots and technical report requested. Shared projection correction needs reproduction and cross-platform checks. |
@@ -17,6 +17,32 @@ steps. Open reports are not treated as verified root causes.
 | [#90](https://github.com/chrissotraidis/kartpad/issues/90) Wiimmfi | Open compatibility feature, no release commitment. Requires matching executable integration and private identity/authentication handling, not just a MAC/host field. |
 | [#5](https://github.com/chrissotraidis/kartpad/issues/5) Mii/Wii Remote | Shipped cursor/Mii work; reporter directed to current ready-made Mac download for remaining experimental Wii Remote/Nunchuk hardware results. |
 | [#92](https://github.com/chrissotraidis/kartpad/issues/92) licensing clarity | Correction already merged in #93; remains open for upstream author's review. No new unanswered follow-up at review time. |
+
+Latest renderer evidence: #104's video shows character corruption in both
+vehicle selection and the starting grid, before driving. #102's second device,
+Galaxy Tab S7 FE / Adreno 619, also passes all eight synthetic checks. Its
+Android 14 / 0.4.10 build logs confirm Retro at 1× / Fill Screen. The latest
+session ends after roughly 9 FPS with no captured termination reason; the sole
+fatal report is an earlier missing-DVD-root startup, followed by successful
+game loads. A same-scene 4:3 comparison and closed-versus-frozen distinction
+are requested. These are separate observations, not one established GPU bug.
+
+## macOS contribution under local review
+
+[#112](https://github.com/chrissotraidis/kartpad/pull/112) proposes controller
+assignment/profiles, trigger bindings, native settings and menu integration.
+The reviewed head builds and passes its package audit, focused host tests and
+basic local native UI checks. It is **not approved**: final analogue trigger
+pressure overwrites the proposed isolation, and the default Controllers tab
+clips its right-hand controls. A tested trigger correction is available for
+the contributor. See the [local review record](artifacts/2026-09-08/macos-pr112-review.md)
+for exact source and acceptance limits.
+
+Next work prioritizes completing this bounded controller fix and verifying
+save-migration companion data. Android character rendering needs an actual
+failing draw reproduction; synthetic passes are insufficient. Performance and
+external-display reports still need their requested comparisons. DSU and
+Wiimmfi remain independent feature work, not bugs blocked solely on logs.
 
 Profile-aware save management, reusable network-controller input, and any
 shared projection/service fixes need platform-specific UI and acceptance work.

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -31,7 +31,8 @@ Root access is not needed:
 even when opened while playing Retro Rewind. It does not export or restore Retro
 Rewind saves. Update to the testing build for that transfer; keep the PC copy and
 verify the resulting progress offline. The reporter's PC WiiCompiled → Android
-Retro Rewind/PAL acceptance remains open in
+Retro Rewind/PAL test restored the license, but its online rating showed 5000;
+complete migration acceptance remains open in
 [#105](https://github.com/chrissotraidis/kartpad/issues/105).
 
 **Profile selection:** Choose **Original Mario Kart Wii**, **Retro Rewind**, or
@@ -48,6 +49,17 @@ identity compatibility. A save transfer does not transfer the Mii database or
 console identity. If the source is Dolphin, another WiiCompiled build, or
 Retro Rewind, name it and the game region when asking for migration help.
 Never post the save or NAND publicly.
+
+**Retro Rewind ratings:** This picker transfers only `rksys.dat`. Retro Rewind
+also stores ratings in `RRRating.pul`, keyed by online profile, and synchronizes
+them during login. That companion file is not currently included in the transfer.
+A restored license therefore does not establish a complete Retro migration.
+If the rating differs, preserve the source save and Retro folder, stop rated
+races on the migrated copy, and report source/game versions and whether the
+friend code matches locally (only “same” or “different”; do not post the code).
+Do not edit ratings, regenerate identity, or publicly upload rating/Mii files.
+The missing companion file is a known gap; it does not by itself prove the
+cause of any particular server rating. See [#105](https://github.com/chrissotraidis/kartpad/issues/105).
 
 On Mac, **Data → Show KartPad Data** opens KartPad's support directory. Quit
 the game before backing it up. On Apple TV, use

--- a/docs/artifacts/2026-09-08/macos-pr112-review.md
+++ b/docs/artifacts/2026-09-08/macos-pr112-review.md
@@ -1,0 +1,49 @@
+# macOS PR #112 local review — 8 September 2026
+
+Reviewed contributor head `ab9561197ed44692884a80ade8d1b4ccc067ee46`
+from [aedanpilkington's PR #112](https://github.com/chrissotraidis/kartpad/pull/112).
+This is local acceptance work, not a release or merge approval.
+
+## Verified
+
+- Full ARM64 Original + Retro Rewind dual runtime built with the pinned
+  translation inputs. Package audit and strict local signature verification passed.
+- Assignment/cached-index, native settings bridge, controller-profile and
+  virtual-input tests passed, including unreadable-profile preservation.
+- Settings shortcut host test passed.
+- An isolated app copy with separate bundle identifier, portable data and
+  networking disabled reached the Original title screen with locally owned data.
+  Cmd-comma and F10 opened native settings. All five tabs opened; graphics/audio
+  changes persisted to the isolated configuration and were reflected on reopening
+  the panel. Compatibility Tools opened the intended legacy overlay.
+
+The original audited app's unsigned runtime SHA-256 is
+`ca5a83528da0d96f7c9bfeb73194f4906a1a2b56bd396651c26151b940042796`.
+The later trigger-corrected runtime is a different local artifact.
+
+## Required corrections
+
+1. Trigger-axis isolation clears `PADStatus.triggerLeft/Right` before subsequent
+   assignments overwrite them. A fully pressed RT still outputs 255 with an
+   explicit Drift button binding. The [review](https://github.com/chrissotraidis/kartpad/pull/112#pullrequestreview-5137141071)
+   requests changes. Local correction zeros `tl/tr` before final assignment.
+   `scripts/test-macos-trigger-output.py` compiles the prepared runtime's actual
+   trigger block and verifies 200 combinations of both bindings, both axes and
+   trigger emulation. It fails against the contributor head and passes with the
+   correction. Corrected Original and dual executables rebuild successfully.
+   Correction commit: `9b3ea0b` on `codex/pr112-local-validation`.
+2. At the default native settings size, the Controllers tab clips the rightmost
+   Clear buttons. The document's fixed width and mapping columns need to fit
+   the visible scroll viewport or provide suitable scrolling/resizing behavior.
+
+## Remaining acceptance
+
+No physical controller was connected for these checks. Cold launch with a pad
+already connected, hotplug/reconnect, both trigger bindings in a race, profile
+restore across app launches, multiple controllers, full-screen transitions and
+Retro Rewind gameplay still require acceptance. A dual compile does not prove
+those paths. No contributor build has been approved, merged or released here.
+
+Recheck the final contributor head against current main before integration;
+retain contributor attribution. Source-local build notes are not a substitute
+for a portable upstream support guide.


### PR DESCRIPTION
A restored Retro Rewind license does not establish complete migration: the raw-save picker omits the separate rating file and Mii database. Document that limitation and the safe comparison requested in #105.

Record new #102 tablet diagnostics, #104 pre-race character corruption, and PR #112 local acceptance evidence. The macOS contribution remains unapproved; its trigger correction is on a separate contributor-facing branch.

Validation: documentation diff and local links checked. The linked macOS evidence distinguishes full dual compilation, native settings checks and 200 trigger-output cases from outstanding physical-controller/gameplay acceptance. No private archives or game data are included.
