### PR TITLE
Preserve Apple Metal views during surface recovery

### DIFF
--- a/docs/EXTERNAL-DISPLAYS.md
+++ b/docs/EXTERNAL-DISPLAYS.md
@@ -60,3 +60,9 @@ KartPad controls remain on the previous root. Reuse/destruction and control
 ownership need a forced-recovery test; display attachment causing that recovery
 and TV-only black video remain unconfirmed. This is separate from dedicated
 external output and does not authorize a scheduled IPA publication.
+
+The [native recovery correction and tests](artifacts/2026-09-09/apple-metal-surface-recovery.md)
+now preserve one Metal view per window. macOS and iPhone/iPad simulator probes
+pass repeated descriptor recreation, presentation and teardown, with failing
+unpatched controls. tvOS probe compilation also passes. Full-game surface loss
+and physical external-output acceptance remain open; this does not close #100.

--- a/docs/artifacts/2026-09-09/apple-metal-surface-recovery.md
+++ b/docs/artifacts/2026-09-09/apple-metal-surface-recovery.md
@@ -65,14 +65,16 @@ The candidate was development-signed with an existing profile that includes the
 attached iPad and installed in place over 0.4.10 / build 25. Before installation,
 the stopped app's normal NAND, Retro Rewind save directory, Mii/save backups,
 console identity, configuration and preferences were copied privately. All 32
-files (19,871,307 bytes) have identical hashes immediately after installation.
+files (19,871,307 bytes) have identical hashes immediately after installation
+and again after the candidate reached its chooser.
 The chooser launches and recognizes the existing Original and Retro Rewind
 6.12.7 installations. The signed executable SHA-256 is
 `2ea1c5e86ac43e04f4fcf362f447062d80100573eb4e47a9915111bd672ed402`.
 The iPhone was not modified. Device identifiers, signing details, backups and
 raw device logs remain outside the repository.
 
-The separate native probe also ran successfully on this physical iPad. Game
+The separate native probe also ran successfully on this physical iPad and was
+removed after its test. Game
 launch from the chooser and forced surface loss in the full game still require
 the pending on-device interaction; the probe and chooser are not gameplay
 acceptance.

--- a/docs/artifacts/2026-09-09/apple-metal-surface-recovery.md
+++ b/docs/artifacts/2026-09-09/apple-metal-surface-recovery.md
@@ -40,6 +40,7 @@ is checked after bounded run-loop settling to allow appearance transitions.
 | Native Apple Silicon macOS | 300 repeated descriptor requests, three successful Metal presentations and three layer releases pass |
 | iPad Pro 13-inch (M5), iPadOS 26.5 simulator | Same native probe passes |
 | iPhone 17 Pro, iOS 26.5 simulator | Same native probe passes |
+| Physical M2 iPad Pro 12.9-inch (6th generation), iPadOS 26.6.1 | Same native probe passes: 300 requests, stable root/overlay/layer, three presentations and three teardowns |
 | Unpatched helper, macOS and iPhone simulator | Negative controls fail at the first repeated request because the Metal layer is replaced |
 | tvOS device target | Native probe compiles and links with the existing SDL library; Mach-O TVOS, minimum 17.0; not run on Apple TV |
 | Injected SDL failures | Actual patched helper passes ASan/UBSan coverage for null window, property/create/register/layer failures, retry, descriptor destruction, independent windows and window-ID reuse |
@@ -50,7 +51,31 @@ reaches configuration; full-game configuration/build was deliberately stopped.
 All three prepared Metal helpers have SHA-256
 `451345117f3968eb3bf900da6baee9503226ac4032a475f8c8358171ebca1109`.
 The probes contain no translated game code or game assets and use a separate
-bundle identifier. The physical iPad/iPhone apps and their data were not changed.
+bundle identifier.
+
+## Physical iPad candidate
+
+The full dual-profile iPhoneOS app built from `3606741` passes the existing app
+audit. Its unsigned executable SHA-256 is
+`d4fda0c28172e870147c5bbab3e1d65cd10be8443a46f19d5b656afc1095b1ff`.
+It retains the source version metadata, 0.4.13 / build 29; this is a private
+candidate with the Metal correction, not a replacement public release.
+
+The candidate was development-signed with an existing profile that includes the
+attached iPad and installed in place over 0.4.10 / build 25. Before installation,
+the stopped app's normal NAND, Retro Rewind save directory, Mii/save backups,
+console identity, configuration and preferences were copied privately. All 32
+files (19,871,307 bytes) have identical hashes immediately after installation.
+The chooser launches and recognizes the existing Original and Retro Rewind
+6.12.7 installations. The signed executable SHA-256 is
+`2ea1c5e86ac43e04f4fcf362f447062d80100573eb4e47a9915111bd672ed402`.
+The iPhone was not modified. Device identifiers, signing details, backups and
+raw device logs remain outside the repository.
+
+The separate native probe also ran successfully on this physical iPad. Game
+launch from the chooser and forced surface loss in the full game still require
+the pending on-device interaction; the probe and chooser are not gameplay
+acceptance.
 
 ## Reproduction
 
@@ -69,4 +94,4 @@ These are native helper/recovery-path tests, not a forced Dawn surface-loss
 result inside a running game. They establish the view-ownership fix, not the
 cause or resolution of TV-only black video in #100. Full-game surface recovery,
 touch/controller continuity, wired mirroring, AirPlay and Apple TV gameplay
-remain separate acceptance gates. No IPA or game release is produced here.
+remain separate acceptance gates. No public IPA or game release is produced here.

--- a/docs/artifacts/2026-09-09/apple-metal-surface-recovery.md
+++ b/docs/artifacts/2026-09-09/apple-metal-surface-recovery.md
@@ -74,10 +74,39 @@ The iPhone was not modified. Device identifiers, signing details, backups and
 raw device logs remain outside the repository.
 
 The separate native probe also ran successfully on this physical iPad and was
