### PR TITLE
Restore useful README FAQ and update Android technical debt

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ chooser, game-data management, packaging, and release workflows.
   <img alt="Android ARM64 with Vulkan" src="https://img.shields.io/badge/Android-ARM64%20%2F%20Vulkan-3DDC84?logo=android">
   <img alt="Ahead-of-time static recompilation" src="https://img.shields.io/badge/PowerPC-static%20recompilation-FF9F0A">
   <img alt="macOS development target" src="https://img.shields.io/badge/macOS%20target-14%2B-0A84FF">
-  <img alt="iPhone and iPad physical builds accepted" src="https://img.shields.io/badge/iPhone%20%2F%20iPad-physical%20builds%20accepted-30D158">
+  <img alt="iPhone and iPad preview" src="https://img.shields.io/badge/iPhone%20%2F%20iPad-preview-FF9F0A">
   <img alt="Retro Rewind supported" src="https://img.shields.io/badge/Retro%20Rewind-6.12.7-FF375F">
   <img alt="Game data not included" src="https://img.shields.io/badge/game%20data-not%20included-FF453A">
 </p>
@@ -64,6 +64,8 @@ Private Android previews use a different signer and need a backed-up migration.
 
 ## Playing
 
+[Frequently asked questions](#frequently-asked-questions) · [Controls](docs/MULTIPLAYER.md) · [Save transfer and troubleshooting](docs/SUPPORT.md)
+
 - Choose **Mario Kart Wii** or **Retro Rewind** when KartPad opens. Retro
   Rewind 6.12.7 content installs separately; KartPad requires a matching native
   profile when the mod updates. Follow your platform's setup guide above.
@@ -86,6 +88,134 @@ Original remain unfinished. [Online status](docs/ONLINE.md) records the limits.
 Startup shader compilation, track-dependent dips and warm slowdown remain
 known issues. Android's suggested starting point is **1x Native**. Sustained
 60 FPS and external-display output are not generally verified.
+
+## Frequently asked questions
+
+<details>
+<summary>Can I download an IPA or playable app?</summary>
+
+Yes—use the [platform downloads above](#downloads). The latest iPhone/iPad preview is **0.4.13 build 29**; Mac and Apple TV have separate packages. Apple IPAs need re-signing. Every package requires your own supported game data. A [Personal IPA Builder](docs/BUILDER.md) is also available.
+
+</details>
+
+<details>
+<summary>Are Android and Apple TV supported?</summary>
+
+Android has a playable ARM64/Vulkan APK for Android 9+, plus an explicitly unstable preview. Device-specific graphics corruption, freezes and slowdowns remain unresolved; a successful Pixel run does not certify other phones. Apple TV is an **experimental** tvOS 17+ preview with separate controller and hardware acceptance. See [Android setup](docs/INSTALL_ANDROID.md) and [Apple TV setup](docs/INSTALL_TVOS.md).
+
+</details>
+
+<details>
+<summary>Does online multiplayer work?</summary>
+
+The owner reported Retro WFC login, matchmaking and live racing on Android. Separate isolated-server tests covered race results and lobby return. Those results do not establish complete production online behavior on every platform or preview. Native room hosting and Original Wiimmfi compatibility remain unfinished; entering a server address does not implement them. See [online status](docs/ONLINE.md) and [friend-room guidance](docs/MULTIPLAYER.md#private-friend-rooms).
+
+</details>
+
+<details>
+<summary>Does KartPad support Retro Rewind, and what if it updates?</summary>
+
+Yes, with the separately installed **6.12.7** content and matching compiled profile. A newer Retro pack can require a new KartPad build; replacing files alone does not update translated game code. Apple checks the version before launch; Android checks the official version during installation and validates installed content at launch. Follow your [platform setup guide](#downloads) if a compatibility update is requested.
+
+</details>
+
+<details>
+<summary>How do I switch between Mario Kart Wii and Retro Rewind?</summary>
+
+Choose the game when KartPad opens. On iPhone/iPad, **••• → Return to KartPad Menu** pauses the session; **Resume** continues it. Choose **Use on Next Launch** for the other game, fully close the app, then reopen it. Returning to the chooser alone does not apply pending license edits. Mac game selection also applies after reopening. See the platform installation guides for their distinct flows.
+
+</details>
+
+<details>
+<summary>How do touch controls, acceleration lock and motion steering work?</summary>
+
+On iPhone/iPad, hold **A for one uninterrupted second** to lock acceleration; tap A again to release it. Touch settings let you move, resize, hide and restore controls, including the normally hidden D-pad for tricks. Motion steering is optional and offers recenter, inversion and sensitivity. See the [mobile controls guide](docs/MULTIPLAYER.md#iphone-and-ipad-touch-and-motion-controls) for floating-stick behavior and controller handoff. Android has its own [controls/settings guide](docs/INSTALL_ANDROID.md).
+
+</details>
+
+<details>
+<summary>Can I use controllers or local split-screen?</summary>
+
+Yes. Pair controllers in the operating system, choose Multiplayer in the game and press each pad’s mapped A button to register. On iPhone/iPad, the first controller shares Player 1 with touch; the other players keep stable slots. Full three/four-player and reconnect acceptance remains incomplete. See [controller setup and adapter limits](docs/MULTIPLAYER.md).
+
+</details>
+
+<details>
+<summary>Can KartPad set my player name or import a custom Mii?</summary>
+
+On iPhone/iPad, **••• → Game Data & Saves → Player Identity…** manages names and exact license slots. Restart to apply edits. Standard 74-byte `.mii` appearance import is experimental, not a full Wii Mii editor. Renaming a Mii and renaming one license are different actions. See [identity instructions](docs/INSTALL_IPA.md#player-identity). Android save/rating transfer does not include the Mii database.
+
+</details>
+
+<details>
+<summary>Can I connect a Wii Remote and Nunchuk without a DolphinBar?</summary>
+
+Experimentally, on **macOS only**, using the direct Bluetooth pairing flow. It still needs broader original-hardware, reconnect and long-session testing; it is not an iPhone/iPad feature. See [pairing instructions and hardware limits](docs/INSTALL_MACOS.md#experimental-wii-remote-and-nunchuk).
+
+</details>
+
+<details>
+<summary>How much storage does KartPad use?</summary>
+
+Package size varies by platform and version; the iPhone/iPad build 29 IPA download is about **45 MB**. Extracted base-game data is roughly **2.5 GiB**, and Retro content, the original image and temporary installation files require more. Android setup recommends at least **6 GiB free**. Check the platform guide and leave room for updates; the IPA download size is not the installed-data footprint.
+
+</details>
+
+<details>
+<summary>Does this repository include Mario Kart Wii?</summary>
+
+No disc image or extracted retail assets are included. Supply your own legally obtained supported PAL **RMCP01 revision 0** image. Public packages contain compiled translated logic, so software licensing and game-content rights are separate; see [rights and provenance](RIGHTS_AND_LICENSES.md). Do not request or attach game data in issues.
+
+</details>
+
+<details>
+<summary>Is KartPad a general Wii emulator?</summary>
+
+No. It is a game-specific static recompilation for supported Mario Kart Wii and Retro Rewind profiles, not a loader for arbitrary Wii games.
+
+</details>
+
+<details>
+<summary>Is KartPad using Dolphin or streaming from a Mac?</summary>
+
+The game runs locally as native ARM64 code translated by WiiCompiled, with Vulkan on Android and Metal on Apple platforms. It is not streamed from another computer or run inside the Dolphin emulator. KartPad does use Dolphin-derived components, including game-data handling; [third-party notices](THIRD_PARTY_NOTICES.md) preserve that attribution.
+
+</details>
+
+<details>
+<summary>Does KartPad use a PowerPC JIT on iPhone or iPad?</summary>
+
+No. PowerPC code is translated ahead of time and compiled into the app. The iPhone/iPad app does not JIT-compile PowerPC or execute a newly downloaded PowerPC patch. New executable profiles require a compatible app build.
+
+</details>
+
+<details>
+<summary>Why is it slow or freezing, and are distorted graphics fixed?</summary>
+
+First-use shader/pipeline compilation can cause stalls, and heat or higher render resolution can worsen performance. **Not every freeze is shader compilation.** Android has separate unresolved character corruption, online-menu stalls and cup-transition crashes. Start at **1x Native**, but do not treat a settings change or passing renderer probe as a confirmed fix. Use [known issues](docs/KNOWN-ISSUES.md) and [diagnostic guidance](docs/SUPPORT.md) to match your symptoms; the preview adds useful changes and logs, not a blanket stability guarantee.
+
+</details>
+
+<details>
+<summary>Why are the inherited experimental modes absent?</summary>
+
+Those settings applied to Sunshine-specific CPU-clock and 60 FPS behavior and did not affect KartPad’s Mario Kart Wii runtime. They were removed because they were misleading no-ops. Use actual display controls and the [performance guidance](docs/PERF.md).
+
+</details>
+
+<details>
+<summary>Do saves survive an update, and can I transfer Retro ratings?</summary>
+
+Supported in-place updates preserve saves; **do not uninstall or clear app data**. Keep backups and the same signing identity/bundle ID. Android private previews have a different signer and need a planned migration. Raw save backups do not include every companion file: Android preview 1 adds matched offline Retro rating restore, but Mii transfer and real-save acceptance remain pending. See [save and rating transfer](docs/SUPPORT.md).
+
+</details>
+
+<details>
+<summary>Is everything finished? How do I report a problem?</summary>
+
+No. Check [current platform acceptance](docs/STATUS.md), [known issues](docs/KNOWN-ISSUES.md) and [technical debt](docs/TECH-DEBT.md). Report your exact build, device/OS, selected game, settings and reproducible steps using the [bug form](https://github.com/chrissotraidis/kartpad/issues/new?template=bug_report.yml). Export a problem report using the [support guide](docs/SUPPORT.md), review it before sharing, and keep saves, identities and game data private.
+
+</details>
 
 ## Build and contribute
 

--- a/docs/INSTALL_MACOS.md
+++ b/docs/INSTALL_MACOS.md
@@ -49,6 +49,19 @@ Regenerable graphics caches live under `~/Library/Caches/KartPad`. Replacing
 the app does not remove either folder, but back up important saves before
 manually deleting application data.
 
+## Experimental Wii Remote and Nunchuk
+
+Enable **Controls → Experimental Wii Remote + Nunchuk**, use the Wii Remote's
+red **SYNC** button to pair, attach the Nunchuk, then select **Wii Remote +
+Nunchuk (Experimental)** in Controller Settings. The intended hardware is an
+original `RVL-CNT-01` or Wii Remote Plus `RVL-CNT-01-TR`.
+
+This opt-in path pairs through the Mac's Bluetooth hardware without a DolphinBar
+and hands input to SDL. It uses private macOS Bluetooth interfaces and is not a
+Mac App Store workflow. Actual pairing, Nunchuk input, reconnect and long-session
+behavior need wider hardware testing. iPhone/iPad do not provide this direct
+pairing path; a similarly named informational menu is not support for it.
+
 ## Build it yourself
 
 Install the [Apple build prerequisites](BUILDING.md#prerequisites), then run:

--- a/docs/MULTIPLAYER.md
+++ b/docs/MULTIPLAYER.md
@@ -5,6 +5,30 @@ Mac, or **Multiplayer…** on the Apple TV game chooser. The menu covers
 Original Mario Kart Wii and Retro Rewind; available online guidance depends on
 the game profile. Apple mobile menu names below follow 0.4.10 and later.
 
+## iPhone and iPad touch and motion controls
+
+These instructions describe the Apple touch interface. Android has its own
+[controls and display settings](INSTALL_ANDROID.md); do not assume menu parity.
+
+- **Acceleration lock:** hold A continuously for one second until it turns cyan.
+  Release your finger to keep accelerating; tap A to unlock. Opening a modal,
+  hiding touch or handing Player 1 to a controller clears the lock.
+- **Layout:** open **••• → Touch Control Settings** to move, resize, hide or
+  restore controls. The D-pad is hidden by default and can be enabled for tricks
+  and wheelies. Existing custom visibility choices are preserved. Phone and
+  tablet layouts are stored separately; **Back** returns to touch settings.
+- **Floating stick:** touch within its pickup area to place it under your thumb;
+  it disappears on release. R is a digital drift control, not an analog trigger.
+- **Controller handoff:** the first extended gamepad takes Player 1, clears held
+  touch input and hides touch controls by default. Disconnecting restores touch;
+  additional controllers retain their Player 2–4 slots.
+- **Motion steering:** **••• → Motion Steering…** is off by default. It provides
+  recenter, inversion and 0.5×/1×/2× sensitivity. Touch can override motion;
+  physical controllers take priority, and backgrounding clears live motion state.
+
+Motion tuning, full race coverage and reconnect behavior still need physical
+acceptance on the exact build; the existence of a setting does not prove them.
+
 ## Local split-screen
 
 Pair each controller in the operating system, select Multiplayer in the game,

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,8 @@
 # KartPad documentation
 
 For downloads, start with the [project README](../README.md#downloads).
+The [expandable FAQ](../README.md#frequently-asked-questions) answers common
+setup, controls, compatibility and troubleshooting questions.
 Guides below describe current workflows; dated records describe only the build
 and observations named in them.
 
@@ -45,7 +47,9 @@ and observations named in them.
   are historical. Their old candidates, local paths and pending actions are not
   instructions for the next session.
 
-Keep the README focused on introduction, downloads and usage. Update current
+Keep the README focused on introduction, downloads, usage and its expandable FAQ.
+Preserve useful user answers and controls guidance when shortening a page; move
+detailed instructions to a linked guide rather than silently deleting them. Update current
 summaries in place and link one dated record for detailed evidence. Preserve
 release notes, license/provenance records and referenced artifacts; remove
 superseded duplicate summaries rather than copying them into more running logs.

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -6,7 +6,70 @@ feature works on untested hardware. External pull requests listed here are sourc
 material only; any follow-up is maintainer-owned and its completed and remaining
 gates are stated explicitly below.
 
-## tvOS A12 compiler baseline
+## Current priorities across platforms
+
+Reviewed 9 September 2026 against [known issues](KNOWN-ISSUES.md), the
+[maintenance board](MAINTENANCE-BOARD.md) and their dated evidence. This document
+records engineering gaps and what would demonstrate progress; the board owns
+assignments and candidate status. Open reports are not automatically one shared
+bug. The tvOS experiments below remain useful, but are not the whole debt queue.
+
+### Android stability and performance
+
+Android is the main current stability priority. Public preview 1/code 28 adds
+rating restore and diagnostics; it is **not** a verified fix for the reports
+below. Preview 2/code 29 is a local candidate, not a published download.
+
+| Work / reports | Established evidence and remaining gap | Next discriminating check / acceptance |
+| --- | --- | --- |
+| Character/geometry corruption: [#102](https://github.com/chrissotraidis/kartpad/issues/102), [#104](https://github.com/chrissotraidis/kartpad/issues/104), [#120](https://github.com/chrissotraidis/kartpad/issues/120), [#137](https://github.com/chrissotraidis/kartpad/issues/137) | Multiple Adreno devices pass synthetic renderer probes while actual characters remain corrupted. Validation on/off has not resolved reported corruption; road textures may be a separate symptom. No verified rendering correction. | Reproduce a failing game draw and trace its transform/upload/shader inputs; verify a correction on affected hardware and a non-affected GPU. Avoid repeating already-completed synthetic or settings tests. [Draw evidence](artifacts/2026-09-09/graphics-preview28-evidence.md). |
+| Online-menu stalls: [#123](https://github.com/chrissotraidis/kartpad/issues/123) | A matched build-28 log shows a 2.222-second presentation gap with thermal status 0. Recorded receive waits lie outside that gap. A separate actual-HLE probe reproduced alarm rescheduling under a recursive pump guard; its Android correction is merged, but reporter causality is unproven. | Compare the exact corrected candidate on the affected gameplay path; correlate guest progress, callbacks and presentation. Require real freeze/audio behavior to improve before calling it a fix. [Timing review](artifacts/2026-09-09/pixel-online-log-review.md), [local candidate](artifacts/2026-09-09/android-preview2-local-candidate.md). |
+| Slowdown, frame pacing and heat: [#103](https://github.com/chrissotraidis/kartpad/issues/103) | Performance varies with device power mode, scene, compilation and heat. An independently reviewed scalar-context optimization remains separate from released builds; a synthetic multiply improvement is not a game FPS gain. | Matched cold/warm runs at the same resolution, track and power mode, measuring frame-time tails, audio and thermal state. Benchmark the optimization in-game before integration or performance claims. [Review boundary](artifacts/2026-09-09/maintenance-source-reviews.md), [performance guide](PERF.md). |
+| End-of-cup crashes: [#128](https://github.com/chrissotraidis/kartpad/issues/128), [#131](https://github.com/chrissotraidis/kartpad/issues/131) | Reported after Next at the final race, before awards, with Original and Retro both reported affected. Shared awards/resource paths are identified; the matching termination cause is not. | Use the requested exit/console evidence to classify the failure, then exercise the affected awards transition. Do not infer a Retro-only bug or require destructive reimports. [Investigation](artifacts/2026-09-09/cup-transition-investigation.md). |
+| Game-launch crash: [#143](https://github.com/chrissotraidis/kartpad/issues/143) | Honor X7D / Snapdragon 685 report after import and Launch. Exact build/profile and matching termination evidence are still needed. | Separate importer completion from native launch and identify the failing boundary before choosing a CPU/GPU correction. Do not infer incompatibility from the chipset name alone. |
+| System bars and aspect: [#119](https://github.com/chrissotraidis/kartpad/issues/119), [#101](https://github.com/chrissotraidis/kartpad/issues/101) | System-bar handling has shipped changes but reporter/device confirmation remains separate. Fill Screen distortion needs its own projection/presentation reproduction. | Verify focus, chooser/game transitions and system UI on the affected device; compare the same scene in 4:3, 16:9 and Fill. Keep UI lifecycle separate from character corruption. |
+| Save/rating/Mii migration: [#105](https://github.com/chrissotraidis/kartpad/issues/105) | Preview 1 implements reviewed, backed-up, matched offline rating restore. Real-save acceptance is pending; raw save export does not carry the Mii database, and file copying is not online rating synchronization. | Complete the existing offline restore test with matching profiles before separate online checks. Design Mii transfer and Apple UI parity independently, preserving unrelated identities and licenses. [Support workflow](SUPPORT.md). |
+
+### Apple and shared runtime gaps
+
+- **Older-device launch (#135):** iPhone/iPad 0.4.13 build 29 ships the reviewed
+  generic ARM64/RCpc-disabled correction. The final binary and initializer were
+  audited; A10X physical launch and a matching original crash PC/UUID remain
+  necessary before attributing the reporter's crash to that defect. This is
+  distinct from the tvOS A12 gate below. [Build evidence](artifacts/2026-09-09/ios-preview-build29.md).
+- **External displays (#100):** source review found that surface recovery can
+  replace the SDL Metal view and detach its controls. A real mirroring trigger
+  is not established. Correct ownership with a forced-recovery regression,
+  then test wired/wireless connect, disconnect and resume on each platform.
+  [Source evidence](artifacts/2026-09-09/external-display-surface-ownership.md),
+  [display plan](EXTERNAL-DISPLAYS.md).
+- **Mac input and two-player rendering:** PR #112 still needs capture-cancel
+  and physical-scancode corrections plus hardware acceptance. #127's character
+  offsets need a same-scene main/PR comparison; controller success does not
+  establish rendering correctness. [Current boundaries](KNOWN-ISSUES.md).
+- **Diagnostics:** richer context/provenance is published on Android preview 1
+  and iPhone/iPad build 29. Physical report export/share still needs acceptance
+  on the exact Apple package. Use existing targeted logs first; bounded samples
+  can miss a failing draw or an indefinitely blocked call. More logging without
+  a discriminating experiment is not itself a stability fix.
+- **Retro version compatibility and online behavior:** keep compiled profiles,
+  installed content and service compatibility distinct. Apple pre-launch and
+  Android install-time update checks are not identical. Future version rollout
+  needs mismatch/recovery tests, plus exact-build race/results/reconnect checks;
+  changing a pack or server field cannot add new executable compatibility.
+  [Upstream updates](UPSTREAM_UPDATES.md), [online limits](ONLINE.md).
+- **Long-session and peripheral acceptance:** sustained frame pacing/audio,
+  motion steering, reconnect and complete three/four-player results remain
+  per-platform gates. DSU (#91) and Wiimmfi (#90) are separate feature work,
+  not already-supported paths. [Acceptance](PHYSICAL-ACCEPTANCE.md),
+  [future features](FUTURE-FEATURES.md).
+
+## Deferred tvOS work
+
+The following compiler, presentation, haptics and audio work retains its own
+source and physical-device acceptance boundaries.
+
+### tvOS A12 compiler baseline
 
 Status: defensive compiler hardening implemented; physical A12 compatibility
 unverified.
@@ -36,7 +99,7 @@ Source: pull request [#31](https://github.com/chrissotraidis/kartpad/pull/31)
 and its physical-device follow-up. The submitted pull-request head did not
 include the RCpc fix.
 
-## tvOS settings and aspect presentation
+### tvOS settings and aspect presentation
 
 Status: aspect-state consistency implemented; presentation choices remain deferred.
 
@@ -68,7 +131,7 @@ Acceptance requires all of the following:
 
 Source: pull request [#32](https://github.com/chrissotraidis/kartpad/pull/32).
 
-## tvOS controller rumble
+### tvOS controller rumble
 
 Status: hardware experiment required.
 
@@ -88,7 +151,7 @@ Acceptance requires all of the following:
 
 Source: pull request [#33](https://github.com/chrissotraidis/kartpad/pull/33).
 
-## Dolby Pro Logic II to multichannel LPCM
+### Dolby Pro Logic II to multichannel LPCM
 
 Status: audio experiment required.
 
@@ -108,7 +171,7 @@ Acceptance requires all of the following:
 
 Source: pull request [#35](https://github.com/chrissotraidis/kartpad/pull/35).
 
-## Integration order
+### tvOS experiment integration order
 
 1. Retain the statically verified A12 compiler hardening and keep physical
    compatibility explicitly unclaimed unless exact-artifact evidence arrives.


### PR DESCRIPTION
The README cleanup removed the FAQ entirely and lost useful touch-control and direct Wii Remote instructions. Restore 18 expandable FAQ answers with current platform/version limits, recover the detailed controls in linked guides, and keep the requested opening order and AI disclosure. The README is 249 lines; long build/history material stays in its existing guides and archive.

Expand TECH-DEBT beyond tvOS to cover Android corruption, online stalls, performance, cup/launch crashes, system UI and save migration, plus shared/Apple gaps. Each entry distinguishes evidence from pending acceptance. Correct the badge implying current iPhone/iPad preview physical acceptance.

Validation: GitHub GFM renders 18 details/summary controls and their answers; 115 relative links/anchors across five changed documents resolve; 10 existing touch/layout/Mii/Wii Remote contract tests and whitespace checks pass. Documentation only; no builds, device changes or issue replies.
