### PR TITLE
Improve the iOS game chooser and setup help

### DIFF
--- a/apple/ios/KartPadRuntimeOverlayHost.mm
+++ b/apple/ios/KartPadRuntimeOverlayHost.mm
@@ -669,141 +669,304 @@ NSError *KartPadPerformGameDataImport(NSURL *url,
 @property(nonatomic, copy) void (^modeSelected)(BOOL retroRewind);
 @property(nonatomic, assign) BOOL resumingGame;
 @property(nonatomic, assign) BOOL currentRetroRewind;
-@property(nonatomic, strong) CAGradientLayer *backgroundGradient;
+@property(nonatomic, assign) BOOL gameDataReady;
 @property(nonatomic, strong) NSLayoutConstraint *contentWidthConstraint;
+@property(nonatomic, strong) UIStackView *choices;
+@property(nonatomic, strong) NSMutableArray<UIView *> *compactDetails;
 @end
 
 @implementation KartPadFirstLaunchViewController
 
+- (UILabel *)label:(NSString *)text style:(UIFontTextStyle)style secondary:(BOOL)secondary {
+  UILabel *label = [UILabel new];
+  label.text = text;
+  label.font = [UIFont preferredFontForTextStyle:style];
+  label.adjustsFontForContentSizeCategory = YES;
+  label.textColor = secondary
+      ? [UIColor colorWithRed:0.70 green:0.75 blue:0.82 alpha:1] : UIColor.whiteColor;
+  label.numberOfLines = 0;
+  return label;
+}
+
+- (UIButton *)link:(NSString *)title symbol:(NSString *)symbol action:(void (^)(void))action {
+  UIButtonConfiguration *configuration = [UIButtonConfiguration plainButtonConfiguration];
+  configuration.title = title;
+  configuration.image = [UIImage systemImageNamed:symbol];
+  configuration.imagePadding = 8;
+  configuration.baseForegroundColor = [UIColor colorWithRed:0.48 green:0.75 blue:1 alpha:1];
+  configuration.contentInsets = NSDirectionalEdgeInsetsMake(12, 0, 12, 12);
+  UIButton *button = [UIButton buttonWithConfiguration:configuration primaryAction:
+      [UIAction actionWithHandler:^(__kindof UIAction *event) { action(); }]];
+  [button.heightAnchor constraintGreaterThanOrEqualToConstant:44].active = YES;
+  return button;
+}
+
+- (void)openGuide:(NSString *)path {
+  NSURL *url = [NSURL URLWithString:[@"https://github.com/chrissotraidis/kartpad/"
+      stringByAppendingString:path]];
+  __weak KartPadFirstLaunchViewController *weakSelf = self;
+  [UIApplication.sharedApplication openURL:url options:@{} completionHandler:^(BOOL opened) {
+    if (opened) return;
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Could Not Open GitHub"
+        message:@"Please try again when a browser is available. Setup and troubleshooting guides are in the chrissotraidis/kartpad repository on GitHub."
+        preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
+    [weakSelf presentViewController:alert animated:YES completion:nil];
+  }];
+}
+
+- (void)closeSetupHelp {
+  [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (void)showSetupHelp {
+  UIViewController *help = [UIViewController new];
+  help.title = @"Getting Started";
+  help.view.backgroundColor = self.view.backgroundColor;
+  help.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc]
+      initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(closeSetupHelp)];
+  UILabel *importTitle = [self label:@"1. Import Mario Kart Wii" style:UIFontTextStyleTitle2 secondary:NO];
+  UILabel *importBody = [self label:
+      @"Use your own PAL (Europe) ISO or WBFS: RMCP01, revision 0. An extracted DATA folder also works. RVZ files must be converted before importing."
+      style:UIFontTextStyleBody secondary:YES];
+  UILabel *retroTitle = [self label:@"2. Add Retro Rewind, if you want it" style:UIFontTextStyleTitle2 secondary:NO];
+  UILabel *retroBody = [self label:[NSString stringWithFormat:
+      @"Import Mario Kart Wii first, then choose Retro Rewind. KartPad can download and install the official %@ pack. You do not need to import a second disc.",
+      KartPadRetroRewindInstaller.requiredVersion] style:UIFontTextStyleBody secondary:YES];
+  UILabel *supportTitle = [self label:@"Stuck on a step?" style:UIFontTextStyleTitle2 secondary:NO];
+  UILabel *supportBody = [self label:
+      @"The GitHub guides cover supported files, free space, installation and common problems. If you report an issue, include your KartPad version, device, and the exact message you see."
+      style:UIFontTextStyleBody secondary:YES];
+  for (UILabel *title in @[importTitle, retroTitle, supportTitle]) title.accessibilityTraits |= UIAccessibilityTraitHeader;
+  __weak KartPadFirstLaunchViewController *weakSelf = self;
+  UIButton *setup = [self link:@"Setup Guide on GitHub" symbol:@"book.closed" action:^{
+    [weakSelf openGuide:@"blob/main/docs/INSTALL_IPA.md"];
+  }];
+  UIButton *troubleshooting = [self link:@"Troubleshooting on GitHub" symbol:@"wrench.and.screwdriver" action:^{
+    [weakSelf openGuide:@"blob/main/docs/SUPPORT.md"];
+  }];
+  UIStackView *content = [[UIStackView alloc] initWithArrangedSubviews:
+      @[importTitle, importBody, retroTitle, retroBody, supportTitle, supportBody, setup, troubleshooting]];
+  content.axis = UILayoutConstraintAxisVertical;
+  content.spacing = 12;
+  [content setCustomSpacing:28 afterView:importBody];
+  [content setCustomSpacing:28 afterView:retroBody];
+  content.translatesAutoresizingMaskIntoConstraints = NO;
+  UIScrollView *scroll = [UIScrollView new];
+  scroll.translatesAutoresizingMaskIntoConstraints = NO;
+  [help.view addSubview:scroll];
+  [scroll addSubview:content];
+  [NSLayoutConstraint activateConstraints:@[
+    [scroll.leadingAnchor constraintEqualToAnchor:help.view.safeAreaLayoutGuide.leadingAnchor],
+    [scroll.trailingAnchor constraintEqualToAnchor:help.view.safeAreaLayoutGuide.trailingAnchor],
+    [scroll.topAnchor constraintEqualToAnchor:help.view.safeAreaLayoutGuide.topAnchor],
+    [scroll.bottomAnchor constraintEqualToAnchor:help.view.safeAreaLayoutGuide.bottomAnchor],
+    [content.leadingAnchor constraintEqualToAnchor:scroll.contentLayoutGuide.leadingAnchor constant:24],
+    [content.trailingAnchor constraintEqualToAnchor:scroll.contentLayoutGuide.trailingAnchor constant:-24],
+    [content.topAnchor constraintEqualToAnchor:scroll.contentLayoutGuide.topAnchor constant:24],
+    [content.bottomAnchor constraintEqualToAnchor:scroll.contentLayoutGuide.bottomAnchor constant:-24],
+    [content.widthAnchor constraintEqualToAnchor:scroll.frameLayoutGuide.widthAnchor constant:-48],
+  ]];
+  UINavigationController *navigation = [[UINavigationController alloc] initWithRootViewController:help];
+  navigation.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+  navigation.modalPresentationStyle = UIModalPresentationFormSheet;
+  navigation.preferredContentSize = CGSizeMake(620, 640);
+  [self presentViewController:navigation animated:YES completion:nil];
+}
+
+- (UIView *)gameCard:(BOOL)retro installedVersion:(NSString *)installedVersion {
+  BOOL current = self.resumingGame && self.currentRetroRewind == retro;
+  BOOL ready = self.gameDataReady && (!retro || installedVersion.length > 0);
+  UIColor *accent = retro ? [UIColor colorWithRed:0.77 green:0.67 blue:1 alpha:1]
+                          : [UIColor colorWithRed:0.43 green:0.73 blue:1 alpha:1];
+  NSString *status = current ? @"CURRENT GAME · PAUSED"
+      : (self.resumingGame ? @"NEXT LAUNCH"
+      : (ready ? @"READY TO PLAY" : (retro && !self.gameDataReady ? @"BASE GAME REQUIRED" : @"SETUP NEEDED")));
+  UILabel *badge = [self label:status style:UIFontTextStyleCaption1 secondary:NO];
+  badge.textColor = accent;
+  badge.font = [UIFontMetrics.defaultMetrics scaledFontForFont:
+      [UIFont systemFontOfSize:12 weight:UIFontWeightSemibold]];
+  UIImageView *icon = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:
+      retro ? @"gobackward" : @"flag.checkered"]];
+  icon.tintColor = accent;
+  icon.contentMode = UIViewContentModeScaleAspectFit;
+  icon.isAccessibilityElement = NO;
+  [NSLayoutConstraint activateConstraints:@[
+    [icon.widthAnchor constraintEqualToConstant:32], [icon.heightAnchor constraintEqualToConstant:32],
+  ]];
+  UIView *spacer = [UIView new];
+  UIStackView *top = [[UIStackView alloc] initWithArrangedSubviews:@[icon, spacer, badge]];
+  top.axis = UILayoutConstraintAxisHorizontal;
+  top.alignment = UIStackViewAlignmentCenter;
+  top.spacing = 12;
+  UILabel *title = [self label:retro ? @"Retro Rewind" : @"Mario Kart Wii"
+      style:UIFontTextStyleTitle1 secondary:NO];
+  title.accessibilityTraits |= UIAccessibilityTraitHeader;
+  NSString *detail = retro ? @"More tracks, characters and Retro WFC online play. Uses your Mario Kart Wii game data."
+                           : @"Grand Prix, time trials and local races. Your original game, on this device.";
+  UILabel *description = [self label:detail style:UIFontTextStyleBody secondary:YES];
+  NSString *note = retro ? (installedVersion.length > 0
+      ? [NSString stringWithFormat:@"Installed pack · %@", installedVersion]
+      : [NSString stringWithFormat:@"Official pack · %@ · downloaded in the app", KartPadRetroRewindInstaller.requiredVersion])
+      : (self.gameDataReady ? @"Game data imported" : @"PAL (Europe) · ISO / WBFS · RMCP01 rev 0");
+  UILabel *metadata = [self label:note style:UIFontTextStyleFootnote secondary:YES];
+  [self.compactDetails addObjectsFromArray:@[description, metadata]];
+  NSString *actionTitle = current ? @"Resume Game" : (self.resumingGame ? @"Use on Next Launch"
+      : (ready ? @"Play Game" : (retro ? @"Set Up Retro Rewind" : @"Import Mario Kart Wii")));
+  UIButtonConfiguration *configuration = [UIButtonConfiguration filledButtonConfiguration];
+  configuration.title = actionTitle;
+  configuration.image = [UIImage systemImageNamed:current || ready ? @"play.fill" : @"arrow.right"];
+  configuration.imagePlacement = NSDirectionalRectEdgeTrailing;
+  configuration.imagePadding = 10;
+  configuration.baseBackgroundColor = current || (!self.resumingGame && !retro)
+      ? [UIColor colorWithRed:0.16 green:0.47 blue:0.88 alpha:1]
+      : [UIColor colorWithRed:0.19 green:0.23 blue:0.31 alpha:1];
+  configuration.baseForegroundColor = UIColor.whiteColor;
+  configuration.cornerStyle = UIButtonConfigurationCornerStyleMedium;
+  configuration.contentInsets = NSDirectionalEdgeInsetsMake(14, 18, 14, 18);
+  __weak KartPadFirstLaunchViewController *weakSelf = self;
+  UIButton *action = [UIButton buttonWithConfiguration:configuration primaryAction:
+      [UIAction actionWithHandler:^(__kindof UIAction *event) {
+    if (weakSelf.modeSelected != nil) weakSelf.modeSelected(retro);
+  }]];
+  action.accessibilityIdentifier = retro ? @"kartpad.mode.retro-rewind" : @"kartpad.mode.original";
+  action.accessibilityLabel = [actionTitle containsString:title.text] ? actionTitle
+      : [NSString stringWithFormat:@"%@, %@", actionTitle, title.text];
+  action.accessibilityHint = status;
+  [action.heightAnchor constraintGreaterThanOrEqualToConstant:50].active = YES;
+  UIView *gap = [UIView new];
+  UIStackView *content = [[UIStackView alloc] initWithArrangedSubviews:
+      @[top, title, description, metadata, gap, action]];
+  content.axis = UILayoutConstraintAxisVertical;
+  content.spacing = 12;
+  [content setCustomSpacing:18 afterView:top];
+  content.translatesAutoresizingMaskIntoConstraints = NO;
+  UIView *card = [UIView new];
+  card.backgroundColor = [UIColor colorWithRed:0.075 green:0.10 blue:0.15 alpha:1];
+  card.layer.cornerRadius = 20;
+  card.layer.borderWidth = 1;
+  card.layer.borderColor = [UIColor colorWithRed:0.17 green:0.21 blue:0.28 alpha:1].CGColor;
+  [card addSubview:content];
+  [NSLayoutConstraint activateConstraints:@[
+    [content.leadingAnchor constraintEqualToAnchor:card.leadingAnchor constant:24],
+    [content.trailingAnchor constraintEqualToAnchor:card.trailingAnchor constant:-24],
+    [content.topAnchor constraintEqualToAnchor:card.topAnchor constant:24],
+    [content.bottomAnchor constraintEqualToAnchor:card.bottomAnchor constant:-24],
+    [gap.heightAnchor constraintGreaterThanOrEqualToConstant:0],
+  ]];
+  return card;
+}
+
 - (void)viewDidLoad {
   [super viewDidLoad];
-  self.view.backgroundColor = UIColor.blackColor;
-  CAGradientLayer *gradient = [CAGradientLayer layer];
-  gradient.colors = @[
-    (__bridge id)[UIColor colorWithRed:0.025 green:0.075 blue:0.15 alpha:1.0].CGColor,
-    (__bridge id)[UIColor colorWithRed:0.10 green:0.055 blue:0.18 alpha:1.0].CGColor,
-    (__bridge id)[UIColor colorWithRed:0.18 green:0.045 blue:0.08 alpha:1.0].CGColor,
-  ];
-  gradient.startPoint = CGPointMake(0.0, 0.0);
-  gradient.endPoint = CGPointMake(1.0, 1.0);
-  [self.view.layer insertSublayer:gradient atIndex:0];
-  self.backgroundGradient = gradient;
-
-  UIImage *markImage = [[UIImage imageNamed:@"KartPadLogo"]
-      imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
-  UIImageView *mark = [[UIImageView alloc] initWithImage:markImage];
-  mark.translatesAutoresizingMaskIntoConstraints = NO;
+  self.compactDetails = [NSMutableArray array];
+  self.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+  self.view.backgroundColor = [UIColor colorWithRed:0.035 green:0.05 blue:0.08 alpha:1];
+  UIImageView *mark = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"KartPadLogo"]];
   mark.contentMode = UIViewContentModeScaleAspectFit;