-removed after its test. Game
-launch from the chooser and forced surface loss in the full game still require
-the pending on-device interaction; the probe and chooser are not gameplay
-acceptance.
+removed after its test. The user subsequently entered a Mario / Luigi Circuit
+Grand Prix race: the game and touch overlay were visible. The game exited during
+an attempted debugger attachment, before any graphics fault was injected. Its
+exact exit cause remains unconfirmed. This is not a successful full-game recovery
+test; subsequent automated checks use a separate app without a debugger.
+
+## Real WebGPU surface recreation on the physical iPad
+
+`apple_webgpu_surface_probe.mm` links the same pinned physical-iOS Dawn and SDL
+libraries and compiles the actual Metal descriptor helper. It automatically
+acquires, submits and presents 120 frames, replacing its Dawn surface after frames
+30, 60 and 90. It drains submitted GPU work, unconfigures/releases the old surface,
+creates/configures a replacement, and continues rendering. Every frame checks
+native root and overlay attachment; every recreation checks Metal-layer identity.
+Any acquisition, submission-completion, presentation or uncaptured Dawn error
+fails the test.
+
+On the same physical M2 iPad and iPadOS 26.6.1:
+
+- Corrected helper: **PASS**, three actual Dawn surface recreations and 120
+  acquired/submitted/presented frames; root, overlay and Metal layer preserved.
+- Original helper: **FAIL at frame 30**, before completing its first recreation,
+  because the Metal layer is replaced. The preceding 30 frames rendered normally.
+- The signed passing test executable has SHA-256
+  `ffb2ca0fb3089bf447c686ffe0e661e23885448801a0dc80ecb46c688fd59aed`.
+  Private signing details and device logs remain outside the repository.
+
+This is a bounded, automatic test with a separate bundle identifier,
+`dev.kartpad.webgpu-recovery-probe`. It requires no game files, debugger attachment,
+race setup, or user taps. Its own frame loop deliberately requests recreation;
+it does not simulate an OS-generated SurfaceLost event or execute Aurora's full
+presenter/worker scheduling. It also does not test physical touch delivery to
+KartPad's actual game controls.
 
 ## Reproduction
 
@@ -90,10 +119,18 @@ Run the macOS executable directly; simulator apps use bundle identifier
 Pass the unpatched Aurora directory for the negative control. No game import or
 installed KartPad data is necessary.
 
+For the WebGPU variant, add `--dawn-library` pointing to the matching SDK's pinned
+`libwebgpu_dawn.a`. The builder selects the automatic WebGPU probe and its separate
+bundle identifier. Physical-device signing/installation is still separate from
+the builder. For the negative control, use the unpatched Aurora directory with
+otherwise identical SDL/Dawn inputs; the expected failure is the first recreation
+at frame 30.
+
 ## Acceptance boundary
 
-These are native helper/recovery-path tests, not a forced Dawn surface-loss
-result inside a running game. They establish the view-ownership fix, not the
+These include native helper and actual WebGPU surface-recreation tests, not a
+forced Dawn surface-loss result inside a running game. They establish the
+view-ownership fix, not the
 cause or resolution of TV-only black video in #100. Full-game surface recovery,
 touch/controller continuity, wired mirroring, AirPlay and Apple TV gameplay
 remain separate acceptance gates. No public IPA or game release is produced here.

