### PR TITLE
Document Android report triage and resolution priorities

### DIFF
--- a/docs/KNOWN-ISSUES.md
+++ b/docs/KNOWN-ISSUES.md
@@ -11,6 +11,12 @@ experiments and distinguishes installed, public and local candidate builds.
 The [maintenance workflow](MAINTENANCE.md) defines how evidence advances into
 reviewed fixes, platform tests and accepted builds.
 
+The [9 September Reddit triage](artifacts/2026-09-09/reddit-android-report-triage.md)
+maps additional Android reports to these issues and records setup, remapping
+and resolution-change leads in [technical debt](TECH-DEBT.md#android-community-reports-and-flow-gaps).
+Those comments omit exact APK versions and do not establish results for the
+separate Android build/test workstream.
+
 | Issue | Current boundary / next evidence |
 | --- | --- |
 | [#142](https://github.com/chrissotraidis/kartpad/issues/142) AI disclosure and documentation | Answered publicly; disclosure shipped. README ordering and repository documentation cleanup merged in PR #148. Remains open; UI criticism is not a diagnosed rendering or performance defect. |

--- a/docs/MAINTENANCE-BOARD.md
+++ b/docs/MAINTENANCE-BOARD.md
@@ -7,6 +7,10 @@ Private artifact paths and task identifiers belong in the local maintenance file
 Open-issue audit: 19 open issues and PR #112 checked during the 01:14 UTC cycle on 9 September 2026.
 Next manual Android investigation: [bounded handoff and test plan](ANDROID-PERFORMANCE-HANDOFF.md).
 
+The [Android technical debt work order](TECH-DEBT.md#order-of-operations)
+defines failure classification, evidence requirements and completion criteria.
+Use it to select ready follow-up work without duplicating the active build owner.
+
 ## Ready work and dependencies
 
 | Workstream | State / owner role | Next action and completion condition | Platform boundary |

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -67,6 +67,237 @@ It is **not** a verified graphics, freeze or crash fix. Preview 2/code 29 is a l
   not already-supported paths. [Acceptance](PHYSICAL-ACCEPTANCE.md),
   [future features](FUTURE-FEATURES.md).
 
+## Android community reports and flow gaps
+
+Status: triaged on 9 September 2026; runtime symptoms remain reporter claims
+unless independently supported below. See the
+[Reddit report mapping](artifacts/2026-09-09/reddit-android-report-triage.md)
+for source attribution, exact observations, GitHub links and missing evidence.
+The owner reports ongoing Android build work; its current build/test stage is
+not verified here. These unversioned Reddit reports neither validate nor reject
+that candidate. Retain the existing
+[known-issue evidence](KNOWN-ISSUES.md) and avoid duplicate issue filings.
+
+### Order of operations
+
+The largest recurring problem areas are getting into the game, rendering it
+correctly, and keeping gameplay smooth. This is an impact-based work order,
+not a measured ranking by affected user count: the supplied comments do not
+identify enough builds, sessions or unique devices to calculate failure rates.
+Crashes during a cup also matter even when individual races work.
+
+Keep the [maintenance board](MAINTENANCE-BOARD.md) as the work-owner and candidate
+ledger. This section defines how to choose and finish work; it does not assign
+another Android builder or supersede the active owner's test. Consult its latest
+handoff for the build's exact identity, included changes and observed results
+before requesting another comparison. The
+[Android investigation handoff](ANDROID-PERFORMANCE-HANDOFF.md) owns the ranked
+runtime experiments; the order below guides community triage and does not
+reassign that work. A completed build alone changes none of the issue acceptance
+states.
+
+| Order | Work and reason | Next bounded action | Completion condition |
+| --- | --- | --- | --- |
+| 1. Classify and reuse evidence | “Does not work” cannot select an engineering fix. Do this for new reports while existing investigations continue. | Identify the last successful step using the table below; link an existing issue and record exact build/profile when available. Mark missing details unknown. | Each actionable report has a failure category, evidence link and one next question or experiment. Vague reports remain unclassified, not counted as confirmed crashes. |
+| 2. Remove setup and session blockers | Import/launch failures (#143 and Reddit setup reports), plus cup-ending crashes (#128/#131), prevent starting or completing play. | Correct the confirmed import wording in a focused future change; classify startup exits; use the existing awards/resource investigation for the cup transition. Treat these as separate fixes. | An affected setup reaches valid game data and gameplay; the failing cup transition reaches the ceremony/menu with expected progress retained. One successful race does not close a cup crash. |
+| 3. Fix broken graphics | #102/#104/#120/#137 can make a running game unusable. Existing diagnostics already narrow the work. | Review captured game-draw evidence, then isolate a failing character transform, upload or shader path. Compare the same scene with a known-good rendering result. | The affected device renders the failing scene correctly on the identified candidate; relevant Original/Retro and unaffected-device regression checks pass. Synthetic probes alone are insufficient. |
+| 4. Stabilize gameplay and transitions | #103 slowdowns, #123 online stalls and the Reddit resolution-change freeze interrupt different parts of play. | First interpret the active build's targeted results. Measure sustained/repeat gameplay separately from online-menu waits and live resolution changes; select one supported hypothesis per experiment. | Matched gameplay improves without an unacknowledged power/heat cost; online and resolution transitions each pass their own formerly failing sequence. A higher average FPS cannot close a freeze. |
+| 5. Finish presentation and control gaps | System bars #119, aspect distortion #101 and trigger/stick-click mapping affect usability. External output #100 and save migration #105 retain separate plans. | Take small ready fixes without disturbing higher-priority investigations. Confirm the exact affected route/controller; preserve the now-confirmed offline rating transfer in #105; investigate Mii and server synchronization separately. | Affected-device behavior and persistence/lifecycle checks pass; save, Mii and rating transfer boundaries remain explicit. Do not call partial transfer complete migration. |
+
+This order is not a rule to wait idle on a missing log. Continue the highest
+impact ready, unowned investigation when another needs device evidence. Promote
+any newly confirmed data loss, broad startup regression or reproducible hard
+freeze ahead of tuning and convenience work. Save-transfer mismatches do not
+currently establish data loss. Feature requests such as DSU, Wiimmfi, a Switch
+port or higher FPS caps do not block these fixes. Apple-only reports retain
+their own owners and acceptance; Android results cannot close #135 or #127.
+
+### Turn “it does not load” into an identifiable failure
+
+Ask for the last screen that worked and what happened next before asking for
+logs. The following categories describe observations, not proposed causes.
+
+| Last successful step / symptom | Classify as | Useful next evidence |
+| --- | --- | --- |
+| Android refuses to install/update the APK | Package installation | Exact installer error, APK version, Android version and whether this is an update. Check package requirements, signer/version conflict and space without uninstalling. The Reddit export does not establish a package-installer defect. |
+| APK installs, but no KartPad chooser appears | App startup | Exact build and any available matching OS exit reason; an in-app export is unavailable if the chooser never opens. Absence of an exit record is inconclusive. |
+| Chooser opens, but a file/folder cannot be selected or import rejects it | Input selection/import | Picker versus validation failure, input format, reported region/revision, exact error and whether previous valid data still works. Do not request the image itself. |
+| Base data works, but Retro setup is missing or rejects content | Retro setup | Selected mode, base-data readiness, pack version and visible installer/error state. Distinguish downloading the pack from importing the base game. |
+| Import finishes, Launch is pressed, then app exits | Game startup crash | Matching build/profile, last session console lines and OS exit record when available; #143 is this reported path. |
+| Launch gives black/frozen video while app or audio continues | Game startup/render stall | Whether native menu, audio and frame presentation continue; last completed startup step and bounded renderer/runtime context. Do not automatically call it a crash. |
+| Game runs with stretched characters or wrong textures | Rendering corruption | Exact scene, character/vehicle, build, profile, GPU/driver and screenshot. Reuse #102/#104 evidence rather than rerunning completed import/validation checks. |
+| Game slows during a race or on repeat play | Performance | Course/section, cold versus repeat session, elapsed play time, settings, power mode and matching timing/thermal samples. |
+| Game stops only after Next, an online action or a settings change | Transition failure | Exact action and before/after state; distinguish cup crash, online stall and resolution freeze. Preserve separate reproductions even on the same device. |
+
+Storage capacity, RAM pressure and thermal/power limits are different questions.
+Do not infer any of them from the phone model, low FPS or a generic launch
+failure. Existing [import storage checks](artifacts/2026-09-08/android-import-storage-errors.md)
+already reject insufficient space and failed extraction while retaining previous
+data in local validation. Preserve those checks and verify which APK a report
+used before proposing them again. Android exit diagnostics can report a
+`low_memory` reason where the OS supplies it; battery/thermal samples do not
+measure RAM or GPU memory exhaustion. Add resource measurements only when they
+can distinguish a concrete suspected failure.
+
+### Reporting debt: join the right evidence, then add only what is missing
+
+Status: useful diagnostics exist; a simpler failure-oriented reporting flow
+needs design and acceptance. This documentation does not implement it.
+
+Current Android source already exports version/profile/settings context,
+session console logs, performance/health samples and bounded OS exit history.
+The issue template already asks for build, device, steps and performance
+settings. The gap is making these usable for the specific failed session:
+
+- `report-context.json` describes export time. It must not relabel old logs as
+  the new build after an update. Chooser context may not know the active runtime
+  validation state; a saved next-launch setting is not evidence of the previous
+  session's active setting. See
+  [`KartPadDiagnosticExport.kt`](../android/app/src/main/java/dev/kartpad/android/KartPadDiagnosticExport.kt).
+- Define a compact local session summary tied to the build/profile at session
+  start, with monotonic timing and the last completed startup/transition step.
+  First audit existing markers; fill demonstrated gaps instead of adding a
+  second independent log system. An unfinished step is a lead, not proof it
+  caused termination; manual stops and normal exits must remain distinguishable.
+- Let a future chooser report flow select the failed session, show its last
+  known step and guide the user to a bounded, reviewable excerpt. Explain that
+  opening GitHub does not attach the report. Retain a local-only export and
+  the fallback for failures before the chooser opens; no automatic uploading.
+- Capture transitions such as scale changes or entering online menus only if
+  missing timing prevents a specific decision. Log old/new state and completion
+  with bounded retention; avoid per-frame disk writes and verbose normal-play
+  tracing. Gate expensive renderer diagnostics behind explicit investigation.
+
+Acceptance: reproduce a classified startup failure and a recoverable stall in
+appropriate controlled tests; the report identifies the correct session/build,
+last step and available evidence without needing the whole private archive.
+Check export after an update, manual stop, missing OS history and failure before
+runtime initialization. Missing data stays unknown, no private paths/accounts
+are exposed in the share summary, and diagnostic overhead is measured on the
+affected path. Better reporting is complete when it enables a troubleshooting
+decision, not when it emits more lines.
+
+### Record what “works” actually means
+
+Use one evidence entry per source, device, exact build, profile and test scenario
+in the dated investigation record linked from the existing issue. Record:
+
+- source/comment and review date; device/OS and GPU/driver where supplied;
+- app version/code and source/artifact identity when known; Original or Retro
+  and content version; scene/mode, settings, controller and display path;
+- furthest observed milestone: chooser, validated import, title, completed race,
+  completed cup, repeat session, or online race/results; duration when known;
+- outcome and evidence level: reporter claim, inspected logs/image, locally
+  reproduced, or affected-device confirmation; next action/dependency.
+
+Store missing fields as unknown. A versionless “works great” stays a positive
+claim with unspecified coverage; it is not a compatibility pass. Record failure
+and successful milestones together: a Thor can complete races yet crash at cup
+results; a Fold can present near 60 FPS yet corrupt characters. Keep Retroid
+Original and Retro observations separate. Do not infer that matching handles or
+devices across sites represent the same person, or count repeated advice as
+additional devices. The [dated comparison examples](artifacts/2026-09-09/reddit-android-report-triage.md#comparison-examples-for-future-reviews)
+show how existing reports fit this approach.
+
+### Finish each investigation with a decision
+
+1. Name one question and reuse existing evidence. Choose a reproduction and
+   the observation that would support or reject the hypothesis.
+2. Change one relevant variable where practical. For performance, match build,
+   scene, profile, resolution, power mode and starting thermal condition; report
+   any unmatched conditions. Retain frame-time/stall evidence, not only FPS.
+3. Record supported, rejected or unresolved, with the next action. If a test
+   passes while the actual game still fails, narrow the reproduction instead
+   of requesting the same test again. If blocked, identify the exact missing
+   input and continue other ready work.
+4. For a correction, distinguish implemented, reviewed, merged, packaged,
+   locally tested, affected-device accepted and released in the existing board.
+   Ask for a targeted retest only when a candidate addresses that report or a
+   new comparison will discriminate between remaining explanations.
+5. Close only the demonstrated scope. Verify the formerly failing action and
+   the relevant regression path; link the exact candidate and result. Keep
+   other profiles/devices or transition failures open where evidence is absent.
+
+### Performance, graphics and fullscreen follow-through
+
+Poco X6 Pro repeat-session/track-dependent slowdown and the Retroid Pocket 5
+comparison belong with [#103](https://github.com/chrissotraidis/kartpad/issues/103),
+while retaining device, profile and cold/repeat distinctions. Fold corruption
+overlaps [#102](https://github.com/chrissotraidis/kartpad/issues/102); vague
+“not working” reports still need a failure stage. Thor fullscreen likely relates
+to [#119](https://github.com/chrissotraidis/kartpad/issues/119), but system bars
+and aspect-ratio letterboxing must be distinguished first.
+
+Acceptance needs the exact tested APK and a targeted affected-device result:
+same-scene cold/repeat performance with power/thermal context, an actual failing
+game draw for graphics work, or launch/menu/resume system-bar behavior for
+fullscreen. Existing synthetic renderer passes, emulator checks, another
+device's success and CPU microbenchmarks do not close these reports. Reuse
+already supplied evidence; the Retroid GitHub reporter needs no repeat hot
+profile or Dolphin benchmark now. No vendor-wide diagnosis is established.
+
+### Disc import and Retro Rewind setup clarity
+
+Status: reported confusion plus a source-confirmed messaging inconsistency;
+no reproduced import failure.
+
+The current chooser routes through base-data setup before Retro installation.
+[`RetroRewindInstallActivity.kt`](../android/app/src/main/java/dev/kartpad/android/RetroRewindInstallActivity.kt)
+already offers **Download official pack**. The fallback status in
+[`KartPadGameDataActivity.kt`](../android/app/src/main/java/dev/kartpad/android/KartPadGameDataActivity.kt)
+asks only for an extracted RMCP01 DATA folder even though the screen also
+supports disc-image import. A reporter seeing only input choices may be at
+this prerequisite; their exact build/screen is still unknown.
+
+Follow-up: make the base-disc → official Retro-pack sequence visible before
+selection, use consistent ISO/WBFS-or-DATA-folder wording, state the owned PAL
+RMCP01 revision 0 requirement, and distinguish unsupported format, wrong
+region/revision, wrong folder, missing base data and incompatible pack errors.
+Explain that an RVZ must first be converted from the user's own supported dump
+to a supported input and that Retro installation is a separate step.
+
+Acceptance: a fresh user can reach the official downloader after valid base
+import; rejected inputs explain the next action; cancel/retry, unavailable file
+providers and incomplete installs preserve existing valid data. Verify the
+reported route on its exact build before calling it fixed. Keep identity and
+pack checks intact; no game-download sourcing or validation bypass is needed.
+
+### Trigger and stick-click remapping for tricks/wheelies
+
+Status: confirmed Android feature gap, not blocked on logs.
+
+[`KartPadControllerMapping.kt`](../android/app/src/main/java/dev/kartpad/android/KartPadControllerMapping.kt)
+only maps A/B/X/Y/Z to A/B/X/Y/left shoulder. A Thor user specifically wants
+tricks/wheelies accessible from triggers or stick clicks. Evaluate a focused
+extension after confirming the desired bindings; macOS PR #112 does not supply
+Android acceptance.
+
+Acceptance: physical Thor or affected controller confirms the requested action,
+including press/hold/release, without breaking analog trigger behavior,
+existing defaults, saved mappings, player assignment or touch handoff. Check
+menu dismissal, disconnect/reconnect and reset for stuck or duplicate inputs.
+
+### Freeze after changing render resolution
+
+Status: new unverified reproduction lead; no exact matching GitHub issue found.
+
+One commenter reports freezes following resolution changes and recovery after
+pause/unpause. Track separately from online-menu issue #123. The current
+`showResolutionSettings` path in
+[`KartPadActivity.kt`](../android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt)
+persists the scale and immediately calls `applyDisplaySettings`; inspect that
+transition and the renderer/lifecycle response once the build, scene, scale
+change and pause action are known. This is a source entry point, not a diagnosis.
+
+Acceptance: the previously failing scale change completes during the affected
+scene with frames/audio/input continuing, correct persisted scale after restart,
+and no recovery pause required. Check Original and Retro independently. Capture
+a bounded matching interval if reproduced; do not conflate a recoverable freeze
+with a process crash or ship a speculative automatic pause workaround.
+
+The export's FPS-uncapping wording remains ambiguous. Clarify the requested
+behavior before adding a frame-rate feature or acceptance commitment.
+
 ## Deferred tvOS work
 
 The following compiler, presentation, haptics and audio work retains its own

--- a/docs/artifacts/2026-09-09/reddit-android-report-triage.md
+++ b/docs/artifacts/2026-09-09/reddit-android-report-triage.md
@@ -1,0 +1,80 @@
+# Android Reddit report triage — 9 September 2026
+
+Source: owner-supplied text export of the r/decomps post **“KartPad
+(wiicompiled) — first Android community release · chrissotraidis/kartpad”**
+by TypeZaxter. The export has relative timestamps, no post/comment permalinks,
+no exact APK versions and no attached logs. Its “Comment Image” placeholders
+are not screenshots we inspected. Handles below identify comments within that
+export; they do not establish identities across Reddit and GitHub.
+
+Compared with the live GitHub issue list and relevant issue comments on
+9 September, plus checkout `ca36e2b`. These are reported symptoms and product
+leads, not reproduced defects or verified shared causes. Another Android build
+is currently being tested by the owner. None of these comments establishes a
+result for that build. The [local preview 2 record](android-preview2-local-candidate.md)
+documents a candidate separately; the owner did not identify the active test
+build in this request. No builds, installs, releases or public replies were
+performed for this triage.
+
+## Report mapping
+
+| Report in the supplied export | Existing work / interpretation | Smallest useful next evidence or action |
+| --- | --- | --- |
+| Bubbly-Thanks-8076: Poco X6 Pro / reported Dimensity 8300U; about 40 FPS, repeat play falls to about 20 with slow motion; restart sometimes helps. 1–3x feels similar, 4x costs more. | Performance symptom overlaps [#103](https://github.com/chrissotraidis/kartpad/issues/103). Repeat-session degradation is a useful distinct trigger. Neither MediaTek nor thermal throttling is established as the cause. | Exact build/profile, what “play again” means, same course cold/repeat, power mode and elapsed time; use an existing matching performance/health interval if available. Similar resolution performance alone does not identify a CPU bottleneck. |
+| jakeburns99: Poco X6 Pro 12/512; menus 60 FPS, races 25–30, sections 15–21, no graphical glitches reported. | Second comment on this device family supports investigating scene-dependent performance under #103, separately from repeat-session degradation. | Course/section, Original versus Retro, build and settings. Preserve the clean-graphics observation as a comparison; do not combine the two Poco accounts into one measured session. |
+| Cammie_Crossing: Retroid Pocket 5 / Snapdragon 865 with active cooling; Retro below 60 FPS and Dolphin faster at twice the resolution. | Strong device/symptom overlap with the [Retroid report in #103](https://github.com/chrissotraidis/kartpad/issues/103#issuecomment-5589429674). GitHub later confirms .2 and preview 1, validation off, mainly **Original**; Reddit explicitly names **Retro**. Reporter identity is unconfirmed. | Keep the profiles separate. Existing GitHub reporter was already told no repeat benchmark is needed. Await a targeted candidate comparison; active cooling and comparative impressions do not establish equal temperature/power or performance parity. |
+| Feeling-Key5883: Spanish comment says Dolphin runs better than this native port on reported “MTK G100 Ultimate.” | Qualitative performance comparison related to #103, without enough context to group by GPU or diagnose. | Device model, exact build and game/profile before requesting profiling. The later GameCube Mario Party optimization question supplies no additional KartPad measurement. |
+| PattF: Fold 8 graphics are messed up. | Strong symptom/device overlap with [#102](https://github.com/chrissotraidis/kartpad/issues/102); related renderer reports [#104](https://github.com/chrissotraidis/kartpad/issues/104), [#120](https://github.com/chrissotraidis/kartpad/issues/120), [#137](https://github.com/chrissotraidis/kartpad/issues/137) do not establish a common mechanism. | Exact build and one matching scene image; use existing actual-game renderer investigation. Do not repeat synthetic probes or imports already completed by GitHub reporters. |
+| Chriscautillo: “not working” on reported “8 elite gen 5 on fold 8”; PattF replies “same boat.” | Unclassified failure. Could overlap #102, but this is not evidence of a crash. [#143](https://github.com/chrissotraidis/kartpad/issues/143) is a separate launch-crash report on different hardware. | Identify the last working screen and whether import rejects, graphics corrupt, game freezes, or Android closes the app. Preserve reported hardware wording until a technical report confirms it. Request exit metadata only for an actual unexpected exit. |
+| TypeZaxter: AYN Thor works well but fullscreen is missing. | Likely overlap with system-bar issue [#119](https://github.com/chrissotraidis/kartpad/issues/119), also reported on Thor in [#128](https://github.com/chrissotraidis/kartpad/issues/128). If this means aspect bars, [#101](https://github.com/chrissotraidis/kartpad/issues/101) is a different path. | Distinguish Android status/navigation bars from expected 4:3/16:9 letterboxing; record display and launch/resume behavior. Build 23 has local immersive-mode checks, but Thor acceptance remains open. |
+| WayApprehensive6494: Thor runs well; wants triggers/stick clicks remappable for wheelies/tricks instead of D-pad. | Confirmed **source-level feature limitation**: current Android mapping exposes only A/B/X/Y/Z to A/B/X/Y/left shoulder. [macOS PR #112](https://github.com/chrissotraidis/kartpad/pull/112) is related design work, not Android implementation or acceptance. | Record in tech debt. Confirm desired physical button → action; preserve defaults, analog behavior, player assignment and release edges if expanded. No crash logs needed. |
+| 420MacMan: Retro folder is not recognized; sees only ISO/folder selection and cannot find the suggested in-app download. | Setup/discoverability lead, no exact matching open issue found. Current source already has an official-pack downloader; failure to reach it is not proof it is absent. | Exact build, selected mode, whether base data was validated, and error/screen text. Explain the owned base-disc prerequisite separately from the official Retro pack; distinguish wrong folder, missing base data and incompatible pack. |
+| Dank_boredom: tried both suggested inputs, later reports success after ISO-conversion guidance, then asks whether Retro uses the same process. Ambitious_Stock_4211 also reports success after repeated setup guidance; Terminator996 reports Snapdragon 778g+ working. | Disc-format/region and base-versus-mod confusion; no confirmed importer regression. Closed Apple picker [#1](https://github.com/chrissotraidis/kartpad/issues/1) is historical UX context, not the same Android defect. Deduplicate the repeated conversion reply. | Explain owned PAL RMCP01 revision 0 ISO/WBFS versus unsupported direct RVZ input and separate official Retro installation. Success does not reveal which earlier check failed. Do not reproduce game-download links from the comments. |
+| Terminator996: changing render resolution freezes the game; pausing/unpausing reportedly recovers it. | New settings-transition reproduction lead; no exact matching issue found. Keep separate from online-menu stalls in [#123](https://github.com/chrissotraidis/kartpad/issues/123). | Build/device/profile, old → new scale, scene and exact pause control used; whether audio, native menu and FPS continue. Inspect settings application, renderer resource transition and lifecycle state. Pause/resume is a reporter workaround, not a verified fix. |
+| TypeZaxter: wording “fullscreen is fps uncapped.” | Ambiguous request concerning an FPS cap/uncapping, not evidence that game speed or frame limiting is broken. | Clarify whether they want a higher cap, observe uncapped rendering, or mean something else. Any future option needs game-speed/audio/physics validation; do not infer the request from punctuation. |
+
+## Questions and positive reports
+
+- Switch-port and Nvidia Shield questions are demand/compatibility questions,
+  not failed runs. No Shield acceptance or Switch delivery commitment follows.
+- A PC-server compatibility question receives a community “yes” for Retro
+  Rewind. Treat it as a question to answer using the supported Retro WFC flow,
+  matching content and existing platform acceptance boundaries; it is not a
+  captured successful Android online session and does not imply Wiimmfi support.
+- Thor users, a Snapdragon 778g+ user and SimpleDrawer26 (unspecified device,
+  reportedly smooth at 4x/16:9) provide positive comparisons. None provides a
+  sustained benchmark, build identity or all-mode acceptance. Keep these beside
+  failures so a vendor-wide incompatibility is not inferred.
+- The maintainer's comment anticipates a preview improving frame stability.
+  It is an announcement, not the result of the Android test now in progress.
+
+## Comparison examples for future reviews
+
+These examples use the evidence reviewed for this dated triage and the linked
+repository records. They illustrate coverage, not a maintained compatibility
+list. Update the existing issue/board when new test results arrive; do not infer
+that the active Android build matches any row below.
+
+| Source / device | Build and profile known here | What the report supports | What remains unresolved |
+| --- | --- | --- | --- |
+| Reddit TypeZaxter / AYN Thor | Build/profile unknown | Positive play claim; fullscreen complaint | Race/cup duration and fullscreen meaning; no general pass |
+| GitHub #128 / AYN Thor | Build 23 per known-issue record; Retro | Reaches end of cup; reports crash and persistent system bars | Exact exit evidence and affected bars; separate from Reddit identity |
+| GitHub #102 / Fold | Actual validation comparison on build 23; Original and Retro corruption reported in separate runs | Game presents near 60 FPS in supplied interval, corruption unchanged | Actual failing draw; speed does not establish correct graphics |
+| Reddit Bubbly-Thanks-8076 / Poco X6 Pro | Build/profile unknown | Reported repeat-play decline from about 40 to 20 FPS | Exact repeat sequence, scene, settings and thermal/power context |
+| Reddit jakeburns99 / Poco X6 Pro | Build/profile unknown | Reported 60 FPS menus, 25–30 racing, lower in sections; clean graphics | Scene/build/context; do not merge with the other Poco session |
+| GitHub #103 Retroid contributor / Pocket 5 | .2 and preview 1, mainly Original, validation off | Reported standard-profile slowdown and higher-power 60 FPS | Sustained improvement on a targeted candidate; no repeat hot benchmark needed |
+| Reddit Cammie_Crossing / Pocket 5 | Build unknown; Retro | Reported sub-60 performance with active cooling | Build/settings and comparable session; not the same known profile as the GitHub result |
+| GitHub #143 / Honor X7D | Build/profile not yet supplied in reviewed record | Reported exit after import and Launch | Import completion, matching exit and console evidence |
+| Reddit SimpleDrawer26 / unspecified device | Build/profile unknown; 4x/16:9 reported | Qualitative smooth-play claim | Device, duration and completed milestone; cannot certify 4x generally |
+
+## Follow-up boundary
+
+The [Android community section in technical debt](../../TECH-DEBT.md#android-community-reports-and-flow-gaps)
+records the actionable work and acceptance criteria. Existing
+[known issues](../../KNOWN-ISSUES.md) remain the live hardware-evidence register.
+Use current GitHub evidence before asking an existing reporter to repeat work.
+For a new report, first obtain build, profile, visible failure and trigger;
+request only a short matching, reviewed diagnostic excerpt when it can answer
+the remaining question. Missing logs do not block documenting a confusing flow
+or the confirmed remapping limitation. No raw private archive, game data, save
+or account identifier is needed for this aggregation.


### PR DESCRIPTION
Community reports mix setup failures, launch crashes, graphics corruption and slow gameplay, making it difficult to choose the next useful investigation. Add a dated Reddit-to-issue mapping and an ordered technical debt plan with failure categories, focused evidence requests and explicit completion criteria.

Record the limits of positive device reports, distinguish storage/RAM/thermal symptoms, and define how existing diagnostics should identify the failed session before adding instrumentation. Link the plan from known issues and the maintenance board. Preserve current main's newer platform/support records, including confirmed offline rating transfer, and defer runtime experiment ownership to the existing Android handoff.

Validation: all 56 local file/heading links pass; staged diff whitespace check and repository safety audit pass. Four Markdown files only; no runtime, build, device or release changes.
