### PR TITLE
Add AYN Thor status-bar, aspect and remapping follow-up

### DIFF
--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -228,6 +228,20 @@ overlaps [#102](https://github.com/chrissotraidis/kartpad/issues/102); vague
 to [#119](https://github.com/chrissotraidis/kartpad/issues/119), but system bars
 and aspect-ratio letterboxing must be distinguished first.
 
+An [additional owner-supplied Thor comment](artifacts/2026-09-09/reddit-android-report-triage.md#additional-ayn-thor-report--9-september-2026)
+explicitly identifies the **top time/battery status bar** remaining visible,
+alongside the game not filling the screen. Record the status-bar symptom under
+#119/#128. Keep unused screen area separate until the selected aspect mode,
+display and screenshot distinguish expected letterboxing, system-inset sizing
+and a Fill Screen defect. No bottom-bar symptom or candidate-build result was
+supplied. Do not count this as a new unique affected device without attribution.
+
+Thor presentation acceptance: the top status bar hides during normal gameplay
+and hides again after menu/resume or a transient edge swipe; controls remain
+accessible. At the chosen aspect mode, the game uses the intended content area
+without unintended crop/stretch. Verify 4:3, 16:9 and Fill Screen separately on
+the reported display; expected letterboxing is not itself a defect.
+
 Acceptance needs the exact tested APK and a targeted affected-device result:
 same-scene cold/repeat performance with power/thermal context, an actual failing
 game draw for graphics work, or launch/menu/resume system-bar behavior for
@@ -272,10 +286,20 @@ tricks/wheelies accessible from triggers or stick clicks. Evaluate a focused
 extension after confirming the desired bindings; macOS PR #112 does not supply
 Android acceptance.
 
+The additional Thor comment requests **D-pad and shoulder-button remapping**.
+Add D-pad directions and shoulder inputs to the proposed scope, alongside the
+earlier trigger/stick-click request. Left shoulder already participates in the
+limited mapping; right shoulder and D-pad need separate consideration. Confirm
+which physical input should produce which action rather than assuming this
+comment requests the same wheelie/trick assignment as the earlier reporter.
+
 Acceptance: physical Thor or affected controller confirms the requested action,
 including press/hold/release, without breaking analog trigger behavior,
 existing defaults, saved mappings, player assignment or touch handoff. Check
 menu dismissal, disconnect/reconnect and reset for stuck or duplicate inputs.
+For D-pad support, include diagonal and simultaneous direction/button input,
+menu navigation, conflict handling and restoring defaults; distinguish digital
+shoulders from analog triggers when verifying press and release behavior.
 
 ### Freeze after changing render resolution
 

--- a/docs/artifacts/2026-09-09/reddit-android-report-triage.md
+++ b/docs/artifacts/2026-09-09/reddit-android-report-triage.md
@@ -33,6 +33,33 @@ performed for this triage.
 | Terminator996: changing render resolution freezes the game; pausing/unpausing reportedly recovers it. | New settings-transition reproduction lead; no exact matching issue found. Keep separate from online-menu stalls in [#123](https://github.com/chrissotraidis/kartpad/issues/123). | Build/device/profile, old → new scale, scene and exact pause control used; whether audio, native menu and FPS continue. Inspect settings application, renderer resource transition and lifecycle state. Pause/resume is a reporter workaround, not a verified fix. |
 | TypeZaxter: wording “fullscreen is fps uncapped.” | Ambiguous request concerning an FPS cap/uncapping, not evidence that game speed or frame limiting is broken. | Clarify whether they want a higher cap, observe uncapped rendering, or mean something else. Any future option needs game-speed/audio/physics validation; do not infer the request from punctuation. |
 
+## Additional AYN Thor report — 9 September 2026
+
+The owner supplied a further comment reporting that the game does not completely
+fill the Thor screen, leaves the time/battery bar visible at the top, and needs
+D-pad and shoulder-button remapping. No handle, permalink, build, Android version,
+selected aspect mode or screenshot accompanied it. It is not established as an
+additional unique reporter/device or a result for the active Android candidate.
+
+- **Top status bar:** the time/battery description identifies a reported Android
+  status-bar symptom, strengthening the link to #119 and the Thor bar report in
+  #128. It does not establish whether the bottom navigation bar is also affected.
+- **Unused screen area:** retain separately from the status bar. Without the
+  selected aspect mode and a screenshot, expected 4:3/16:9 letterboxing, reduced
+  usable area from system insets, and an actual Fill Screen defect remain distinct
+  possibilities. #101 is related presentation work, not a confirmed duplicate.
+- **Remapping:** expand the existing Thor controls request to include D-pad
+  directions and shoulder buttons alongside triggers/stick clicks. Current source
+  already allows the left shoulder within the limited A/B/X/Y/Z mapping; this
+  request concerns broader assignment, not total absence of shoulder mapping.
+
+Next evidence: exact build/OS, selected aspect mode, which Thor display, a screenshot
+with notifications hidden, and whether the bar is present from launch or after
+menu/resume. For controls, obtain desired physical input → game action pairs and
+which shoulder/trigger buttons are meant. No crash logs are needed to record
+these UI and control requests. See the corresponding technical debt acceptance
+criteria; do not force stretched output or assume a remapping default.
+
 ## Questions and positive reports
 
 - Switch-port and Nvidia Shield questions are demand/compatibility questions,


### PR DESCRIPTION
Record an additional owner-supplied AYN Thor report: the top time/battery bar remains visible, the game does not fill the screen, and broader D-pad/shoulder remapping is wanted. Link the status-bar symptom to #119/#128 while keeping aspect sizing separate until settings and screenshots identify the failure.

Expand controls acceptance to cover D-pad directions and shoulder inputs, preserving the existing limited left-shoulder mapping. Record missing attribution/build details without counting a new unique device or claiming a result for the active Android candidate.

Validation: 34 local links/anchors, diff whitespace check and repository safety audit pass. Two documentation files only; isolated from the Android worktree and device/build operations.