--- a/docs/artifacts/2026-09-09/apple-metal-surface-recovery.md
+++ b/docs/artifacts/2026-09-09/apple-metal-surface-recovery.md
@@ -1,0 +1,72 @@
+# Apple Metal surface recovery correction
+
+9 September 2026. Based on main `1e10db7`. This follows the
+[ownership investigation](external-display-surface-ownership.md) associated with
+[#100](https://github.com/chrissotraidis/kartpad/issues/100).
+
+## Reproduced defect and correction
+
+Aurora's Metal descriptor helper created a new SDL Metal view on every call.
+WebGPU surface recreation calls this helper again. SDL UIKit replaces its root
+view, leaving children of the previous root detached; on macOS, repeated calls
+also allocate additional Metal views. Existing KartPad overlay reattachment on
+activation/screenshots does not make ownership during surface recovery correct.
+
+`aurora-metal-view-lifetime.patch` owns one SDL Metal view through a window
+property and reuses it for subsequent descriptors. Its cleanup destroys the
+view when SDL cleans up the window properties, before native-window destruction
+in pinned SDL 3.4.4. Descriptor lifetime does not own the view. Creation,
+property-registration and missing-layer failures return no descriptor; cleanup
+also covers failed registration, as required by
+[SDL's cleanup contract](https://wiki.libsdl.org/SDL3/SDL_SetPointerPropertyWithCleanup).
+No retry loop, additional game window or new external-display mode is introduced.
+
+The Mac and iOS preparation scripts apply the patch. tvOS inherits iOS
+preparation. Android's shared preparation can contain the source patch, but its
+renderer does not compile the Apple-only MetalBinding.mm implementation.
+No Android runtime behavior or optimization is changed.
+
+## Validation
+
+The checked-in native probe compiles the actual prepared MetalBinding.mm against
+real SDL 3.4.4 and Dawn headers. It attaches an ordinary native button below the
+SDL root, requests 100 descriptors per window for three successive windows,
+checks root/overlay/layer identity, clears and presents a real Metal drawable,
+and verifies the layer is released after each window's teardown. UIKit release
+is checked after bounded run-loop settling to allow appearance transitions.
+
+| Target | Result |
+| --- | --- |
+| Native Apple Silicon macOS | 300 repeated descriptor requests, three successful Metal presentations and three layer releases pass |
+| iPad Pro 13-inch (M5), iPadOS 26.5 simulator | Same native probe passes |
+| iPhone 17 Pro, iOS 26.5 simulator | Same native probe passes |
+| Unpatched helper, macOS and iPhone simulator | Negative controls fail at the first repeated request because the Metal layer is replaced |
+| tvOS device target | Native probe compiles and links with the existing SDL library; Mach-O TVOS, minimum 17.0; not run on Apple TV |
+| Injected SDL failures | Actual patched helper passes ASan/UBSan coverage for null window, property/create/register/layer failures, retry, descriptor destruction, independent windows and window-ID reuse |
+| Existing Apple contracts | 23 iOS, 10 tvOS and eight macOS Python tests pass |
+
+Fresh iOS/tvOS preparation completes. macOS preparation applies all patches and
+reaches configuration; full-game configuration/build was deliberately stopped.
+All three prepared Metal helpers have SHA-256
+`451345117f3968eb3bf900da6baee9503226ac4032a475f8c8358171ebca1109`.
+The probes contain no translated game code or game assets and use a separate
+bundle identifier. The physical iPad/iPhone apps and their data were not changed.
+
+## Reproduction
+
+Run `python3 -m unittest discover -s tests -p test_apple_metal_view_lifetime.py`.
+Build the native probe using `scripts/build-apple-metal-surface-probe.py` with
+`--aurora` pointing at a prepared Aurora directory, `--sdl-include`,
+`--sdl-library`, `--dawn-include`, `--sdk` and a fresh `--output` directory.
+Run the macOS executable directly; simulator apps use bundle identifier
+`dev.kartpad.metal-recovery-probe` and can be installed/launched with `simctl`.
+Pass the unpatched Aurora directory for the negative control. No game import or
+installed KartPad data is necessary.
+
+## Acceptance boundary
+
+These are native helper/recovery-path tests, not a forced Dawn surface-loss
+result inside a running game. They establish the view-ownership fix, not the
+cause or resolution of TV-only black video in #100. Full-game surface recovery,
+touch/controller continuity, wired mirroring, AirPlay and Apple TV gameplay
+remain separate acceptance gates. No IPA or game release is produced here.

--- a/patches/aurora-metal-view-lifetime.patch
+++ b/patches/aurora-metal-view-lifetime.patch
@@ -1,0 +1,49 @@
+--- a/lib/dawn/MetalBinding.mm
++++ b/lib/dawn/MetalBinding.mm
+@@ -2,12 +2,43 @@
+ 
+ #import <Foundation/Foundation.h>
+ #include <SDL3/SDL_metal.h>
++#include <SDL3/SDL_properties.h>
++#include <SDL3/SDL_video.h>
+ 
+ namespace aurora::webgpu::utils {
++namespace {
++constexpr const char* MetalViewProperty = "aurora.window.metal_view";
++
++void SDLCALL DestroyMetalView(void*, void* value) {
++  SDL_Metal_DestroyView(value);
++}
++} // namespace
++
+ std::shared_ptr<wgpu::ChainedStruct> SetupWindowAndGetSurfaceDescriptorCocoa(SDL_Window* window) {
+-  SDL_MetalView view = SDL_Metal_CreateView(window);
+-  std::shared_ptr<wgpu::SurfaceSourceMetalLayer> desc = std::make_shared<wgpu::SurfaceSourceMetalLayer>();
++  const auto properties = SDL_GetWindowProperties(window);
++  if (!properties) {
++    return nullptr;
++  }
++  auto view = SDL_GetPointerProperty(properties, MetalViewProperty, nullptr);
++  if (!view) {
++    view = SDL_Metal_CreateView(window);
++    if (!view) {
++      return nullptr;
++    }
++    // Own one view per window, not per WebGPU surface. Surface recovery must
++    // preserve the UIKit root and its controls (and the Cocoa Metal subview).
++    // SDL cleans window properties before destroying its native window.
++    // The cleanup callback also runs if setting the property fails.
++    if (!SDL_SetPointerPropertyWithCleanup(properties, MetalViewProperty, view, DestroyMetalView, nullptr)) {
++      return nullptr;
++    }
++  }
++  auto desc = std::make_shared<wgpu::SurfaceSourceMetalLayer>();
+   desc->layer = SDL_Metal_GetLayer(view);
+-  return std::move(desc);
++  if (!desc->layer) {
++    SDL_ClearProperty(properties, MetalViewProperty);
++    return nullptr;
++  }
++  return desc;
+ }
+ } // namespace aurora::webgpu::utils

--- a/scripts/build-apple-metal-surface-probe.py
+++ b/scripts/build-apple-metal-surface-probe.py
@@ -14,6 +14,8 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     for name in ('aurora', 'sdl-include', 'sdl-library', 'dawn-include', 'output'):
         parser.add_argument('--' + name, required=True, type=Path)
+    parser.add_argument('--dawn-library', type=Path,
+                        help='Link Dawn and exercise real WebGPU surface recreation')
     parser.add_argument('--sdk', choices=('macosx', 'iphonesimulator', 'appletvsimulator',
                                          'iphoneos', 'appletvos'), required=True)
     args = parser.parse_args()
@@ -31,7 +33,8 @@ def main():
         app.mkdir(exist_ok=True)
         binary = app / 'MetalProbe'
         with (app / 'Info.plist').open('wb') as f:
-            plistlib.dump(dict(CFBundleIdentifier='dev.kartpad.metal-recovery-probe',
+            plistlib.dump(dict(CFBundleIdentifier=('dev.kartpad.webgpu-recovery-probe' if args.dawn_library
+                                                 else 'dev.kartpad.metal-recovery-probe'),
                               CFBundleName='Metal Recovery Probe', CFBundleExecutable='MetalProbe',
                               CFBundleVersion='1', CFBundleShortVersionString='1.0',
                               CFBundlePackageType='APPL', MinimumOSVersion='17.0' if 'tvos' in args.sdk else '16.0',
@@ -49,9 +52,13 @@ def main():
            '-target', targets[args.sdk], '-isysroot', sdk,
            '-I' + str(args.sdl_include), '-I' + str(args.dawn_include),
            '-I' + str(args.aurora / 'lib/dawn'),
-           str(root / 'tests/native/apple_metal_surface_probe.mm'),
+           str(root / ('tests/native/apple_webgpu_surface_probe.mm' if args.dawn_library
+                       else 'tests/native/apple_metal_surface_probe.mm')),
            str(args.aurora / 'lib/dawn/MetalBinding.mm'), str(args.sdl_library),
            '-liconv', '-o', str(binary)]
+    if args.dawn_library:
+        cmd += [str(args.dawn_library)]
+        frameworks += ['IOSurface', 'Security']
     for framework in frameworks:
         cmd += ['-framework', framework]
     subprocess.run(cmd, check=True)

--- a/scripts/build-apple-metal-surface-probe.py
+++ b/scripts/build-apple-metal-surface-probe.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Build the native recovery probe against an existing prepared Aurora and SDL.
+
+Run the macOS executable directly. Install/launch simulator apps with simctl;
+this builder does not operate devices or sign physical-device apps.
+"""
+import argparse
+from pathlib import Path
+import plistlib
+import subprocess
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    for name in ('aurora', 'sdl-include', 'sdl-library', 'dawn-include', 'output'):
+        parser.add_argument('--' + name, required=True, type=Path)
+    parser.add_argument('--sdk', choices=('macosx', 'iphonesimulator', 'appletvsimulator',
+                                         'iphoneos', 'appletvos'), required=True)
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[1]
+    sdk = subprocess.check_output(['xcrun', '--sdk', args.sdk, '--show-sdk-path'], text=True).strip()
+    targets = {'macosx': 'arm64-apple-macos14.0', 'iphonesimulator': 'arm64-apple-ios16.0-simulator',
+               'iphoneos': 'arm64-apple-ios16.0', 'appletvos': 'arm64-apple-tvos17.0',
+               'appletvsimulator': 'arm64-apple-tvos17.0-simulator'}
+    desktop = args.sdk == 'macosx'
+    args.output.mkdir(parents=True, exist_ok=True)
+    if desktop:
+        binary = args.output / 'MetalProbe'
+    else:
+        app = args.output / 'MetalProbe.app'
+        app.mkdir(exist_ok=True)
+        binary = app / 'MetalProbe'
+        with (app / 'Info.plist').open('wb') as f:
+            plistlib.dump(dict(CFBundleIdentifier='dev.kartpad.metal-recovery-probe',
+                              CFBundleName='Metal Recovery Probe', CFBundleExecutable='MetalProbe',
+                              CFBundleVersion='1', CFBundleShortVersionString='1.0',
+                              CFBundlePackageType='APPL', MinimumOSVersion='17.0' if 'tvos' in args.sdk else '16.0',
+                              UIDeviceFamily=[3] if 'tvos' in args.sdk else [1, 2],
+                              UIApplicationSupportsIndirectInputEvents=True, UILaunchScreen={},
+                              UISupportedInterfaceOrientations=['UIInterfaceOrientationLandscapeLeft',
+                                                               'UIInterfaceOrientationLandscapeRight']), f)
+    frameworks = ('CoreVideo CoreAudio AudioToolbox GameController CoreHaptics Metal QuartzCore '
+                  'UniformTypeIdentifiers AVFoundation Foundation CoreMedia').split()
+    frameworks += ('Cocoa IOKit Carbon ForceFeedback' if desktop else
+                   'UIKit OpenGLES CoreGraphics CoreBluetooth').split()
+    if args.sdk.startswith('iphone'):
+        frameworks.append('CoreMotion')
+    cmd = ['xcrun', '--sdk', args.sdk, 'clang++', '-std=c++20', '-fobjc-arc',
+           '-target', targets[args.sdk], '-isysroot', sdk,
+           '-I' + str(args.sdl_include), '-I' + str(args.dawn_include),
+           '-I' + str(args.aurora / 'lib/dawn'),
+           str(root / 'tests/native/apple_metal_surface_probe.mm'),
+           str(args.aurora / 'lib/dawn/MetalBinding.mm'), str(args.sdl_library),
+           '-liconv', '-o', str(binary)]
+    for framework in frameworks:
+        cmd += ['-framework', framework]
+    subprocess.run(cmd, check=True)
+    if 'simulator' in args.sdk:
+        subprocess.run(['codesign', '--force', '--sign', '-', '--timestamp=none', str(app)], check=True)
+    print(binary if desktop else app)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/prepare-g7-game-runtime.sh
+++ b/scripts/prepare-g7-game-runtime.sh
@@ -53,6 +53,8 @@ PYTHONPATH="${repo_root}/builder" python3 -m kartpad_builder.release_header \
 patch --batch -p1 -d "${runtime_source}/aurora-main" < \
   "${repo_root}/patches/aurora-present-telemetry.patch"
 patch --batch -p1 -d "${runtime_source}/aurora-main" < \
+  "${repo_root}/patches/aurora-metal-view-lifetime.patch"
+patch --batch -p1 -d "${runtime_source}/aurora-main" < \
   "${repo_root}/patches/aurora-gx-resolve-snapshot-copy-src.patch"
 patch --batch -p1 -d "${runtime_source}/aurora-main" < \
   "${repo_root}/patches/aurora-viewport-policy-window-guard.patch"

--- a/scripts/prepare-ios-game-runtime.sh
+++ b/scripts/prepare-ios-game-runtime.sh
@@ -77,6 +77,8 @@ cp -R "${repo_root}/ref/upstream/Wiicompiled/aurora-main" \
 patch --batch -p1 -d "${runtime_source}/aurora-main" < \
   "${repo_root}/patches/aurora-present-telemetry.patch"
 patch --batch -p1 -d "${runtime_source}/aurora-main" < \
+  "${repo_root}/patches/aurora-metal-view-lifetime.patch"
+patch --batch -p1 -d "${runtime_source}/aurora-main" < \
   "${repo_root}/patches/aurora-gx-resolve-snapshot-copy-src.patch"
 patch --batch -p1 -d "${runtime_source}/aurora-main" < \
   "${repo_root}/patches/aurora-ios-opaque-letterbox.patch"

--- a/tests/native/apple_metal_surface_probe.mm
+++ b/tests/native/apple_metal_surface_probe.mm
@@ -1,0 +1,89 @@
+// Native SDL/Metal recovery probe. No game code, data or installed KartPad state.
+#import <Foundation/Foundation.h>
+#import <QuartzCore/CAMetalLayer.h>
+#import <Metal/Metal.h>
+#import <TargetConditionals.h>
+#if TARGET_OS_OSX
+#import <Cocoa/Cocoa.h>
+#else
+#import <UIKit/UIKit.h>
+#endif
+#include <SDL3/SDL.h>
+#include "BackendBinding.hpp"
+#include <cstdio>
+#include <cstdlib>
+namespace aurora::webgpu::utils {
+std::shared_ptr<wgpu::ChainedStruct> SetupWindowAndGetSurfaceDescriptorCocoa(SDL_Window*);
+}
+static void check(bool ok, const char* message) {
+  if (!ok) { fprintf(stderr, "FAIL: %s (%s)\n", message, SDL_GetError()); fflush(stderr); exit(1); }
+}
+static CAMetalLayer* descriptor(SDL_Window* window) {
+  auto d = aurora::webgpu::utils::SetupWindowAndGetSurfaceDescriptorCocoa(window);
+  check(bool(d), "descriptor exists");
+  return (__bridge CAMetalLayer*)static_cast<wgpu::SurfaceSourceMetalLayer*>(d.get())->layer;
+}
+static void runProbe() {
+  check(SDL_Init(SDL_INIT_VIDEO), "SDL video init");
+  for (int cycle = 0; cycle < 3; ++cycle) {
+    __weak CAMetalLayer* destroyedLayer;
+    @autoreleasepool {
+      auto window = SDL_CreateWindow("KartPad Metal recovery test", 640, 480, SDL_WINDOW_METAL | SDL_WINDOW_RESIZABLE);
+      check(window != nullptr, "create window");
+      CAMetalLayer* layer = descriptor(window);
+      destroyedLayer = layer;
+#if TARGET_OS_OSX
+      NSWindow* native = (__bridge NSWindow*)SDL_GetPointerProperty(SDL_GetWindowProperties(window), SDL_PROP_WINDOW_COCOA_WINDOW_POINTER, nullptr);
+      NSView* root = native.contentView;
+      NSButton* overlay = [[NSButton alloc] initWithFrame:NSMakeRect(20,20,100,40)];
+#else
+      UIWindow* native = (__bridge UIWindow*)SDL_GetPointerProperty(SDL_GetWindowProperties(window), SDL_PROP_WINDOW_UIKIT_WINDOW_POINTER, nullptr);
+      UIView* root = native.rootViewController.view;
+      UIButton* overlay = [[UIButton alloc] initWithFrame:CGRectMake(20,20,100,40)];
+#endif
+      [root addSubview:overlay];
+      for (int recovery = 0; recovery < 100; ++recovery) {
+        @autoreleasepool {
+          check(descriptor(window) == layer, "recovery preserves Metal layer");
+#if TARGET_OS_OSX
+          check(native.contentView == root, "recovery preserves root");
+#else
+          check(native.rootViewController.view == root, "recovery preserves root");
+#endif
+          check(overlay.superview == root && overlay.window == native, "overlay remains attached to visible window");
+          SDL_PumpEvents();
+        }
+      }
+      layer.device = MTLCreateSystemDefaultDevice();
+      layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+      id<CAMetalDrawable> drawable = [layer nextDrawable];
+      check(drawable != nil, "drawable after repeated recovery");
+      auto pass = [MTLRenderPassDescriptor renderPassDescriptor];
+      pass.colorAttachments[0].texture = drawable.texture;
+      pass.colorAttachments[0].loadAction = MTLLoadActionClear;
+      pass.colorAttachments[0].storeAction = MTLStoreActionStore;
+      pass.colorAttachments[0].clearColor = MTLClearColorMake(0.05, 0.35, 0.15, 1);
+      auto queue = [layer.device newCommandQueue];
+      auto buffer = [queue commandBuffer];
+      auto encoder = [buffer renderCommandEncoderWithDescriptor:pass];
+      [encoder endEncoding];
+      [buffer presentDrawable:drawable];
+      [buffer commit];
+      [buffer waitUntilCompleted];
+      check(buffer.status == MTLCommandBufferStatusCompleted, "Metal presentation completes");
+      SDL_DestroyWindow(window);
+    }
+    for (int i = 0; i < 20 && destroyedLayer != nil; ++i) {
+      @autoreleasepool { CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.05, false); }
+    }
+    check(destroyedLayer == nil, "window teardown releases Metal layer");
+  }
+  SDL_Quit();
+  fprintf(stderr, "PASS: 300 descriptor recoveries; root/overlay/layer stable; 3 presentations and window teardowns\n"); fflush(stderr);
+}
+#define SDL_MAIN_USE_CALLBACKS 1
+#include <SDL3/SDL_main.h>
+SDL_AppResult SDL_AppInit(void**, int, char**) { runProbe(); return SDL_APP_SUCCESS; }
+SDL_AppResult SDL_AppIterate(void*) { return SDL_APP_SUCCESS; }
+SDL_AppResult SDL_AppEvent(void*, SDL_Event*) { return SDL_APP_CONTINUE; }
+void SDL_AppQuit(void*, SDL_AppResult) {}

--- a/tests/native/apple_webgpu_surface_probe.mm
+++ b/tests/native/apple_webgpu_surface_probe.mm
@@ -1,0 +1,215 @@
+// Automated Dawn/Metal surface recreation. No game, saves, or debugger attachment.
+#import <Foundation/Foundation.h>
+#import <QuartzCore/CAMetalLayer.h>
+#import <TargetConditionals.h>
+#if TARGET_OS_OSX
+#import <Cocoa/Cocoa.h>
+#else
+#import <UIKit/UIKit.h>
+#endif
+#include <SDL3/SDL.h>
+#include "BackendBinding.hpp"
+#include <cstdio>
+#include <cstdlib>
+#include <string_view>
+
+namespace aurora::webgpu::utils {
+std::shared_ptr<wgpu::ChainedStruct> SetupWindowAndGetSurfaceDescriptorCocoa(SDL_Window*);
+}
+namespace {
+SDL_Window* window;
+wgpu::Instance instance;
+wgpu::Adapter adapter;
+wgpu::Device device;
+wgpu::Queue queue;
+wgpu::Surface surface;
+wgpu::SurfaceConfiguration config;
+CAMetalLayer* originalLayer;
+#if TARGET_OS_OSX
+NSWindow* nativeWindow;
+NSView* originalRoot;
+NSButton* overlay;
+#else
+UIWindow* nativeWindow;
+UIView* originalRoot;
+UIButton* overlay;
+#endif
+unsigned frames = 0, recreations = 0;
+
+void check(bool ok, const char* message) {
+  if (!ok) {
+    fprintf(stderr, "FAIL: %s; frame=%u recreations=%u SDL=%s\n",
+            message, frames, recreations, SDL_GetError());
+    fflush(stderr);
+    exit(1);
+  }
+}
+
+void drain() {
+  bool completed = false;
+  auto future = queue.OnSubmittedWorkDone(wgpu::CallbackMode::WaitAnyOnly,
+      [&completed](wgpu::QueueWorkDoneStatus status, wgpu::StringView) {
+        completed = status == wgpu::QueueWorkDoneStatus::Success;
+      });
+  check(instance.WaitAny(future, 5000000000) == wgpu::WaitStatus::Success && completed,
+        "submitted GPU work completes");
+}
+
+void checkViews() {
+#if TARGET_OS_OSX
+  check(nativeWindow.contentView == originalRoot, "native root survives surface recreation");
+#else
+  check(nativeWindow.rootViewController.view == originalRoot, "native root survives surface recreation");
+#endif
+  check(overlay.superview == originalRoot && overlay.window == nativeWindow,
+        "native overlay remains in the window");
+}
+
+void createSurface() {
+  // Match Aurora's descriptor -> release old surface -> create new surface order.
+  auto chain = aurora::webgpu::utils::SetupWindowAndGetSurfaceDescriptorCocoa(window);
+  check(bool(chain), "Metal surface descriptor exists");
+  auto layer = (__bridge CAMetalLayer*)static_cast<wgpu::SurfaceSourceMetalLayer*>(chain.get())->layer;
+  if (originalLayer) {
+    check(layer == originalLayer, "Metal layer survives real WebGPU surface recreation");
+    checkViews();
+  } else {
+    originalLayer = layer;
+  }
+  if (surface) {
+    surface.Unconfigure();
+    surface = {};
+    drain();
+  }
+  wgpu::SurfaceDescriptor descriptor{.nextInChain = chain.get(), .label = "Recovery probe"};
+  surface = instance.CreateSurface(&descriptor);
+  check(bool(surface), "Dawn creates surface");
+}
+
+void initialize() {
+  check(SDL_Init(SDL_INIT_VIDEO), "SDL video initializes");
+  window = SDL_CreateWindow("KartPad graphics recovery check", 640, 480,
+                             SDL_WINDOW_METAL | SDL_WINDOW_RESIZABLE);
+  check(window != nullptr, "SDL window exists");
+  const auto feature = wgpu::InstanceFeatureName::TimedWaitAny;
+  const wgpu::InstanceDescriptor descriptor{.requiredFeatureCount = 1, .requiredFeatures = &feature};
+  instance = wgpu::CreateInstance(&descriptor);
+  check(bool(instance), "Dawn instance exists");
+  createSurface();
+#if TARGET_OS_OSX
+  nativeWindow = (__bridge NSWindow*)SDL_GetPointerProperty(SDL_GetWindowProperties(window),
+      SDL_PROP_WINDOW_COCOA_WINDOW_POINTER, nullptr);
+  originalRoot = nativeWindow.contentView;
+  overlay = [[NSButton alloc] initWithFrame:NSMakeRect(20, 20, 320, 50)];
+  overlay.title = @"Automatic graphics recovery check";
+#else
+  nativeWindow = (__bridge UIWindow*)SDL_GetPointerProperty(SDL_GetWindowProperties(window),
+      SDL_PROP_WINDOW_UIKIT_WINDOW_POINTER, nullptr);
+  originalRoot = nativeWindow.rootViewController.view;
+  overlay = [[UIButton alloc] initWithFrame:CGRectMake(20, 20, 320, 50)];
+  [overlay setTitle:@"Automatic graphics recovery check" forState:UIControlStateNormal];
+#endif
+  [originalRoot addSubview:overlay];
+  const wgpu::RequestAdapterOptions options{.backendType = wgpu::BackendType::Metal,
+                                           .compatibleSurface = surface};
+  auto future = instance.RequestAdapter(&options, wgpu::CallbackMode::WaitAnyOnly,
+      [](wgpu::RequestAdapterStatus status, wgpu::Adapter result, wgpu::StringView) {
+        if (status == wgpu::RequestAdapterStatus::Success) adapter = std::move(result);
+      });
+  check(instance.WaitAny(future, 5000000000) == wgpu::WaitStatus::Success && adapter,
+        "Metal adapter request succeeds");
+  wgpu::DeviceDescriptor deviceDescriptor{};
+  deviceDescriptor.SetUncapturedErrorCallback(
+      [](const wgpu::Device&, wgpu::ErrorType, wgpu::StringView message) {
+        const std::string_view text{message};
+        fprintf(stderr, "Dawn error: %.*s\n", int(text.size()), text.data());
+        check(false, "no uncaptured Dawn error");
+      });
+  future = adapter.RequestDevice(&deviceDescriptor, wgpu::CallbackMode::WaitAnyOnly,
+      [](wgpu::RequestDeviceStatus status, wgpu::Device result, wgpu::StringView) {
+        if (status == wgpu::RequestDeviceStatus::Success) device = std::move(result);
+      });
+  check(instance.WaitAny(future, 5000000000) == wgpu::WaitStatus::Success && device,
+        "Metal device request succeeds");
+  queue = device.GetQueue();
+  wgpu::SurfaceCapabilities caps;
+  check(surface.GetCapabilities(adapter, &caps) == wgpu::Status::Success && caps.formatCount,
+        "surface capabilities available");
+  int width = 0, height = 0;
+  check(SDL_GetWindowSizeInPixels(window, &width, &height) && width > 0 && height > 0,
+        "native pixel dimensions available");
+  config.device = device;
+  config.format = caps.formats[0];
+  config.usage = wgpu::TextureUsage::RenderAttachment;
+  config.width = width;
+  config.height = height;
+  config.presentMode = wgpu::PresentMode::Fifo;
+  config.alphaMode = caps.alphaModes[0];
+  surface.Configure(&config);
+}
+
+void frame() {
+  // A bounded automatic trigger replaces debugger-driven fault injection here.
+  // Each cycle has visible frames before and after a real surface replacement.
+  if (frames != 0 && frames % 30 == 0) {
+    drain();
+    createSurface();
+    surface.Configure(&config);
+    ++recreations;
+  }
+  wgpu::SurfaceTexture acquired;
+  surface.GetCurrentTexture(&acquired);
+  check(acquired.status == wgpu::SurfaceGetCurrentTextureStatus::SuccessOptimal ||
+        acquired.status == wgpu::SurfaceGetCurrentTextureStatus::SuccessSuboptimal,
+        "surface texture acquired after recovery");
+  check(bool(acquired.texture), "acquired surface texture exists");
+  wgpu::RenderPassColorAttachment color{};
+  color.view = acquired.texture.CreateView();
+  color.loadOp = wgpu::LoadOp::Clear;
+  color.storeOp = wgpu::StoreOp::Store;
+  color.clearValue = {0.05, 0.15 + 0.15 * recreations, 0.3, 1.0};
+  const wgpu::RenderPassDescriptor passDescriptor{.colorAttachmentCount = 1, .colorAttachments = &color};
+  auto encoder = device.CreateCommandEncoder();
+  auto pass = encoder.BeginRenderPass(&passDescriptor);
+  pass.End();
+  auto command = encoder.Finish();
+  queue.Submit(1, &command);
+  check(surface.Present() == wgpu::Status::Success, "Dawn presents frame");
+  checkViews();
+  ++frames;
+  SDL_Delay(16);
+}
+
+void finish() {
+  drain();
+  check(recreations == 3 && frames == 120, "all recovery cycles completed");
+  surface.Unconfigure();
+  surface = {};
+  config.device = {};
+  queue = {};
+  device = {};
+  adapter = {};
+  instance = {};
+  overlay = nil;
+  originalRoot = nil;
+  nativeWindow = nil;
+  originalLayer = nil;
+  SDL_DestroyWindow(window);
+  SDL_Quit();
+  fprintf(stderr, "PASS: 3 real Dawn surface recreations; 120 acquired/submitted/presented frames; root, overlay and Metal layer preserved\n");
+  fflush(stderr);
+}
+} // namespace
+#define SDL_MAIN_USE_CALLBACKS 1
+#include <SDL3/SDL_main.h>
+SDL_AppResult SDL_AppInit(void**, int, char**) { initialize(); return SDL_APP_CONTINUE; }
+SDL_AppResult SDL_AppIterate(void*) {
+  frame();
+  if (frames < 120) return SDL_APP_CONTINUE;
+  finish();
+  return SDL_APP_SUCCESS;
+}
+SDL_AppResult SDL_AppEvent(void*, SDL_Event* event) {
+  return event->type == SDL_EVENT_QUIT ? SDL_APP_FAILURE : SDL_APP_CONTINUE;
+}
+void SDL_AppQuit(void*, SDL_AppResult) {}

--- a/tests/test_apple_metal_view_lifetime.py
+++ b/tests/test_apple_metal_view_lifetime.py
@@ -1,0 +1,110 @@
+"""Exercise the actual patched helper with injected SDL failures under sanitizers."""
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCH = ROOT / 'patches/aurora-metal-view-lifetime.patch'
+
+
+@unittest.skipUnless(shutil.which('clang++'), 'requires clang++ and sanitizers')
+class MetalViewLifetimeTests(unittest.TestCase):
+    def test_actual_helper_ownership_and_failures(self):
+        # The patch replaces this complete small upstream file; reconstruct its
+        # preimage so this regression also runs without private runtime inputs.
+        before = ''.join(line[1:] + '\n' for line in PATCH.read_text().splitlines()
+                         if line.startswith((' ', '-')) and not line.startswith('---'))
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            source = tmp / 'lib/dawn/MetalBinding.mm'
+            source.parent.mkdir(parents=True)
+            source.write_text(before)
+            subprocess.run(['patch', '--batch', '-p1', '-d', d, '-i', str(PATCH)],
+                           capture_output=True, text=True, check=True)
+            (tmp / 'Foundation').mkdir()
+            (tmp / 'Foundation/Foundation.h').write_text('')
+            (tmp / 'SDL3').mkdir()
+            stub = r'''
+#pragma once
+#include <map>
+#include <memory>
+#include <cassert>
+#include <cstdio>
+#define SDLCALL
+struct SDL_Window { int id; };
+using SDL_PropertiesID = int;
+using SDL_MetalView = void*;
+using Cleanup = void(*)(void*, void*);
+struct Property { void* view; Cleanup cleanup; };
+inline std::map<int, Property> props;
+inline int creates = 0, destroys = 0;
+inline bool failProperties = false, failCreate = false, failSet = false, failLayer = false;
+inline int SDL_GetWindowProperties(SDL_Window* w) { return w && !failProperties ? w->id : 0; }
+inline void* SDL_GetPointerProperty(int id, const char*, void*) {
+  auto p = props.find(id); return p == props.end() ? nullptr : p->second.view;
+}
+inline void SDL_Metal_DestroyView(void* view) { ++destroys; delete static_cast<int*>(view); }
+inline void* SDL_Metal_CreateView(SDL_Window*) { if (failCreate) return nullptr; ++creates; return new int(creates); }
+inline bool SDL_SetPointerPropertyWithCleanup(int id, const char*, void* view, Cleanup cleanup, void*) {
+  if (failSet) { cleanup(nullptr, view); return false; }
+  assert(!props.count(id)); props[id] = {view, cleanup}; return true;
+}
+inline void* SDL_Metal_GetLayer(void* view) { return failLayer ? nullptr : view; }
+inline bool SDL_ClearProperty(int id, const char*) {
+  auto p = props.find(id);
+  if (p != props.end()) { p->second.cleanup(nullptr, p->second.view); props.erase(p); }
+  return true;
+}
+namespace wgpu {
+struct ChainedStruct {};
+struct SurfaceSourceMetalLayer : ChainedStruct { void* layer = nullptr; };
+}
+'''
+            (tmp / 'stub.hpp').write_text(stub)
+            for header in ['SDL_metal.h', 'SDL_video.h', 'SDL_properties.h']:
+                (tmp / 'SDL3' / header).write_text('#include "stub.hpp"\n')
+            (source.parent / 'BackendBinding.hpp').write_text('#include "stub.hpp"\n')
+            test = tmp / 'test.cpp'
+            test.write_text(r'''
+#include "lib/dawn/MetalBinding.mm"
+using aurora::webgpu::utils::SetupWindowAndGetSurfaceDescriptorCocoa;
+auto get(SDL_Window* w) { return SetupWindowAndGetSurfaceDescriptorCocoa(w); }
+void reset() { assert(props.empty()); assert(creates == destroys); creates = destroys = 0; }
+int main() {
+  SDL_Window a{1}, b{2};
+  assert(!get(nullptr)); assert(creates == 0);
+  failProperties = true; assert(!get(&a)); assert(creates == 0); failProperties = false;
+  failCreate = true; assert(!get(&a)); assert(props.empty()); failCreate = false;
+  failSet = true; assert(!get(&a)); assert(creates == 1 && destroys == 1); failSet = false; reset();
+  failLayer = true; assert(!get(&a)); assert(creates == 1 && destroys == 1); failLayer = false; reset();
+  auto layer = static_cast<wgpu::SurfaceSourceMetalLayer*>(get(&a).get())->layer;
+  for (int i = 0; i < 100; ++i) {
+    auto desc = get(&a);
+    assert(static_cast<wgpu::SurfaceSourceMetalLayer*>(desc.get())->layer == layer);
+  }
+  assert(creates == 1 && destroys == 0); // descriptors do not own the view
+  auto second = get(&b);
+  assert(static_cast<wgpu::SurfaceSourceMetalLayer*>(second.get())->layer != layer);
+  assert(creates == 2);
+  SDL_ClearProperty(a.id, ""); assert(destroys == 1);
+  assert(get(&b)); assert(creates == 2); // separate windows do not share ownership
+  SDL_ClearProperty(b.id, ""); reset();
+  assert(get(&a)); assert(creates == 1); // window ID reuse creates a fresh view
+  failLayer = true; assert(!get(&a)); assert(destroys == 1); failLayer = false;
+  assert(get(&a)); assert(creates == 2); // retry after failed layer
+  SDL_ClearProperty(a.id, ""); reset();
+  puts("PASS: null window, properties/create/set/layer failures, retry, recovery, two windows and teardown");
+}
+''')
+            binary = tmp / 'test'
+            subprocess.run(['clang++', '-std=c++20', '-fsanitize=address,undefined',
+                            '-fno-omit-frame-pointer', '-I' + d, str(test), '-o', str(binary)],
+                           capture_output=True, text=True, check=True)
+            result = subprocess.run([str(binary)], capture_output=True, text=True, check=True)
+            self.assertIn('PASS:', result.stdout)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Repeated WebGPU surface creation allocated a new SDL Metal view each time. On UIKit that replaces the root holding KartPad's controls; on macOS it accumulates Metal views. Keep one view owned by each SDL window, reuse it for new descriptors, and release it during window cleanup, including failure paths.

Validation:
- The actual prepared helper with SDL 3.4.4 passes 300 descriptor requests, three Metal presentations and three layer teardowns on native macOS, iPhone/iPad simulators, and the physical M2 iPad. Unpatched macOS/iPhone controls fail at the first repeated request. The tvOS native probe compiles and links.
- A new automatic physical-iPad probe uses the pinned Dawn library: three real WebGPU surface recreations and 120 acquired/submitted/presented frames pass with root, overlay and layer preserved. With the original helper, the same probe fails at frame 30, its first recreation. No game files, debugger or user taps are required; the temporary app was removed.
- Injected helper failures pass ASan/UBSan; 41 existing Apple contracts pass. The full physical-iOS candidate builds and passes its app audit. Its in-place installation preserved all 32 protected files byte-for-byte before/after installation and chooser launch.

Related to #100. These tests establish view ownership and explicit WebGPU surface recreation. Aurora's complete worker/presenter recovery path, physical game-control continuity, wired mirroring, AirPlay and Apple TV gameplay remain unverified. A user-driven race rendered on the iPad, but it exited during debugger setup before any fault injection; that attempted test is not counted as recovery acceptance. No public game release is included.

[Reproduction and evidence](docs/artifacts/2026-09-09/apple-metal-surface-recovery.md) include the automatic probe's build option and the physical negative control.
