### PR TITLE
Preserve redirected saves when replacing the Android Retro pack

### DIFF
--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallStorage.java
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindInstallStorage.java
@@ -110,6 +110,9 @@ final class RetroRewindInstallStorage {
         boolean movedExisting = false;
         if (exists(installed)) {
             requireDirectory(installed, "Retro Rewind installed root is invalid");
+            // Saves live beside pack content. Copy them before moving either root;
+            // a failed copy must leave the installed pack and progress untouched.
+            preserveRedirectedSaves(installed, normalizedStaging);
             mover.move(installed, rollback);
             movedExisting = true;
         }
@@ -128,6 +131,49 @@ final class RetroRewindInstallStorage {
 
         if (movedExisting) {
             deleteTree(rollback);
+        }
+    }
+
+    private static void preserveRedirectedSaves(Path installed, Path staging) throws IOException {
+        Path riivolution = installed.resolve("riivolution");
+        if (!exists(riivolution)) return;
+        requireDirectory(riivolution, "Retro Rewind save parent is invalid");
+        Path saves = riivolution.resolve("save");
+        if (!exists(saves)) return;
+        requireDirectory(saves, "Retro Rewind save root is invalid");
+
+        Path destinationParent = staging.resolve("riivolution");
+        ensureSaveDirectory(destinationParent);
+        Path destination = destinationParent.resolve("save");
+        // Do not follow links from either the retained data or the staged pack.
+        Files.walkFileTree(saves, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path directory, BasicFileAttributes attrs)
+                    throws IOException {
+                ensureSaveDirectory(destination.resolve(saves.relativize(directory)));
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                    throws IOException {
+                Path target = destination.resolve(saves.relativize(file));
+                if (!attrs.isRegularFile() || (exists(target) &&
+                        !Files.isRegularFile(target, LinkOption.NOFOLLOW_LINKS))) {
+                    throw new IOException("Retro Rewind save entry is invalid");
+                }
+                Files.copy(file, target, StandardCopyOption.REPLACE_EXISTING,
+                        LinkOption.NOFOLLOW_LINKS);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private static void ensureSaveDirectory(Path directory) throws IOException {
+        if (exists(directory)) {
+            requireDirectory(directory, "Retro Rewind save destination is invalid");
+        } else {
+            Files.createDirectory(directory);
         }
     }
 

--- a/android/app/src/test/java/dev/kartpad/android/RetroRewindInstallStorageTestMain.java
+++ b/android/app/src/test/java/dev/kartpad/android/RetroRewindInstallStorageTestMain.java
@@ -17,10 +17,15 @@ public final class RetroRewindInstallStorageTestMain {
             testRecovery(temporary.resolve("recovery"));
             testAmbiguousRecovery(temporary.resolve("ambiguous"));
             testActivation(temporary.resolve("activation"));
+            testSavePreservingReplacement(temporary.resolve("saves"));
+            for (String boundary : new String[]{"source-parent", "source-file", "target-parent", "target-file", "target-conflict"}) {
+                testSaveCopyFailure(temporary.resolve(boundary), boundary);
+            }
             testActivationRollback(temporary.resolve("rollback"));
             testScopeChecks(temporary.resolve("scope"));
             testSymlinkBoundary(temporary.resolve("symlink"));
             testRollbackSymlinkBoundary(temporary.resolve("rollback-symlink"));
+            System.out.println("Retro install storage: 13 cases passed");
         } finally {
             deleteTree(temporary);
         }
@@ -72,11 +77,96 @@ public final class RetroRewindInstallStorageTestMain {
                 "successful rollback was not removed");
     }
 
+    private static void testSavePreservingReplacement(Path root) throws Exception {
+        File files = Files.createDirectories(root).toFile();
+        Path support = RetroRewindInstallStorage.supportRoot(files);
+        Path installed = Files.createDirectories(support.resolve("RetroRewind"));
+        String[] saves = {"riivolution/save/RetroWFC/RMCP/rksys.dat",
+                "riivolution/save/RetroWFC2/RMCP/rksys.dat",
+                "riivolution/save/RetroWFC/RMCP/other-progress.dat"};
+        for (String save : saves) {
+            Files.createDirectories(installed.resolve(save).getParent());
+            write(installed.resolve(save), "player:" + save);
+        }
+        Path pulsar = support.resolve("NAND/shared2/Pulsar/RetroRewind6/Ghosts/track/ldb.pul");
+        Files.createDirectories(pulsar.getParent());
+        write(pulsar, "custom record");
+        Path staging = RetroRewindInstallStorage.createStagingDirectory(files, "preserve");
+        write(staging.resolve("new-pack"), "new pack");
+        Files.createDirectories(staging.resolve(saves[0]).getParent());
+        write(staging.resolve(saves[0]), "pack default must not replace player save");
+
+        RetroRewindInstallStorage.activateValidatedStaging(files, staging, "preserve");
+        RetroRewindInstallStorage.recover(files);
+
+        for (String save : saves) {
+            expect(Files.exists(installed.resolve(save)), "replacement lost save: " + save);
+            expect(Files.readString(installed.resolve(save)).equals("player:" + save),
+                    "replacement overwrote save: " + save);
+        }
+        expect(Files.readString(installed.resolve("new-pack")).equals("new pack"),
+                "updated pack was not activated");
+        expect(Files.readString(pulsar).equals("custom record"), "Pulsar data changed");
+    }
+
+    private static void testSaveCopyFailure(Path root, String boundary) throws Exception {
+        File files = Files.createDirectories(root.resolve("files")).toFile();
+        Path installed = Files.createDirectories(RetroRewindInstallStorage.installedRoot(files));
+        write(installed.resolve("old"), "old pack");
+        Path outside = Files.createDirectories(root.resolve("outside"));
+        write(outside.resolve("sentinel"), "unchanged");
+        Path save = installed.resolve("riivolution/save/RetroWFC/RMCP/rksys.dat");
+        Path staging = RetroRewindInstallStorage.createStagingDirectory(files, "boundary");
+        Path target = staging.resolve("riivolution/save/RetroWFC/RMCP/rksys.dat");
+        if (boundary.equals("source-parent")) {
+            Files.createSymbolicLink(installed.resolve("riivolution"), outside);
+        } else {
+            Files.createDirectories(save.getParent());
+            if (boundary.equals("source-file")) {
+                Files.createSymbolicLink(save, outside.resolve("sentinel"));
+            } else {
+                write(save, "player progress");
+                if (boundary.equals("target-parent")) {
+                    Files.createSymbolicLink(staging.resolve("riivolution"), outside);
+                } else {
+                    Files.createDirectories(target.getParent());
+                    if (boundary.equals("target-file")) {
+                        Files.createSymbolicLink(target, outside.resolve("sentinel"));
+                    } else {
+                        Files.createDirectory(target);
+                    }
+                }
+            }
+        }
+        AtomicInteger moves = new AtomicInteger();
+        try {
+            RetroRewindInstallStorage.activateValidatedStaging(files, staging, "boundary",
+                    (source, destination) -> {
+                        moves.incrementAndGet();
+                        Files.move(source, destination);
+                    });
+            throw new AssertionError("unsafe save copy was accepted: " + boundary);
+        } catch (IOException expected) {
+            expect(moves.get() == 0, "save-copy failure moved active data");
+        }
+        expect(Files.readString(installed.resolve("old")).equals("old pack"),
+                "save-copy failure replaced active pack");
+        expect(Files.readString(outside.resolve("sentinel")).equals("unchanged"),
+                "save-copy failure changed link target");
+        if (boundary.startsWith("target-")) {
+            expect(Files.readString(save).equals("player progress"),
+                    "save-copy failure changed original progress");
+        }
+    }
+
     private static void testActivationRollback(Path root) throws Exception {
         File files = Files.createDirectories(root).toFile();
         Path support = RetroRewindInstallStorage.supportRoot(files);
         Path installed = Files.createDirectories(support.resolve("RetroRewind"));
         write(installed.resolve("old"), "old");
+        Path save = installed.resolve("riivolution/save/RetroWFC/RMCP/rksys.dat");
+        Files.createDirectories(save.getParent());
+        write(save, "retained progress");
         Path staging = RetroRewindInstallStorage.createStagingDirectory(files, "failure");
         write(staging.resolve("new"), "new");
         AtomicInteger calls = new AtomicInteger();
@@ -97,6 +187,8 @@ public final class RetroRewindInstallStorageTestMain {
 
         expect(Files.readString(support.resolve("RetroRewind/old")).equals("old"),
                 "old install was not restored after activation failure");
+        expect(Files.readString(save).equals("retained progress"),
+                "activation rollback lost saved progress");
         expect(Files.exists(staging.resolve("new")),
                 "failed staging directory was unexpectedly removed");
         expect(!Files.exists(support.resolve("RetroRewind.rollback-failure")),

--- a/android/app/src/test/java/dev/kartpad/android/RetroRewindSpacePreflightTestMain.java
+++ b/android/app/src/test/java/dev/kartpad/android/RetroRewindSpacePreflightTestMain.java
@@ -76,7 +76,7 @@ public final class RetroRewindSpacePreflightTestMain {
                 RetroRewindRelease.ARCHIVE_BYTES,
                 RetroRewindRelease.MAXIMUM_EXPANDED_BYTES);
         expect(production.isReady(), "production requirements overflowed");
-        expect(production.requiredFilesBytes == 4_327_477_355L,
+        expect(production.requiredFilesBytes == 4_327_477_144L,
                 "production shared-store requirement drifted");
         var productionCached = RetroRewindSpacePreflight.evaluate(
                 Long.MAX_VALUE, Long.MAX_VALUE, true,

--- a/docs/artifacts/2026-09-10/android-retro-pack-save-preservation.md
+++ b/docs/artifacts/2026-09-10/android-retro-pack-save-preservation.md
@@ -60,3 +60,18 @@ compile/lint log. Prepare the next local APK using the unchanged accepted native
 payload, verify signing/package identity and perform a backed-up in-place update.
 Do not exercise pack replacement against the owner's real saves as a regression.
 The physical menu-delay profile remains the next performance measurement.
+
+## Independent integration review
+
+The focused commit applies to current main; all 13 storage cases and the space,
+pipeline, content and worker-policy checks pass in the integration checkout.
+Independent Medium review found no blocker for replacement with guest saves
+quiescent. Copy failure preserves the installed tree; activation failure restores
+it or retains rollback if restoration fails.
+
+Concurrent gameplay/update safety is not established: storage and worker do not
+lock guest writes, and a worker can outlive the installer screen. The healthy
+ready-pack UI hides installation, but any future update/reinstall flow needs an
+explicit runtime-stop gate. Extra duplicated save bytes are not included in the
+space estimate and may cause a safe copy failure. Actual pack replacement,
+power-loss recovery and #169 ordinary-exit attribution remain unverified.

--- a/docs/artifacts/2026-09-10/android-retro-pack-save-preservation.md
+++ b/docs/artifacts/2026-09-10/android-retro-pack-save-preservation.md
@@ -1,0 +1,62 @@
+# Preserve redirected saves when replacing the Android Retro pack
+
+Source investigation prompted by [issue #169](https://github.com/chrissotraidis/kartpad/issues/169)
+found a reproducible pack-replacement defect. It does not establish the cause of
+the reporter's ordinary-exit loss on build 21. No reporter logs or exact lost-data
+category are available yet; support remains coordinator-owned.
+
+## Defect and correction
+
+`RetroRewindInstallStorage.activateValidatedStaging` moved the old RetroRewind
+root to rollback, activated the staged pack, then deleted rollback. That also
+deleted `riivolution/save`, including RetroWFC and RetroWFC2 redirected license
+saves. The same implementation exists in v0.4.10-android.1, local build 61 and
+origin/main at 19f946d. Successful replacement is the trigger; ordinary chooser
+recovery does not delete the active root. Missing redirected saves can subsequently
+be initialized or cloned, which is distinct from saving successfully on exit.
+
+The correction copies retained `riivolution/save` into the staged pack before
+either root moves. Existing user files override any staged defaults. All save
+subdirectories are retained, including Separate Save. Copy failures leave the
+active pack untouched; activation rollback retains its previous behavior. Links,
+special files and incompatible destination entries fail before activation.
+Pulsar records/ghosts/ratings under `NAND/shared2/Pulsar/RetroRewind6` are outside
+the replaced pack and remain untouched. No native runtime or Apple source changes.
+
+## Evidence
+
+- Added regression failed on the unchanged implementation: replacement overwrote
+  `riivolution/save/RetroWFC/RMCP/rksys.dat` with a staged default. The same case
+  also checks the separate profile, another retained save entry, pack replacement,
+  startup recovery and an untouched Pulsar sentinel.
+- All 13 storage cases pass with the correction on the pinned host JDK and physical
+  Android ART. Failure cases cover source/destination links, incompatible target
+  type, activation rollback and existing recovery boundaries. Android execution
+  used a D8-built test JAR through app_process with disposable shell-owned files
+  under a unique /data/local/tmp directory, removed after testing. It did not
+  access KartPad data, replace the user's pack or install a test package.
+- Existing installation pipeline, content validation, worker policy and storage
+  space checks pass. The space check initially failed because its literal total
+  was stale by 211 bytes after the pinned archive changed; updated expected total
+  to 4,327,477,144 = 1,859,041,688 archive + 2,200,000,000 expanded + 268,435,456
+  reserve. The production space calculation is unchanged. Save copying may need
+  additional free space; any copy error aborts before active data moves.
+- Android compileDebugJavaWithJavac and lintDebug pass with the retained dual-game
+  configuration. Existing chooser accessibility deprecation warning remains.
+- This is a reliability correction, not an FPS improvement. No real pack update,
+  power-loss recovery or reporter-device reproduction is claimed from these tests.
+
+## Remaining paths and next steps
+
+Current native NAND safe/plain close paths already flush and publish shadow saves;
+IOS/Pulsar uses a different direct-file path. Ordinary exit before guest save
+completion, separate-profile selection and actual I/O errors remain hypotheses.
+Do not force save completion or commit an unfinished shadow when exiting. Native
+write routines also ignore a fflush return; that merits a separate fault-injected
+investigation, not a claim that it caused this report.
+
+Private build/retro-save-preservation contains test JAR, ART result and Android
+compile/lint log. Prepare the next local APK using the unchanged accepted native
+payload, verify signing/package identity and perform a backed-up in-place update.
+Do not exercise pack replacement against the owner's real saves as a regression.
+The physical menu-delay profile remains the next performance measurement.


### PR DESCRIPTION
Replacing the installed Retro pack previously discarded redirected saves when the old directory was deleted. Copy existing save directories into validated staging before activation, so a copy failure leaves the installed pack intact and activation rollback retains the original data.

Validation: 13 storage cases pass on current main, plus space, pipeline, content and worker-policy checks. The implementation owner also ran the storage cases on Android ART with disposable files and passed Android compile/lint. Independent review cleared the quiescent replacement scope.

This does not establish the cause of #169's ordinary-exit report. Concurrent gameplay/update safety and power-loss recovery remain unverified; no package publication is part of this PR.
