### PR TITLE
Track maintenance delivery and require Medium engineering workers

### DIFF
--- a/docs/MAINTENANCE-BOARD.md
+++ b/docs/MAINTENANCE-BOARD.md
@@ -1,0 +1,44 @@
+# Maintenance work and test board
+
+Snapshot: 8 September 2026. Refresh GitHub and active work before claiming a task.
+This is the tracked coordination index, not a claim that all local work is merged.
+See [workflow](MAINTENANCE.md), [known issues](KNOWN-ISSUES.md) and their evidence links.
+Private artifact paths and task identifiers belong in the local maintenance files.
+
+## Ready work and dependencies
+
+| Workstream | State / owner role | Next action and completion condition | Platform boundary |
+| --- | --- | --- | --- |
+| #105 rating companion restore | Local implementation corrected; Medium review next | Independently review correction 5652a7f, especially silent publication failures and custom NAND refusal; then integrate through PR and rebuild a corrected candidate | Android implementation; real-save acceptance pending, Apple parity not implemented |
+| #123 online stalls and Pixel performance | Local investigation / owner device comparison | Separate online-menu waits from general CPU/thermal slowdown; use comparable scene/settings/temperature and existing profiling | Android; no proven freeze fix or FPS improvement percentage |
+| #102/#104/#120 rendering | Ready investigation | Medium worker narrows actual failing character draw using supplied validation results and bounded draw diagnostics; record a discriminating result | Adreno evidence; do not infer same cause on Mali or macOS |
+| #128 cup crash, #119 bars | Await specific reporter evidence | Process exact end-of-cup transition/exit excerpt and separate display/bar lifecycle result | AYN Thor Retro report; Original/all-device scope unconfirmed |
+| PR #112 controller/keyboard work | Contributor changes requested | Review changes after d18d3e6 for capture cancellation and physical-scancode mapping; run regression checks before new-head acceptance | macOS; owner/Retro acceptance pending |
+| #127 two-player rendering | Await same-scene comparison | Compare main and PR source with equivalent settings before attribution | macOS Original; no demonstrated shared Android root cause |
+| #100 external displays | Accepted work; source investigation can proceed | Assign one bounded scene/surface transition investigation; pair with specified device/adapter test | iPhone/iPad and Android separately; wired first, then wireless |
+| Report context/provenance | Local implementation / integration review | Review current source fingerprints and package evidence, then integrate with explicit platform limits | Android and iPhone/iPad; physical Apple share tests remain |
+| Other support/features | See known-issues index | Address new evidence for #103/#101/#5/#92; scope DSU #91 and Wiimmfi #90 separately | Record macOS/iOS/iPadOS/Android/tvOS applicability individually |
+
+Use one owner per task and keep ready, active, awaiting review, awaiting device,
+merged, and released distinct. New replies are not required to work on ready items.
+
+## Build and test-request ledger
+
+Update a row when a candidate is prepared, superseded, requested, tested or rejected.
+Each actual candidate record must include source SHA, version, artifact SHA-256,
+target machines, test evidence, request link/date, outcome and next action. Keep
+local artifact locations in `build/maintenance/CURRENT.md`; never imply they are
+public downloads. Link full provenance records instead of copying raw diagnostics.
+
+| Candidate / work | Current disposition | Test request / next step |
+| --- | --- | --- |
+| Android public v0.4.12-android.2 / code 23 | Published diagnostic beta, not a verified graphics/cup-crash fix | Existing issue threads hold off/on results and pending crash/bar evidence. No repetitive requests |
+| Local Android rating/performance/provenance candidates | Integration review; older packages do not contain 5652a7f safety correction | Do not offer rating restore from older packages. Medium review and corrected-source build precede named owner tests; preserve existing Pixel comparison |
+| Local macOS 0.4.12/build 27 at 271fdc1 | Historical candidate; later PR head adds keyboard behavior | Contributor hardware results apply to exact tested commits; resolve newer review findings before declaring a replacement ready |
+| iPhone/iPad test IPA | No new candidate declared ready here | Build/audit locally when a concrete change warrants device testing; ask owner with precise steps. Scheduled job never publishes IPA |
+| tvOS | No new candidate declared ready here | Track applicable shared changes and experimental device acceptance separately |
+
+A pending request is not acceptance. When results arrive, link them and record
+whether they support the fix, reject it, or require a different experiment.
+Do not close a report solely because a candidate exists. Local tests, owner
+acceptance, reporter confirmation and public availability are separate states.

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -5,8 +5,24 @@ testable builds. Reply counts, new diagnostics, commits and elapsed hours alone
 are not success measures. A run should reduce a specific uncertainty, complete
 a useful implementation/test step, or identify the exact dependency that stops it.
 
