### PR TITLE
Clarify iOS report attachments and keep render resolution in Display

### DIFF
--- a/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
@@ -26,8 +26,6 @@ import android.widget.EditText
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.PopupWindow
-import android.widget.RadioButton
-import android.widget.RadioGroup
 import android.widget.RelativeLayout
 import android.widget.ScrollView
 import android.widget.SeekBar
@@ -1674,29 +1672,6 @@ class KartPadActivity : SDLActivity() {
             setPadding(dp(18), dp(4), dp(18), dp(4))
         }
         val opacityLabel = settingsLabel("")
-        val renderLabel = settingsLabel("Render")
-        val renderScales = floatArrayOf(1f, 2f, 3f, 4f)
-        val render = RadioGroup(this).apply {
-            orientation = RadioGroup.HORIZONTAL
-            gravity = Gravity.CENTER_VERTICAL
-            contentDescription = "Render resolution"
-        }
-        val currentRenderScale = KartPadTouchSettings.resolutionScale(this)
-        renderScales.forEach { scale ->
-            render.addView(RadioButton(this).apply {
-                id = View.generateViewId()
-                text = if (scale == 1f) "1×" else "${scale.toInt()}×"
-                setTextColor(Color.WHITE)
-                tag = scale
-                isChecked = kotlin.math.abs(scale - currentRenderScale) < 0.01f
-            })
-        }
-        render.setOnCheckedChangeListener { group, checkedId ->
-            val scale = group.findViewById<RadioButton>(checkedId)?.tag as? Float
-                ?: return@setOnCheckedChangeListener
-            KartPadTouchSettings.setResolutionScale(this, scale)
-            applyDisplaySettings()
-        }
         val opacity = SeekBar(this).apply {
             max = 75
             progress = (KartPadTouchSettings.opacity(this@KartPadActivity) * 100f)
@@ -1781,8 +1756,6 @@ class KartPadActivity : SDLActivity() {
         val leftColumn = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
             setPadding(0, 0, dp(12), 0)
-            addView(renderLabel)
-            addView(render)
             addView(opacityLabel)
             addView(opacity)
             addView(sizeLabel)
@@ -1819,15 +1792,10 @@ class KartPadActivity : SDLActivity() {
         dialog.show()
         touchSettingsDialog = dialog
         if (debugSettingsFlow != null) {
-            render.post {
+            content.post {
                 runCatching {
-                    val render3 = (0 until render.childCount)
-                        .map { render.getChildAt(it) as RadioButton }
-                        .first { it.tag == 3f }
                     when (debugSettingsFlow) {
                         "seed" -> {
-                            render3.performClick()
-                            check(render3.isChecked) { "3x render did not become checked" }
                             fun setProgress(control: SeekBar, value: Float) {
                                 val arguments = Bundle().apply {
                                     putFloat(
@@ -1852,34 +1820,34 @@ class KartPadActivity : SDLActivity() {
                             val savedSize = KartPadTouchSettings.size(this)
                             val savedHide = KartPadTouchSettings.hideOnController(this)
                             val savedModern = KartPadTouchSettings.modernCStickHorizontal(this)
-                            check(savedRender == 3f && kotlin.math.abs(savedOpacity - 0.64f) < 0.001f &&
+                            check(savedRender == 1f && kotlin.math.abs(savedOpacity - 0.64f) < 0.001f &&
                                 kotlin.math.abs(savedSize - 1.20f) < 0.001f && !savedHide && savedModern
                             ) {
                                 "touch settings seeded render=$savedRender opacity=$savedOpacity " +
                                     "size=$savedSize hide=$savedHide modern=$savedModern"
                             }
                             check(nativeDebugDisplaySettings() ==
-                                "fps=true aspect=0 scale=3.0"
-                            ) { "3x render did not cross the source-fixture JNI bridge" }
+                                "fps=true aspect=0 scale=1.0"
+                            ) { "touch settings changed the display resolution" }
                             Log.i(
                                 TAG,
-                                "A4 touch settings flow seeded render=3x opacity=64 size=120 " +
+                                "A4 touch settings flow seeded render=1x opacity=64 size=120 " +
                                     "hide=false modern=true",
                             )
                         }
                         "verify" -> {
-                            check(render3.isChecked && opacity.progress == 39 && size.progress == 50 &&
+                            check(KartPadTouchSettings.resolutionScale(this) == 1f &&
+                                opacity.progress == 39 && size.progress == 50 &&
                                 opacityLabel.text == "Opacity: 64%" &&
                                 sizeLabel.text == "All sizes: 120%" &&
                                 !hide.isChecked && modernCStick.isChecked
                             ) { "touch settings widgets did not reload persisted values" }
                             KartPadTouchSettings.resetTouchControls(this)
-                            KartPadTouchSettings.setResolutionScale(this, 1f)
                             KartPadTouchSettings.setHideOnController(this, true)
                             KartPadTouchSettings.setModernCStickHorizontal(this, false)
                             Log.i(
                                 TAG,
-                                "A4 touch settings flow passed render=3x opacity=64 size=120 " +
+                                "A4 touch settings flow passed render=1x opacity=64 size=120 " +
                                     "hide=false modern=true",
                             )
                         }

--- a/apple/ios/KartPadRuntimeOverlayHost.mm
+++ b/apple/ios/KartPadRuntimeOverlayHost.mm
@@ -70,6 +70,7 @@ extern "C" int g_gxFrameCount;
 - (void)endLayoutEditing;
 - (void)finishLayoutEditing;
 - (void)refreshMenuButton;
+- (void)buildSettingsPanel;
 - (void)resetLayout;
 - (void)toggleSettingsPanel;
 - (void)selectControlForEditing:(UIView *)control;
@@ -1499,6 +1500,19 @@ NSError *KartPadPerformGameDataImport(NSURL *url,
   [self layoutIfNeeded];
 }
 
+- (void)buildSettingsPanel {
+  [super buildSettingsPanel];
+  // Resolution belongs in Display. Remove the inherited duplicate row while
+  // retaining the pinned SunPad implementation and the user's saved scale.
+  UIView *resolution = KartPadSubviewWithAccessibilityLabel(
+      self, @"Render resolution", UISegmentedControl.class);
+  UIView *row = resolution.superview;
+  if ([row.superview isKindOfClass:UIStackView.class]) {
+    [(UIStackView *)row.superview removeArrangedSubview:row];
+    [row removeFromSuperview];
+  }
+}
+
 - (void)kartPadConfigureTouchLayoutEditor {
   UIButton *done = (UIButton *)KartPadSubviewWithAccessibilityLabel(
       self, @"Finish moving touch controls", UIButton.class);
@@ -1979,9 +1993,12 @@ NSError *KartPadPerformGameDataImport(NSURL *url,
 - (void)reportProblem {
   UIViewController *presenter = KartPadVisibleViewController(self.window);
   if (presenter == nil) return;
+  NSString *instructions =
+      @"Describe the problem. KartPad adds device details and recent logs.\n\n"
+       "Attach the log and relevant screenshots. GitHub reports are public; review before posting.";
   UIAlertController *prompt =
       [UIAlertController alertControllerWithTitle:@"Report a Problem"
-                                          message:@"Answer briefly and KartPad will add the technical details. If the problem is visual, take a screenshot first and attach it with the report on GitHub. The report never includes your game image, extracted files, saves, signing material, or controller inputs. GitHub reports and attachments are public."
+                                          message:instructions
                                    preferredStyle:UIAlertControllerStyleAlert];
   [prompt addTextFieldWithConfigurationHandler:^(UITextField *field) {
     field.placeholder = @"What went wrong?";
@@ -2061,7 +2078,26 @@ NSError *KartPadPerformGameDataImport(NSURL *url,
   }
 
   if (openGitHub) {
-    [self openGitHubReportWithID:reportID answers:answers];
+    NSString *localDevice = self.traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomPad
+        ? @"On My iPad" : @"On My iPhone";
+    NSString *steps = [NSString stringWithFormat:
+        @"Your diagnostic log is saved.\n\n"
+         "1. Review the prefilled GitHub report.\n\n"
+         "2. Attach %@ from Files → %@ → KartPad → Diagnostics.\n\n"
+         "3. Add a screenshot for visual issues.\n\n"
+         "The log is not uploaded automatically. Game files, saves, signing material and controller inputs are excluded.",
+        reportURL.lastPathComponent, localDevice];
+    UIAlertController *attachmentHelp = [UIAlertController
+        alertControllerWithTitle:@"Attach Your Diagnostic Log"
+                         message:steps preferredStyle:UIAlertControllerStyleAlert];
+    [attachmentHelp addAction:[UIAlertAction actionWithTitle:@"Cancel"
+        style:UIAlertActionStyleCancel handler:nil]];
+    __weak KartPadGameOverlay *weakSelf = self;
+    [attachmentHelp addAction:[UIAlertAction actionWithTitle:@"Open GitHub"
+        style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+      [weakSelf openGitHubReportWithID:reportID answers:answers];
+    }]];
+    [presenter presentViewController:attachmentHelp animated:YES completion:nil];
     return;
   }
 
@@ -2105,6 +2141,10 @@ NSError *KartPadPerformGameDataImport(NSURL *url,
     [NSURLQueryItem queryItemWithName:@"summary" value:answers[@"problem"]],
     [NSURLQueryItem queryItemWithName:@"context" value:answers[@"context"]],
     [NSURLQueryItem queryItemWithName:@"frequency" value:answers[@"frequency"]],
+    [NSURLQueryItem queryItemWithName:@"diagnostics" value:
+        @"Attach the diagnostic .log file from Files → KartPad → Diagnostics here. "
+         "Review it before posting and add a screenshot for visual issues. "
+         "The report ID above does not upload the log."],
   ];
   NSURL *url = components.URL;
   if (url == nil) return;

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -153,10 +153,17 @@ raw. Remove usernames, private paths, IP/MAC addresses, console/account IDs,
 friend codes, tokens, and other personal data from excerpts. Do not clear logs
 or app storage before collecting them. No USB debugging or root is needed.
 
-**iPhone/iPad:** **••• → Report a Problem… → Share Report…** creates the bounded
-technical report. Review it and attach it to the existing issue with a
-screenshot if relevant. **Report on GitHub** prefills the form but does not
-attach the report file; its report ID alone is not a log upload.
+**iPhone/iPad:** After reproducing the problem, open **••• → Report a
+Problem…** and describe what happened. If the app crashed, reopen it first.
+
+1. Choose **Share Report…** to save or share the diagnostic `.log` file. It
+   includes device/settings details and current/previous session logs.
+2. Review the file before attaching it to an existing issue or a new GitHub
+   report. Add a screenshot for a visual issue.
+3. **Report on GitHub** creates the file and prefills a new issue, but does
+   **not** upload the log. Attach it from **Files → On My iPhone/iPad →
+   KartPad → Diagnostics → Latest-SunPad-Diagnostic.log**. The report ID
+   alone is not a log upload.
 
 **Mac:** **Help → Save Diagnostics Report…** creates a bounded report with
 settings and current/previous session tails. Review it before attaching.

--- a/docs/artifacts/2026-09-09/ios-reporting-menu-cleanup.md
+++ b/docs/artifacts/2026-09-09/ios-reporting-menu-cleanup.md
@@ -1,0 +1,68 @@
+# iOS reporting and touch-settings cleanup
+
+9 September 2026. Follow-up to the Apple Metal surface candidate in PR #156.
+
+## Owner feedback on the previous candidate
+
+The owner reported smooth controller gameplay at 60 FPS on the attached M2
+12.9-inch iPad Pro, a working three-dot menu, and no visible problems in
+Original 4:3, 16:9 or Fill Screen. This is controller gameplay feedback, not
+touch-input acceptance or confirmation of custom controller remapping. The
+feedback did not establish a separate Original/Retro test matrix, external
+TV/AirPlay output, or the affected A10X device's startup behavior.
+
+## Changes
+
+- iPhone/iPad Report a Problem uses two short paragraphs. The GitHub action
+  creates the existing bounded report, then gives numbered attachment steps
+  with its actual filename and the device-specific Files location. The
+  prefilled issue also reminds the reporter to attach the log; a report ID
+  does not upload it. Share Report continues to use the system share sheet.
+- Render resolution is removed from Touch Control Settings. Display retains
+  its resolution choices and the saved resolution is unchanged. The KartPad
+  subclass removes the inherited row; the pinned SunPad snapshot is unchanged.
+- Android has the same duplicate row removed in a separate commit. Its
+  existing visual and persistence checks now expect touch settings only and
+  verify that changing touch settings preserves display resolution. No Android
+  hardware, optimization worktree, or runtime optimization was changed.
+
+## Validation
+
+- 23 existing iOS contracts pass; 34 Android touch-overlay contracts pass.
+- Android `:app:compileDebugKotlin` passes. Existing deprecation warnings remain.
+  Android device/emulator interaction was intentionally left to its owning task.
+- The pinned SunPad snapshot verifier passes.
+- A temporary UIKit fixture compiles the exact changed methods with the real
+  pinned overlay, settings, input mixer and diagnostics. This fixture uses the
+  inherited SunPad controls, not the complete KartPad control adaptations; it
+  cannot validate the current gameplay control appearance. It was removed
+  from both simulators after the owner identified that visual mismatch.
+  iPhone 17 Pro and
+  iPad Pro 13-inch (M5) simulators exercise the native views. Runtime assertions
+  verify the duplicate row is absent, a saved 3x setting remains 3x, and opacity
+  and size controls remain present. Screenshots inspect the shorter iPad form,
+  iPhone attachment instructions, and iPad touch-settings panel. The narrow
+  iPhone landscape alert retains UIKit's scrolling form behavior.
+- The GitHub preparation path creates the expected diagnostic file with
+  KartPad branding and current/previous session sections before showing help.
+  No GitHub issue was submitted and no diagnostic file was uploaded.
+
+Private UI-review sources, screenshots and logs are in
+`build/menu-ui-review`; physical build/update evidence is in
+`build/ipad-physical`. These fixtures do not establish full-game acceptance.
+
+## Private device candidate
+
+The complete dual-profile physical-iOS app builds from `fc6ee29` and passes
+its unsigned bundle audit. The development-signed copy uses **0.4.13 / build
+30**, with the build number changed only in the private staged bundle so it
+can be distinguished from the earlier build 29. Its executable SHA-256 is
+`ef6fdfb2cb883190e7a1aeafdac0670eceac16dca7b4d3844f43d1ef1a36d84a`.
+The signature passes strict verification. This signed copy contains the local
+development profile and is not a public release artifact.
+
+The public bundle audit intentionally rejects a development profile; its
+passing result applies to the unsigned source app before signing. The full
+app retains KartPad's actual control adaptations, unlike the temporary menu
+fixture. No controller-mapping behavior or renderer algorithm is changed by
+this follow-up.

--- a/docs/artifacts/2026-09-09/ios-reporting-menu-cleanup.md
+++ b/docs/artifacts/2026-09-09/ios-reporting-menu-cleanup.md
@@ -66,3 +66,10 @@ passing result applies to the unsigned source app before signing. The full
 app retains KartPad's actual control adaptations, unlike the temporary menu
 fixture. No controller-mapping behavior or renderer algorithm is changed by
 this follow-up.
+
+The candidate was installed in place and launched without a debugger. Device
+inventory confirms 0.4.13 / build 30. All 32 protected files (19,871,307 bytes)
+are byte-identical between fresh pre-install and post-install snapshots,
+including the owner's current preferences. The older baseline differs only in
+preferences following the owner's settings changes; nothing was restored.
+The new full-game menu appearance awaits the owner's in-game check.

--- a/scripts/check-android-touch-settings-visual.py
+++ b/scripts/check-android-touch-settings-visual.py
@@ -12,11 +12,6 @@ from pathlib import Path
 
 TEXT = (
     "Touch Control Settings",
-    "Render",
-    "1×",
-    "2×",
-    "3×",
-    "4×",
     "Opacity: 82%",
     "All sizes: 100%",
     "Hide on controller",
@@ -26,7 +21,6 @@ TEXT = (
     "DONE",
 )
 DESCRIPTIONS = (
-    "Render resolution",
     "Control opacity",
     "All control sizes",
     "Hide touch controls when controller connected",
@@ -74,8 +68,8 @@ def main() -> None:
         rect = bounds(node.attrib["bounds"])
         if not (0 <= rect[0] < rect[2] <= args.width and 0 <= rect[1] < rect[3] <= args.height):
             raise SystemExit(f"ERROR: settings node is clipped: {rect}")
-    if by_text["1×"].attrib.get("checked") != "true":
-        raise SystemExit("ERROR: native 1x render choice is not selected by default")
+    if "Render" in by_text or "Render resolution" in by_description:
+        raise SystemExit("ERROR: display resolution leaked into touch settings")
 
     opacity = bounds(by_description["Control opacity"].attrib["bounds"])
     all_sizes = bounds(by_description["All control sizes"].attrib["bounds"])
@@ -99,7 +93,7 @@ def main() -> None:
     print(
         "Android touch-settings visual contract passed: "
         f"viewport={width}x{height} text={len(TEXT)} actions={len(DESCRIPTIONS)} "
-        "columns=left-sliders/right-actions render=1x"
+        "columns=left-sliders/right-actions"
     )
 
 

--- a/scripts/test-android-touch-settings-flow.sh
+++ b/scripts/test-android-touch-settings-flow.sh
@@ -31,7 +31,7 @@ apk="$repo_root/android/app/build/outputs/apk/debug/app-debug.apk"
 
 "$adb" shell am start -W -n dev.kartpad.android/.KartPadActivity \
   --es dev.kartpad.android.TEST_TOUCH_SETTINGS_FLOW seed >/dev/null
-seeded="A4 touch settings flow seeded render=3x opacity=64 size=120 hide=false modern=true"
+seeded="A4 touch settings flow seeded render=1x opacity=64 size=120 hide=false modern=true"
 for _ in {1..30}; do
   output="$("$adb" logcat -d -v brief KartPadFixture:I AndroidRuntime:E '*:S')"
   grep -Fq "$seeded" <<<"$output" && break
@@ -50,7 +50,7 @@ sleep 1
 "$adb" shell am force-stop dev.kartpad.android
 "$adb" shell am start -W -n dev.kartpad.android/.KartPadActivity \
   --es dev.kartpad.android.TEST_TOUCH_SETTINGS_FLOW verify >/dev/null
-passed="A4 touch settings flow passed render=3x opacity=64 size=120 hide=false modern=true"
+passed="A4 touch settings flow passed render=1x opacity=64 size=120 hide=false modern=true"
 for _ in {1..30}; do
   output="$("$adb" logcat -d -v brief KartPadFixture:I AndroidRuntime:E '*:S')"
   if grep -Fq "$passed" <<<"$output"; then

--- a/tests/test_android_touch_overlay_contract.py
+++ b/tests/test_android_touch_overlay_contract.py
@@ -223,7 +223,7 @@ class AndroidTouchOverlayContractTests(unittest.TestCase):
         self.assertIn("DEBUG_EXTRA_TOUCH_SETTINGS", activity)
         self.assertIn("showTouchControlSettings()", activity)
         for label in (
-            '"Touch Control Settings"', '"1×"', '"4×"',
+            '"Touch Control Settings"',
             '"Opacity: 82%"', '"All sizes: 100%"',
             '"Hide on controller"', '"Modern C-stick L/R"',
             '"MOVE CONTROLS"', '"RESET THIS DEVICE LAYOUT"', '"DONE"',
@@ -236,7 +236,7 @@ class AndroidTouchOverlayContractTests(unittest.TestCase):
         activity = (REPO / "android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt").read_text()
         runner = (REPO / "scripts/test-android-touch-settings-flow.sh").read_text()
         self.assertIn("TEST_TOUCH_SETTINGS_FLOW", activity)
-        self.assertIn("render3.performClick()", activity)
+        self.assertIn("touch settings changed the display resolution", activity)
         self.assertIn("AccessibilityAction.ACTION_SET_PROGRESS.id", activity)
         self.assertIn("setProgress(opacity, 39f)", activity)
         self.assertIn("setProgress(size, 50f)", activity)
@@ -291,9 +291,10 @@ class AndroidTouchOverlayContractTests(unittest.TestCase):
         self.assertIn('text = "Reset This Device Layout"', activity)
         self.assertIn('text = "Move controls"', activity)
         self.assertIn('text = "Modern C-stick L/R"', activity)
-        self.assertIn('val renderScales = floatArrayOf(1f, 2f, 3f, 4f)', activity)
-        self.assertIn('contentDescription = "Render resolution"', activity)
-        self.assertIn("KartPadTouchSettings.setResolutionScale(this, scale)", activity)
+        touch_settings = activity.split("private fun showTouchControlSettings(", 1)[1].split("private fun ", 1)[0]
+        self.assertNotIn('"Render resolution"', touch_settings)
+        self.assertNotIn("setResolutionScale", touch_settings)
+        self.assertIn("KartPadTouchSettings.setResolutionScale(this, scales[which])", activity)
         self.assertIn("val leftColumn = LinearLayout(this).apply", activity)
         self.assertIn("val rightColumn = LinearLayout(this).apply", activity)
         self.assertIn('text = "Back"', activity)


### PR DESCRIPTION
Report a Problem on iPhone/iPad currently crowds its instructions into one paragraph, and opening GitHub leaves users without clear steps to attach the generated log. This change shortens the initial prompt, shows numbered file-attachment steps before opening GitHub, and adds an attachment reminder to the prefilled issue. The log is still reviewed and uploaded manually.

Render resolution is also duplicated inside Touch Control Settings. Remove that row on iOS/iPadOS and Android while retaining Display → Render Resolution and the saved value. The iOS change stays in the KartPad subclass and leaves the pinned SunPad snapshot unchanged. Android changes are isolated in commit fc6ee29 for its owning task.

Validation: 23 iOS and 34 Android touch-overlay contracts pass; Android Kotlin compilation and the full dual-profile physical-iOS build pass; the unsigned bundle audit and private signature verification pass. A temporary native UIKit fixture checked the changed menu methods, preserved 3x settings, and diagnostic-file creation. Its inherited controls were not a full KartPad UI acceptance test. The owner accepted controller gameplay on the preceding Metal candidate at 60 FPS; the new menu build still needs their in-game UI check.

Stacked on #156. This does not resolve Fill Screen distortion, external-output acceptance, or custom controller-remapping validation. See docs/artifacts/2026-09-09/ios-reporting-menu-cleanup.md for evidence and limits.