-  mark.accessibilityLabel = @"KartPad";
+  mark.isAccessibilityElement = NO;
   [NSLayoutConstraint activateConstraints:@[
-    [mark.widthAnchor constraintEqualToConstant:48.0],
-    [mark.heightAnchor constraintEqualToConstant:48.0],
+    [mark.widthAnchor constraintEqualToConstant:64], [mark.heightAnchor constraintEqualToConstant:64],
   ]];
+  UILabel *brand = [self label:@"KartPad" style:UIFontTextStyleTitle1 secondary:NO];
+  brand.font = [UIFontMetrics.defaultMetrics scaledFontForFont:
+      [UIFont systemFontOfSize:30 weight:UIFontWeightBold]];
+  UILabel *platform = [self label:@"Mario Kart Wii, on your device."
+      style:UIFontTextStyleSubheadline secondary:YES];
+  UIStackView *brandText = [[UIStackView alloc] initWithArrangedSubviews:@[brand, platform]];
+  brandText.axis = UILayoutConstraintAxisVertical;
+  brandText.spacing = 4;
+  __weak KartPadFirstLaunchViewController *weakSelf = self;
+  UIButton *help = [self link:@"Help" symbol:@"questionmark.circle" action:^{ [weakSelf showSetupHelp]; }];
+  help.accessibilityIdentifier = @"kartpad.setup.help";
+  [help setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+  UIStackView *header = [[UIStackView alloc] initWithArrangedSubviews:@[mark, brandText, help]];
+  header.axis = UILayoutConstraintAxisHorizontal;
+  header.alignment = UIStackViewAlignmentCenter;
+  header.spacing = 16;
 
-  UILabel *title = [[UILabel alloc] init];
-  title.translatesAutoresizingMaskIntoConstraints = NO;
-  title.text = @"KartPad";
-  title.font = [UIFont systemFontOfSize:34.0 weight:UIFontWeightBold];
-  title.textAlignment = NSTextAlignmentCenter;
-  title.textColor = UIColor.whiteColor;
+  UILabel *heading = [self label:self.resumingGame ? @"Back to the race" : @"Choose a game"
+      style:UIFontTextStyleLargeTitle secondary:NO];
+  heading.accessibilityTraits |= UIAccessibilityTraitHeader;
+  UILabel *intro = [self label:self.resumingGame
+      ? @"Your game is paused. Resume now, or choose a game for the next launch."
+      : (self.gameDataReady ? @"Your Mario Kart Wii game data is ready."
+                           : @"Start by importing Mario Kart Wii. Add Retro Rewind whenever you're ready.")
+      style:UIFontTextStyleBody secondary:YES];
+  [self.compactDetails addObjectsFromArray:@[heading, intro]];
+  NSString *version = KartPadRetroRewindInstaller.installedVersion;
+  self.choices = [[UIStackView alloc] initWithArrangedSubviews:
+      @[[self gameCard:NO installedVersion:version], [self gameCard:YES installedVersion:version]]];
+  self.choices.axis = UILayoutConstraintAxisHorizontal;
+  self.choices.spacing = 20;
+  self.choices.distribution = UIStackViewDistributionFillEqually;
 
-  UILabel *tagline = [[UILabel alloc] init];
-  tagline.translatesAutoresizingMaskIntoConstraints = NO;
-  tagline.text = @"Choose your way to race";
-  tagline.font = [UIFont systemFontOfSize:20.0 weight:UIFontWeightSemibold];
-  tagline.textColor = [UIColor colorWithWhite:1.0 alpha:0.88];
-  tagline.textAlignment = NSTextAlignmentCenter;
-
-  UILabel *message = [[UILabel alloc] init];
-  message.translatesAutoresizingMaskIntoConstraints = NO;
-  message.text = self.resumingGame
-      ? @"Your current game is paused. Resume it below. Switching games requires closing and reopening KartPad."
-      : @"Your own RMCP01 disc image or extracted game data is required before play.";
-  message.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
-  message.textColor = [UIColor colorWithWhite:1.0 alpha:0.62];
-  message.textAlignment = NSTextAlignmentCenter;
-  message.numberOfLines = 0;
-
-  UIButtonConfiguration *originalConfiguration =
-      [UIButtonConfiguration filledButtonConfiguration];
-  originalConfiguration.title = @"Mario Kart Wii";
-  originalConfiguration.subtitle = @"Original game";
-  if (self.resumingGame) {
-    originalConfiguration.title = self.currentRetroRewind ? @"Mario Kart Wii" : @"Resume Mario Kart Wii";
-    originalConfiguration.subtitle = self.currentRetroRewind ? @"Switch on next launch" : @"Current game • Paused";
-  }
-  originalConfiguration.image = [UIImage systemImageNamed:@"flag.checkered"];
-  originalConfiguration.imagePadding = 12.0;
-  originalConfiguration.baseBackgroundColor =
-      [UIColor colorWithRed:0.03 green:0.49 blue:1.0 alpha:1.0];
-  originalConfiguration.baseForegroundColor = UIColor.whiteColor;
-  originalConfiguration.cornerStyle = UIButtonConfigurationCornerStyleLarge;
-  originalConfiguration.contentInsets = NSDirectionalEdgeInsetsMake(24, 28, 24, 28);
-  UIButton *original = [UIButton buttonWithConfiguration:originalConfiguration
-                                           primaryAction:[UIAction actionWithHandler:^(__kindof UIAction *action) {
-    (void)action;
-    if (self.modeSelected != nil) self.modeSelected(NO);
-  }]];
-  original.accessibilityIdentifier = @"kartpad.mode.original";
-
-  UIButtonConfiguration *retroConfiguration =
-      [UIButtonConfiguration filledButtonConfiguration];
-  retroConfiguration.title = @"Retro Rewind";
-  NSString *installedVersion = KartPadRetroRewindInstaller.installedVersion;
-  retroConfiguration.subtitle = installedVersion.length > 0
-      ? [NSString stringWithFormat:@"Installed %@ • Extra content + Retro WFC",
-                                   installedVersion]
-      : [NSString stringWithFormat:@"Download %@ • Extra content + Retro WFC",
-                                   KartPadRetroRewindInstaller.requiredVersion];
-  if (self.resumingGame) {
-    retroConfiguration.title = self.currentRetroRewind ? @"Resume Retro Rewind" : @"Retro Rewind";
-    retroConfiguration.subtitle = self.currentRetroRewind ? @"Current game • Paused" : @"Switch on next launch";
-  }
-  retroConfiguration.image = [UIImage systemImageNamed:@"gobackward"];
-  retroConfiguration.imagePadding = 12.0;
-  retroConfiguration.baseBackgroundColor =
-      [UIColor colorWithRed:0.96 green:0.22 blue:0.39 alpha:1.0];
-  retroConfiguration.baseForegroundColor = UIColor.whiteColor;
-  retroConfiguration.cornerStyle = UIButtonConfigurationCornerStyleLarge;
-  retroConfiguration.contentInsets = NSDirectionalEdgeInsetsMake(24, 28, 24, 28);
-  UIButton *retro = [UIButton buttonWithConfiguration:retroConfiguration
-                                        primaryAction:[UIAction actionWithHandler:^(__kindof UIAction *action) {
-    (void)action;
-    if (self.modeSelected != nil) self.modeSelected(YES);
-  }]];
-  retro.accessibilityIdentifier = @"kartpad.mode.retro-rewind";
-
-  UIStackView *choices = [[UIStackView alloc] initWithArrangedSubviews:@[original, retro]];
-  choices.axis = UILayoutConstraintAxisHorizontal;
-  choices.spacing = 18.0;
-  choices.distribution = UIStackViewDistributionFillEqually;
-
-  UIStackView *stack =
-      [[UIStackView alloc] initWithArrangedSubviews:
-          @[mark, title, tagline, message, choices]];
-  stack.translatesAutoresizingMaskIntoConstraints = NO;
-  stack.axis = UILayoutConstraintAxisVertical;
-  stack.spacing = 12.0;
-  [stack setCustomSpacing:24.0 afterView:message];
-  [self.view addSubview:stack];
-  self.contentWidthConstraint =
-      [stack.widthAnchor constraintEqualToConstant:320.0];
+  UILabel *supportTitle = [self label:@"A little help getting started"
+      style:UIFontTextStyleHeadline secondary:NO];
+  UILabel *supportText = [self label:@"File formats, importing your game, and adding Retro Rewind — explained step by step."
+      style:UIFontTextStyleSubheadline secondary:YES];
+  UIButton *setup = [self link:@"Setup guide" symbol:@"book.closed" action:^{
+    [weakSelf openGuide:@"blob/main/docs/INSTALL_IPA.md"];
+  }];
+  UIButton *troubleshooting = [self link:@"Troubleshooting" symbol:@"wrench.and.screwdriver" action:^{
+    [weakSelf openGuide:@"blob/main/docs/SUPPORT.md"];
+  }];
+  UIStackView *links = [[UIStackView alloc] initWithArrangedSubviews:@[setup, troubleshooting]];
+  links.axis = UILayoutConstraintAxisHorizontal;
+  links.alignment = UIStackViewAlignmentLeading;
+  links.distribution = UIStackViewDistributionFillEqually;
+  links.spacing = 12;
+  UILabel *footer = [self label:[NSString stringWithFormat:@"KartPad %@ · Build %@   /   Guides open on GitHub",
+      [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"] ?: @"",
+      [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleVersion"] ?: @""]
+      style:UIFontTextStyleCaption1 secondary:YES];
+  UIStackView *content = [[UIStackView alloc] initWithArrangedSubviews:
+      @[header, heading, intro, self.choices, supportTitle, supportText, links, footer]];
+  content.translatesAutoresizingMaskIntoConstraints = NO;
+  content.axis = UILayoutConstraintAxisVertical;
+  content.spacing = 10;
+  [content setCustomSpacing:30 afterView:header];
+  [content setCustomSpacing:22 afterView:intro];
+  [content setCustomSpacing:28 afterView:self.choices];
+  UIScrollView *scroll = [UIScrollView new];
+  scroll.translatesAutoresizingMaskIntoConstraints = NO;
+  [self.view addSubview:scroll];
+  UIView *canvas = [UIView new];
+  canvas.translatesAutoresizingMaskIntoConstraints = NO;
+  [scroll addSubview:canvas];
+  [canvas addSubview:content];
+  self.contentWidthConstraint = [content.widthAnchor constraintEqualToConstant:880];
+  NSLayoutConstraint *height = [canvas.heightAnchor constraintEqualToAnchor:scroll.frameLayoutGuide.heightAnchor];
+  height.priority = UILayoutPriorityDefaultLow;
   [NSLayoutConstraint activateConstraints:@[
-    [stack.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
-    [stack.centerYAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.centerYAnchor
-                                        constant:-18.0],
-    self.contentWidthConstraint,
+    [scroll.leadingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.leadingAnchor],
+    [scroll.trailingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.trailingAnchor],
+    [scroll.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor],
+    [scroll.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor],
+    [canvas.leadingAnchor constraintEqualToAnchor:scroll.contentLayoutGuide.leadingAnchor],
+    [canvas.trailingAnchor constraintEqualToAnchor:scroll.contentLayoutGuide.trailingAnchor],
+    [canvas.topAnchor constraintEqualToAnchor:scroll.contentLayoutGuide.topAnchor],
+    [canvas.bottomAnchor constraintEqualToAnchor:scroll.contentLayoutGuide.bottomAnchor],
+    [canvas.widthAnchor constraintEqualToAnchor:scroll.frameLayoutGuide.widthAnchor],
+    [canvas.heightAnchor constraintGreaterThanOrEqualToAnchor:scroll.frameLayoutGuide.heightAnchor],
+    [content.centerXAnchor constraintEqualToAnchor:canvas.centerXAnchor],
+    [content.centerYAnchor constraintEqualToAnchor:canvas.centerYAnchor],
+    [content.topAnchor constraintGreaterThanOrEqualToAnchor:canvas.topAnchor constant:24],
+    [content.bottomAnchor constraintLessThanOrEqualToAnchor:canvas.bottomAnchor constant:-24],
+    self.contentWidthConstraint, height,
   ]];
 }
 
 - (void)viewDidLayoutSubviews {
   [super viewDidLayoutSubviews];
-  self.backgroundGradient.frame = self.view.bounds;
   const UIEdgeInsets insets = self.view.safeAreaInsets;
-  const CGFloat availableWidth = CGRectGetWidth(self.view.bounds) -
-      insets.left - insets.right - 64.0;
-  self.contentWidthConstraint.constant =
-      MIN(760.0, MAX(320.0, availableWidth));
+  const CGFloat available = CGRectGetWidth(self.view.bounds) - insets.left - insets.right - 48;
+  self.contentWidthConstraint.constant = MIN(920, MAX(0, available));
+  BOOL accessibilityText = UIContentSizeCategoryIsAccessibilityCategory(self.traitCollection.preferredContentSizeCategory);
+  self.choices.axis = available < 660 || accessibilityText
+      ? UILayoutConstraintAxisVertical : UILayoutConstraintAxisHorizontal;
+  BOOL compact = CGRectGetHeight(self.view.bounds) - insets.top - insets.bottom < 500 && !accessibilityText;
+  for (UIView *detail in self.compactDetails) detail.hidden = compact;
 }
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
@@ -1275,7 +1438,7 @@ NSError *KartPadPerformGameDataImport(NSURL *url,
   self.choosingGameDataCopy = NO;
   UIAlertController *options =
       [UIAlertController alertControllerWithTitle:@"Game Data Required"
-          message:@"KartPad does not include Mario Kart Wii. Import your own RMCP01 WBFS, ISO, or extracted DATA folder to continue."
+          message:@"First, import your own Mario Kart Wii game: PAL (Europe), RMCP01 revision 0.\n\nChoose an ISO, WBFS, or extracted DATA folder. RVZ files must be converted first. Retro Rewind is added after this step."
           preferredStyle:UIAlertControllerStyleAlert];
   [options addAction:[UIAlertAction actionWithTitle:@"Choose WBFS, ISO, or DATA Folder…"
                                                style:UIAlertActionStyleDefault
@@ -1387,6 +1550,7 @@ NSError *KartPadPerformGameDataImport(NSURL *url,
     return NO;
   }
   self.root = [[KartPadFirstLaunchViewController alloc] init];
+  self.root.gameDataReady = gameDataReady;
   self.window = [[UIWindow alloc] initWithWindowScene:scene];
   self.window.windowLevel = UIWindowLevelAlert + 1.0;
   self.window.rootViewController = self.root;
@@ -2470,6 +2634,7 @@ NSError *KartPadPerformGameDataImport(NSURL *url,
   __block BOOL finished = NO;
   KartPadFirstLaunchViewController *root = [[KartPadFirstLaunchViewController alloc] init];
   root.resumingGame = YES;
+  root.gameDataReady = YES;
   root.currentRetroRewind = gKartPadRetroRewindSelected;
   UIWindow *home = [[UIWindow alloc] initWithWindowScene:_window.windowScene];
   home.windowLevel = UIWindowLevelAlert + 1;

--- a/apple/ios/KartPadRuntimeOverlayHost.mm
+++ b/apple/ios/KartPadRuntimeOverlayHost.mm
@@ -672,6 +672,9 @@ NSError *KartPadPerformGameDataImport(NSURL *url,
 @property(nonatomic, assign) BOOL gameDataReady;
 @property(nonatomic, strong) NSLayoutConstraint *contentWidthConstraint;
 @property(nonatomic, strong) UIStackView *choices;
+@property(nonatomic, strong) UIStackView *content;
+@property(nonatomic, strong) UIStackView *header;
+@property(nonatomic, strong) NSMutableArray<UILabel *> *cardTitles;
 @property(nonatomic, strong) NSMutableArray<UIView *> *compactDetails;
 @end
 
@@ -745,8 +748,12 @@ NSError *KartPadPerformGameDataImport(NSURL *url,
   UIButton *troubleshooting = [self link:@"Troubleshooting on GitHub" symbol:@"wrench.and.screwdriver" action:^{
     [weakSelf openGuide:@"blob/main/docs/SUPPORT.md"];
   }];
+  UILabel *version = [self label:[NSString stringWithFormat:@"KartPad %@ · Build %@",
+      [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"] ?: @"",
+      [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleVersion"] ?: @""]
+      style:UIFontTextStyleCaption1 secondary:YES];
   UIStackView *content = [[UIStackView alloc] initWithArrangedSubviews:
-      @[importTitle, importBody, retroTitle, retroBody, supportTitle, supportBody, setup, troubleshooting]];
+      @[importTitle, importBody, retroTitle, retroBody, supportTitle, supportBody, setup, troubleshooting, version]];
   content.axis = UILayoutConstraintAxisVertical;
   content.spacing = 12;
   [content setCustomSpacing:28 afterView:importBody];
@@ -802,6 +809,7 @@ NSError *KartPadPerformGameDataImport(NSURL *url,
   UILabel *title = [self label:retro ? @"Retro Rewind" : @"Mario Kart Wii"
       style:UIFontTextStyleTitle1 secondary:NO];
   title.accessibilityTraits |= UIAccessibilityTraitHeader;
+  [self.cardTitles addObject:title];
   NSString *detail = retro ? @"More tracks, characters and Retro WFC online play. Uses your Mario Kart Wii game data."
                            : @"Grand Prix, time trials and local races. Your original game, on this device.";
   UILabel *description = [self label:detail style:UIFontTextStyleBody secondary:YES];
@@ -812,7 +820,7 @@ NSError *KartPadPerformGameDataImport(NSURL *url,
   UILabel *metadata = [self label:note style:UIFontTextStyleFootnote secondary:YES];
   [self.compactDetails addObjectsFromArray:@[description, metadata]];
   NSString *actionTitle = current ? @"Resume Game" : (self.resumingGame ? @"Use on Next Launch"
-      : (ready ? @"Play Game" : (retro ? @"Set Up Retro Rewind" : @"Import Mario Kart Wii")));
+      : (ready ? @"Play Game" : (retro ? @"Set Up Game" : @"Import Game")));
   UIButtonConfiguration *configuration = [UIButtonConfiguration filledButtonConfiguration];
   configuration.title = actionTitle;
   configuration.image = [UIImage systemImageNamed:current || ready ? @"play.fill" : @"arrow.right"];
@@ -860,13 +868,14 @@ NSError *KartPadPerformGameDataImport(NSURL *url,
 - (void)viewDidLoad {
   [super viewDidLoad];
   self.compactDetails = [NSMutableArray array];
+  self.cardTitles = [NSMutableArray array];
   self.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
   self.view.backgroundColor = [UIColor colorWithRed:0.035 green:0.05 blue:0.08 alpha:1];
   UIImageView *mark = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"KartPadLogo"]];
   mark.contentMode = UIViewContentModeScaleAspectFit;
   mark.isAccessibilityElement = NO;
   [NSLayoutConstraint activateConstraints:@[
-    [mark.widthAnchor constraintEqualToConstant:64], [mark.heightAnchor constraintEqualToConstant:64],
+    [mark.widthAnchor constraintEqualToConstant:48], [mark.heightAnchor constraintEqualToConstant:48],
   ]];
   UILabel *brand = [self label:@"KartPad" style:UIFontTextStyleTitle1 secondary:NO];
   brand.font = [UIFontMetrics.defaultMetrics scaledFontForFont:
@@ -884,6 +893,8 @@ NSError *KartPadPerformGameDataImport(NSURL *url,
   header.axis = UILayoutConstraintAxisHorizontal;
   header.alignment = UIStackViewAlignmentCenter;
   header.spacing = 16;
+  self.header = header;
+  [self.compactDetails addObject:platform];
 
   UILabel *heading = [self label:self.resumingGame ? @"Back to the race" : @"Choose a game"
       style:UIFontTextStyleLargeTitle secondary:NO];
@@ -924,6 +935,8 @@ NSError *KartPadPerformGameDataImport(NSURL *url,
       @[header, heading, intro, self.choices, supportTitle, supportText, links, footer]];
   content.translatesAutoresizingMaskIntoConstraints = NO;
   content.axis = UILayoutConstraintAxisVertical;
+  self.content = content;
+  [self.compactDetails addObjectsFromArray:@[supportTitle, supportText, links, footer]];
   content.spacing = 10;
   [content setCustomSpacing:30 afterView:header];
   [content setCustomSpacing:22 afterView:intro];
@@ -951,8 +964,8 @@ NSError *KartPadPerformGameDataImport(NSURL *url,
     [canvas.heightAnchor constraintGreaterThanOrEqualToAnchor:scroll.frameLayoutGuide.heightAnchor],
     [content.centerXAnchor constraintEqualToAnchor:canvas.centerXAnchor],
     [content.centerYAnchor constraintEqualToAnchor:canvas.centerYAnchor],
-    [content.topAnchor constraintGreaterThanOrEqualToAnchor:canvas.topAnchor constant:24],
-    [content.bottomAnchor constraintLessThanOrEqualToAnchor:canvas.bottomAnchor constant:-24],
+    [content.topAnchor constraintGreaterThanOrEqualToAnchor:canvas.topAnchor constant:16],
+    [content.bottomAnchor constraintLessThanOrEqualToAnchor:canvas.bottomAnchor constant:-16],
     self.contentWidthConstraint, height,
   ]];
 }
@@ -963,9 +976,13 @@ NSError *KartPadPerformGameDataImport(NSURL *url,
   const CGFloat available = CGRectGetWidth(self.view.bounds) - insets.left - insets.right - 48;
   self.contentWidthConstraint.constant = MIN(920, MAX(0, available));
   BOOL accessibilityText = UIContentSizeCategoryIsAccessibilityCategory(self.traitCollection.preferredContentSizeCategory);
-  self.choices.axis = available < 660 || accessibilityText
-      ? UILayoutConstraintAxisVertical : UILayoutConstraintAxisHorizontal;
   BOOL compact = CGRectGetHeight(self.view.bounds) - insets.top - insets.bottom < 500 && !accessibilityText;
+  self.choices.axis = (!compact && available < 660) || accessibilityText
+      ? UILayoutConstraintAxisVertical : UILayoutConstraintAxisHorizontal;
+  [self.content setCustomSpacing:compact ? 12 : 30 afterView:self.header];
+  for (UILabel *title in self.cardTitles) {
+    title.font = [UIFont preferredFontForTextStyle:compact ? UIFontTextStyleTitle2 : UIFontTextStyleTitle1];
+  }
   for (UIView *detail in self.compactDetails) detail.hidden = compact;
 }
 

--- a/docs/artifacts/2026-09-09/mobile-game-chooser-audit.md
+++ b/docs/artifacts/2026-09-09/mobile-game-chooser-audit.md
@@ -61,8 +61,11 @@ presentation feedback. No community reply was sent as part of this work.
   32 protected files (19,871,359 bytes) were byte-identical between fresh pre-
   and post-install snapshots, including preferences. No restore was performed.
 - Private full build 32 contains the compact-phone correction and passes strict
-  signing verification. It is staged locally; the hardware iPad remains on build
-  31. Neither candidate is a published IPA. Build numbers are overridden only in
+  signing verification. At the owner's request it was subsequently installed
+  in place on the hardware iPad and launched without a debugger. Device inventory
+  confirms build 32. All 32 protected files (19,871,308 bytes) are byte-identical
+  between fresh build-32 pre/post-install snapshots. Neither candidate is a
+  published IPA. Build numbers are overridden only in
   the private staged bundles; public release metadata is unchanged.
 
 ## Review evidence and remaining scope

--- a/docs/artifacts/2026-09-09/mobile-game-chooser-audit.md
+++ b/docs/artifacts/2026-09-09/mobile-game-chooser-audit.md
@@ -1,0 +1,86 @@
+# Mobile game chooser: iPad-first review
+
+9 September 2026. Stacked on the iOS reporting/menu cleanup in PR #159.
+
+## Findings and changes
+
+1. **Choose a game — improved; physical review pending.** The actual M2 iPad
+   chooser had two small central buttons, a large decorative gradient, and no
+   setup-help entry. The native replacement uses quiet bordered cards, the
+   existing KartPad mark and platform icons, explicit imported/required/ready
+   status, and a visible Help button. Paused games retain Resume and next-launch
+   switching. Runtime profile selection and import/download callbacks are retained.
+2. **Understand setup — improved; native help exercised.** Help explains the
+   supported owned PAL (Europe) Mario Kart Wii ISO/WBFS (RMCP01 revision 0),
+   extracted DATA alternative and RVZ conversion requirement. It then explains
+   adding Retro Rewind through KartPad after importing the base game. Required
+   pack version comes from the existing installer. The two sections avoid implying
+   that a separate Retro Rewind disc is required.
+3. **Find support — working in the native UI fixture.** Setup and troubleshooting
+   buttons open the actual GitHub INSTALL_IPA.md and SUPPORT.md pages. Help's Done
+   control returns to the chooser. Version/build details remain available in Help.
+   No report was posted and no device data was uploaded.
+4. **Fit iPhone landscape — corrected after owner review.** The first candidate
+   still placed the support footer below the phone viewport. The owner rejected
+   that scrolling layout. The revision keeps the brand, Help and both game cards
+   together and moves supplementary guidance into Help on compact screens.
+   Shorter action labels retain the game name in their accessibility labels.
+   iPad retains the fuller descriptions and support footer.
+
+## Research grounding
+
+The current [Android community thread](https://www.reddit.com/r/decomps/comments/1w9wf66/kartpad_wiicompiled_first_android_community/)
+includes confusion about finding the built-in Retro Rewind download, importing a
+Retro folder and choosing the supported game region. Those are setup-order and
+requirements-discovery problems; this pass makes that information available
+before importing. It does not claim to resolve every installation failure.
+The recent GitHub issue list was also reviewed, including closed issue #142's
+presentation feedback. No community reply was sent as part of this work.
+
+## Validation
+
+- Initial source commit `8812843`; compact-phone correction `2e46881`.
+- Complete dual-profile physical iOS app builds and its unsigned bundle audit
+  passes after both changes. The compact correction passes all 18 matching
+  `test_ios_*contract.py` tests; the initial pass also passed 23 focused existing
+  contracts and 25 builder tests.
+- A temporary UIKit fixture compiles the exact chooser class from the source.
+  Only installed-data state and the terminal game-selection callback are stubbed.
+  Actual taps invoke base and Retro callbacks; Help/Done and both real GitHub
+  destinations were exercised. This fixture does not establish gameplay,
+  fresh disc import, network pack installation or VoiceOver acceptance.
+- The final native scroll geometry is checked in missing-data, ready and paused
+  states on iPhone 17 Pro and iPhone SE (3rd generation) simulators. All six cases
+  have zero vertical overflow: content equals viewport (750 x 382 and 667 x 375
+  points respectively). The iPhone 17 Pro screenshot confirms all primary
+  controls are visible together. Accessibility text sizes intentionally retain
+  scrolling rather than shrinking or truncating the text; the largest size was
+  inspected for header/help access, not a complete accessibility certification.
+- Initial full build 31 was installed in place on the physical M2 iPad and
+  launched Retro Rewind using the owner's preserved next-launch choice. All
+  32 protected files (19,871,359 bytes) were byte-identical between fresh pre-
+  and post-install snapshots, including preferences. No restore was performed.
+- Private full build 32 contains the compact-phone correction and passes strict
+  signing verification. It is staged locally; the hardware iPad remains on build
+  31. Neither candidate is a published IPA. Build numbers are overridden only in
+  the private staged bundles; public release metadata is unchanged.
+
+## Review evidence and remaining scope
+
+Private screenshots, exact-source fixture, geometry results and build logs are
+under `build/chooser-review`; installation/signing evidence is under
+`build/ipad-physical`. The accepted before screenshot is
+`01-ipad-current-menu.png`; the revised phone screenshot is
+`09-iphone-no-scroll.png`; help is `04-iphone-help-preview.png`. Intermediate
+letterboxed/rotated simulator captures are not the final visual handoff.
+
+The physical iPad's redesigned menu still needs the owner's visual/interaction
+review. An initial full-app Retro Rewind launch was observed, then the mirror
+became unavailable; no physical after-menu screenshot is claimed. Full fresh
+setup on physical hardware was not tested because its existing game data was
+preserved. Android chooser propagation follows this iPad review as requested;
+this branch does not change Android's chooser or use its owner's hardware.
+
+Build 32 source: `2e46881f6694423c896288fccaddfa53f1b4dcce`.
+Private signed executable SHA-256:
+`66f097da4dd0f1d947e1c49b88d3f07f616043d73025aab48d3f6d18d053d9e5`.


### PR DESCRIPTION
The iOS/iPadOS game chooser previously offered two small game buttons without visible setup help. This replaces them with status-aware cards and native Help explaining the supported base game and the in-app Retro Rewind installation, with working links to the GitHub setup and troubleshooting guides.

The compact iPhone layout keeps the logo, Help and both actions on one screen. Supplementary instructions move into Help; iPad retains the fuller layout. Existing import, resume and next-launch selection callbacks are retained.

Validation: complete dual-profile iOS build and unsigned bundle audit pass; 18 iOS contract tests pass after the compact correction. Exact-source native UI fixtures exercise selection, Help/Done and both real guide destinations. Missing-data, ready and paused layouts all have zero vertical overflow on iPhone 17 Pro and iPhone SE 3. Build 31 was installed in place on the physical M2 iPad with all 32 protected files unchanged and launched Retro Rewind. At the owner's request, the compact correction was then installed and launched as private build 32; device inventory confirms 32 and all 32 protected files are unchanged across fresh pre/post-install snapshots. Physical chooser review and Android propagation remain pending the iPad-first review.

Stacked on #159. Detailed evidence and limits: docs/artifacts/2026-09-09/mobile-game-chooser-audit.md.