+## Coordinator and engineering roles
+
+Astra Light owns triage, prioritization, public replies, work tracking and
+coordination. Substantive debugging, implementation, code review, regression
+testing and candidate build/validation are assigned to bounded Astra Medium
+workers. Routine documentation and metadata updates can stay with the coordinator.
+Use at most two temporary workers concurrently; reuse existing work owners and
+collect their results. Workers do not spawn further workers or publish releases.
+If Medium is unavailable, record the capacity blocker and continue useful light
+triage; do not silently substitute Light for deep engineering or claim it finished.
+
+The coordinator checks the evidence before integration and owns public communication.
+A worker saying “done” is a review handoff, not automatic merge/release acceptance.
+
 ## Records and ownership
 
+- [Maintenance board](MAINTENANCE-BOARD.md): canonical public work queue and
+  build/test-request ledger. Keep current rows updated; link evidence for history.
 - [Known issues](KNOWN-ISSUES.md): public issue/theme index, confirmed evidence,
   current limits and next evidence. Link source comments and investigation records.
 - [Investigation records](artifacts/): dated reproduction, experiment, review and
@@ -18,7 +34,8 @@ a useful implementation/test step, or identify the exact dependency that stops i
 - Local `build/maintenance/CURRENT.md`: compact active work board with one owner,
   source/branch, state, next action and completion condition per workstream.
   Local `build/maintenance/HANDOFF.md`: retained historical context and paths.
-  Both are ignored and must not be the only record of merged technical findings.
+  Both are ignored supplements for machine-specific ownership/artifact paths.
+  They do not replace the tracked maintenance board or public technical records.
 
 Never commit raw private logs, saves, identities, credentials or game assets.
 Summarize reviewed evidence publicly; retain private artifact references locally.
@@ -80,7 +97,22 @@ owner/device accepted, reporter confirmed, released. A local source fix is not a
 publicly available fix. A candidate needs a concrete test purpose and exact
 source/artifact identity, platform requirements, acceptance limits and test steps.
 Batch compatible reviewed work where useful; do not build a new package on every
-hourly check. Do not publish a formal IPA before Christopher tests and approves it.
+hourly check. The scheduled coordinator and its workers MUST NEVER upload or
+publish an IPA, including a prerelease, release asset or distribution-feed update.
+They may build and audit an IPA locally and ask Christopher to test it. Any later
+IPA publication requires a separate explicitly authorized manual release task;
+passing owner tests does not authorize the scheduled job to publish it.
+
+When a candidate is ready, record its exact commit, version, hash, platform/device
+requirements, included changes, completed tests and remaining risks in the board.
+Ask the owner to test a local build with exact steps and a clear pass/fail question.
+For community testing, use an available, verified artifact appropriate for the
+reporter's device; do not link an inaccessible local path or announce an unbuilt
+version. Record the issue/comment, requested comparison, request date, response
+and next action. Never claim a build is “good” merely because it compiled.
+Android/macOS test distribution may follow the existing authorized release
+workflow after appropriate validation. The IPA prohibition remains absolute for
+scheduled work. Do not create automated reminder spam for pending test requests.
 
 ## Progress accounting
 


### PR DESCRIPTION
Make the coordinator/worker division explicit: Astra Light handles triage and tracking; bounded Astra Medium workers handle substantive engineering and validation. Add a tracked maintenance board and build/test-request ledger so local handoff history is not the only coordination record.

The scheduled job may prepare local test builds and request targeted owner/reporter tests, but must never publish an IPA—even after owner acceptance. Any publication requires a separate explicitly authorized manual task. No app behavior changes; documentation links and whitespace checked.
