### PR TITLE
Document Android preview 63 candidate and verified packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ with Retro rating transfer and expanded diagnostics. Offline rating transfer is
 reporter-confirmed; broader device acceptance remains open. It is not a verified
 graphics, slowdown or online-stall fix.
 
+**Next Android release candidate: 0.4.14 preview 1.** It combines a refreshed
+game chooser, reviewed-log problem reports, Retro pack-update save protection,
+and a measured rendering improvement. In local Pixel 9 Pro XL tests at 2x/Fill,
+the warm Grand Prix menu ran at about **58 FPS versus 40–50 FPS** with the change
+disabled; race gains were smaller. These are controlled local rendering-mode
+tests, not an across-device or final public-APK speedup claim. Final physical
+acceptance is pending; the download links above remain the published builds.
+See the [candidate release notes and test limits](docs/releases/v0.4.14-android-preview.1.md).
+
 **0.4.14 is the current official iPhone/iPad build.** It adds a clearer game
 chooser with setup help, an iPhone layout that fits on one screen, clearer
 problem-report attachment instructions, and Apple Metal view recovery fixes.

--- a/docs/INSTALL_ANDROID.md
+++ b/docs/INSTALL_ANDROID.md
@@ -11,6 +11,12 @@ Follow the [preview test steps](releases/v0.4.13-android-preview.1.md); physical
 real-save and performance acceptance remain pending. It is not a verified
 fix for graphics corruption, slowdown, online stalls or cup crashes.
 
+**0.4.14 preview 1 is a release candidate, not yet a public download.** It adds
+the refreshed chooser, explicit reviewed-log reporting, Retro pack replacement
+save protection and native frame overlap. See its
+[changes, measurements and remaining acceptance checks](releases/v0.4.14-android-preview.1.md).
+Keep using the published links above until the candidate is released.
+
 ## Download and first launch
 
 1. Open the [first Android release](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.10-android.1).
@@ -105,6 +111,12 @@ Runtime, renderer-phase and bounded battery/thermal diagnostics are retained
 locally; the app does not upload those reports automatically. Shell profiling
 is enabled in the first release; the later testing builds disable shell profiling.
 Public game packages are non-debuggable.
+
+In the **0.4.14 candidate**, Report a Problem asks you to select a readable text
+log and confirm that you reviewed it, or explain why logs cannot be included.
+Exporting diagnostics does not select or approve an attachment. If you open
+GitHub, attach the reviewed file manually to the issue draft. Opening a share
+sheet does not send anything until you choose a destination and complete it.
 
 Review diagnostics before sharing; do not attach raw private archives, game
 images, extracted assets, saves, account/device identifiers or signing keys to

--- a/docs/artifacts/2026-09-10/android-next-preview-scope.md
+++ b/docs/artifacts/2026-09-10/android-next-preview-scope.md
@@ -48,6 +48,13 @@ Delfino Square and is rejected as a controlled input-duration comparison.
 
 ## Current validation and remaining release gates
 
+Superseded checkpoint: the source below was subsequently reviewed and merged as
+`6a2dffc30f8f0d55a7eb928c614c88e054240d14`. The non-debug APK is built and audited.
+See [the release verification record](android-release63-verification.md) and
+[candidate release notes](../../releases/v0.4.14-android-preview.1.md) for actual
+runtime results, final artifact identity and remaining acceptance gates. The
+older next-step paragraphs below describe the prebuild checkpoint only.
+
 Fresh Android preparation from this integrated source passed. Actual prepared
 resize bounds, sealed debug-marker ownership and captured depth mapping passed
 ASan/UBSan harnesses; VI/aspect callback reentrancy and unchanged viewport-policy

--- a/docs/artifacts/2026-09-10/android-release63-verification.md
+++ b/docs/artifacts/2026-09-10/android-release63-verification.md
@@ -25,6 +25,11 @@ request is pending. The support coordinator owns distribution and public replies
   `cc0eca11878a57c1e2664f0c778492383894a09aee06fd97c3dbc21ebe2cc80e`.
   Final APK ZIP payload differs only in `assets/kartpad-build.json`; all native
   libraries, DEX, resources and game payload are identical.
+- Final APK repeated derivation is byte-identical. The companion ZIP contains
+  28 allowlisted notices/provenance entries; SHA-256
+  `da5d5ce9eb8095f654645146ff408fade531d4c174c9df7cdf9ef789fac315c0`.
+  Both distribution files verify against `SHA256SUMS`. Packaging documentation
+  source is `37ce92d`; exact native/source/APK/AAB allowlists remain enforced.
 
 The native configuration is RelWithDebInfo with `-O2 -DNDEBUG`. Disassembly of
 the linked overlap policy is `mov w0, #1; ret`; its debug-property string is
@@ -87,8 +92,8 @@ numbers and the remaining 2.580–2.732-second menu transitions.
 
 ## Release gates and handoff
 
-Retain this APK as the next official preview candidate. Finish companion
-notices/checksums and review the documentation revision separately from compiled
+Retain this APK as the next official preview candidate. Companion notices and
+checksums are complete; review the documentation revision separately from compiled
 source. The exact release configuration still needs physical controls/audio,
 representative gameplay and restart/save acceptance after safe owner handover.
 The phone uses a private signing identity: derive a matching-signer test variant
@@ -100,6 +105,14 @@ generated/dependency Corresponding Source. Preserve the existing documented
 source-distribution obligations and resolve any missing required source before
 distribution. Public upload and the X announcement remain separate owner
 decisions after the concrete artifacts and test limits are presented.
+
+A local repository-source archive contains the 1,117 tracked files at merged
+application source, including existing documentation images. Its SHA-256 is
+`2e9c689f0b4b7aad4130c2a6f268f112d7e2bc5af663ec6224201da211db00c5`.
+Path audit excludes private/build/bootstrap paths, links, traversal and game,
+package or signing-file extensions. This is not a full content/completeness audit;
+the archive is kept outside the APK/notices distribution directory pending that
+assessment. It omits ignored generated translation and dependency checkouts.
 
 Raw captures, logs, game fixtures, private AAB and signing material remain in
 ignored local `build/release-candidate` and `build/release-final` directories.

--- a/docs/artifacts/2026-09-10/android-release63-verification.md
+++ b/docs/artifacts/2026-09-10/android-release63-verification.md
@@ -1,0 +1,106 @@
+# Android release candidate 63 verification
+
+Status: reviewed and merged, publicly signed candidate packaged locally. Not
+published. Physical phone remains on the owner's private local62; no phone input,
+restart or install was performed during this release integration. A safe handover
+request is pending. The support coordinator owns distribution and public replies.
+
+## Exact artifacts
+
+- Version: `0.4.14-android-preview.1`, code 63, `dev.kartpad.android`.
+- Source: merged `6a2dffc30f8f0d55a7eb928c614c88e054240d14`, clean at build.
+- Reviewed premerge source: `8336948b88641e75e2a3434ea173de942eb866f7`.
+  The two Git trees are identical; PR #174 merged after source review and runtime
+  smoke checks. No application code changed for final packaging.
+- Final APK SHA-256:
+  `4e27897b9bb89e7b24fbe0b2e3dc66fae4efd549edaadf2f748ca22f376d87ff`.
+  Size: 110,355,865 bytes.
+- Final private AAB SHA-256:
+  `7d49f7dd7706b1b1f89fbaa4933f7ae4ac4a79c42ab96c567023b5646238f273`.
+- Existing public certificate SHA-256:
+  `c1dbe0a0d72d830a5779476b346a750d0a37515adef992cad2f3863058f7f2f2`.
+- Stripped `libmain.so` SHA-256:
+  `1502c10b591809d3117b1e057d2273b53ec81fe76bf87d06d31dd1114286cf42`.
+- Premerge tested APK SHA-256:
+  `cc0eca11878a57c1e2664f0c778492383894a09aee06fd97c3dbc21ebe2cc80e`.
+  Final APK ZIP payload differs only in `assets/kartpad-build.json`; all native
+  libraries, DEX, resources and game payload are identical.
+
+The native configuration is RelWithDebInfo with `-O2 -DNDEBUG`. Disassembly of
+the linked overlap policy is `mov w0, #1; ret`; its debug-property string is
+absent from the APK native library. Actual emulator logs contain overlap encode
+phase reports while the debug property is empty. This establishes release-path
+activation, not a new matched public-build performance percentage.
+
+## Checks and observations
+
+- Fresh Android preparation and five extracted-source bounds/ownership/mapping/
+  concurrency harnesses passed ASan/UBSan/TSan as applicable. These are not a
+  sanitizer run of the complete game engine.
+- 66 Android Python contracts passed. Executable Kotlin report/evidence and
+  bounded-export checks passed. Retro storage regression covered 13 cases plus
+  pipeline/content/space checks. Release compile and lintVital passed.
+- AAB/APK content, signature and alignment audits passed unchanged. The initial
+  AAB marker-count audit rejected reused stripped DiscIO input because its symbol
+  metadata was absent. The original unstripped dependency restored that metadata;
+  its stripped library exactly matches the existing public library. No key leak
+  or runtime dependency change was established, and the audit was not weakened.
+- Isolated API 36 ARM64 software-GPU emulator, 1280x720, 1x/4:3, validation off,
+  audio disabled. Private owned-game fixtures were seeded directly; this is not
+  an import/install-transaction test. No owner saves or identities were copied.
+- Exact public28 to premerge63 update used `install -r`: all 19 protected fixture
+  files identical. Final merged63 update also used `install -r`: all 25 protected
+  files identical, including the newly created Retro redirected-save fixture.
+  No uninstall, data clear or downgrade occurred.
+- Original: 50cc, Mario, Standard Kart M, Automatic, Luigi Circuit. Intro,
+  countdown, acceleration and steering worked. Home return, Report a Problem
+  return and live 1440x900/1280x720 resize kept the same game process. Game time
+  advanced beyond six minutes, much of it parked at a wall; no completed lap,
+  race or sustained driven-performance benchmark is claimed.
+- Retro: Mario, Standard Kart M, Hybrid, SNES Mario Circuit 1. Actual race intro
+  says 200cc, correcting an earlier inferred 100cc label. Countdown, acceleration,
+  steering and same-process Home return worked. A fresh KartPad license visibly
+  reloaded after full app restart. This is not saved cup/awards acceptance.
+- Captured Original console: 203 overlap reports; Retro: 133. No renderer
+  error/fatal lines in those captures; crash buffer empty. Counts are diagnostic
+  windows, not a frame-rate benchmark or proof of no unlogged defect.
+- Real public-APK report flow blocked sharing without an evidence choice, then
+  blocked an unreviewed selected text file. Review confirmation opened the share
+  sheet with one harmless test file. No recipient was chosen. GitHub manual-
+  attachment confirmation was inspected and canceled; no report was submitted.
+  A stale inline validation message remained after review selection (cosmetic).
+
+## Rejected inferences
+
+Single title presses separated by long tool/model delays can overlap the attract
+movie. A bounded adjacent-press test reached title, retained license and main.
+Earlier stale screenshots do not establish lost native input or a controller
+fix. A report-screen scroll accidentally invoked the Android Home gesture;
+process/crash checks and successful return distinguish it from an app crash.
+The previous local62 title trial overlapped owner gameplay and remains rejected.
+
+The historical hashing improvement is not a new public gain. Passing Pixel
+vertex probes do not resolve affected Adreno geometry. Save preservation is not
+an FPS change or proof that ordinary-exit progress loss is fixed. See the
+[release notes](../../releases/v0.4.14-android-preview.1.md) for scene-specific
+numbers and the remaining 2.580–2.732-second menu transitions.
+
+## Release gates and handoff
+
+Retain this APK as the next official preview candidate. Finish companion
+notices/checksums and review the documentation revision separately from compiled
+source. The exact release configuration still needs physical controls/audio,
+representative gameplay and restart/save acceptance after safe owner handover.
+The phone uses a private signing identity: derive a matching-signer test variant
+with identical payload; never uninstall to install the public certificate.
+
+No across-device, affected-Adreno, online or completed-cup claim is supported.
+The repository snapshot/build recipe is not a certification of complete
+generated/dependency Corresponding Source. Preserve the existing documented
+source-distribution obligations and resolve any missing required source before
+distribution. Public upload and the X announcement remain separate owner
+decisions after the concrete artifacts and test limits are presented.
+
+Raw captures, logs, game fixtures, private AAB and signing material remain in
+ignored local `build/release-candidate` and `build/release-final` directories.
+Only sanitized measurements and artifact fingerprints belong in this record.

--- a/docs/releases/v0.4.14-android-preview.1-x-draft.md
+++ b/docs/releases/v0.4.14-android-preview.1-x-draft.md
@@ -1,0 +1,18 @@
+# X announcement draft
+
+Do not post the release announcement until the APK is published and the release
+decision is recorded. Replace `[release link]` with the actual release URL. The
+measurements below are local rendering-mode comparisons, not a final public-APK
+versus previous-public-APK benchmark. Do not add a universal speedup percentage.
+
+## Release post
+
+KartPad's new Android preview is here: a refreshed game menu, rendering improvements, better problem reports, and save protection when updating Retro Rewind. Menu delays and device-specific graphics issues still need work. [release link]
+
+## Measurement reply
+
+In local Pixel 9 Pro XL tests at 2x/Fill, enabling the rendering change raised warm GP-menu FPS from 40–50 to about 58. A stationary Retro scene improved less: 51–54 to 55–56 FPS. These are local mode comparisons, not a speedup guarantee for every phone.
+
+## Before-release alternative
+
+We're preparing the next KartPad Android preview with a refreshed menu, rendering improvements and save protection for Retro updates. Release packaging and emulator checks have passed; final phone checks are next. We'll share measured results and known limits with the APK.

--- a/docs/releases/v0.4.14-android-preview.1.md
+++ b/docs/releases/v0.4.14-android-preview.1.md
@@ -1,0 +1,91 @@
+# KartPad Android 0.4.14 preview 1
+
+Release candidate; not yet published or physically accepted in this exact release
+configuration. For ARM64 Android devices, Android 9/API 28 or newer, with Vulkan.
+Version code 63 retains the public signing identity. Update an existing public
+installation in place; keep its game data, saves and settings. Do not uninstall
+to work around a signing mismatch with a private test build.
+
+## What changed
+
+- A refreshed game chooser and setup help, following the newer Apple layout.
+- Native rendering can overlap frame preparation and encoding. The frame owns
+  its debug markers and depth mapping, with synchronization around shared frame
+  state. This is enabled in the release build without a debug setting.
+- A bounds check protects stale UI snapshots during resize/surface changes.
+- The first graphics GEN_MODE write is decoded even if it equals the initial
+  cached value. This corrects a demonstrated initialization defect; it is not a
+  confirmed fix for reported Adreno character corruption.
+- Replacing a Retro Rewind pack preserves redirected saves. This does not
+  establish a fix for separate reports of progress lost on ordinary app exit.
+- Report a Problem asks for a readable text log and explicit review confirmation,
+  or a reason logs cannot be included. GitHub attachments remain manual. Nothing
+  uploads automatically, and opening the share sheet does not send a report.
+
+## Performance evidence and expectations
+
+Controlled local rendering-mode comparisons on one Pixel 9 Pro XL at 2x/Fill:
+
+| Scene | Overlap off | Overlap on | Conservative improvement |
+| --- | --- | --- | --- |
+| Warm Grand Prix menu | 39.52–49.96 FPS | 57.80–58.58 FPS | 15.7% |
+| Stationary Retro race scene | 51.363–54.157 FPS | 54.894–55.728 FPS | 1.36% |
+
+The conservative comparison uses the lowest candidate FPS against the highest
+baseline FPS. These are earlier local debug/property comparisons of the rendering
+change, not a matched previous-public-APK versus this APK benchmark. They do not
+measure all tracks, phones, driven races or cold shader compilation. An unrelated
+24% local hashing result is excluded: the previous public release already used
+the optimized hashing configuration.
+
+Menu transitions can still feel slow: measured Main Menu to Single Player
+transitions took 2.580–2.732 seconds. Racing gains were much smaller than the
+warm-menu gain. There is no defensible across-the-board speedup percentage.
+Adreno graphics reports, cup/awards crashes and other device-specific issues
+remain under investigation.
+
+## Verification
+
+The reviewed source passed focused Android contracts, executable report/export
+checks, save-preservation regressions, and source-body sanitizer/concurrency
+harnesses. The non-debug build passed release compilation, lintVital, package,
+signature, alignment and bounded-content audits. These checks do not certify
+the whole engine or every GPU.
+
+The premerge release candidate passed an actual public-signer update from public
+preview 28 in an isolated API 36 ARM64 emulator. All 19 protected fixture files
+were byte-identical across the update. Both Original and Retro reached races
+with working acceleration and steering and returned from Home in the same game
+process. Original also passed report-return and live-resize checks. The Retro
+fixture license survived a full app restart. Actual release logs confirmed the
+overlap path with no debug property. Captured crash buffers were empty.
+
+This used private seeded game fixtures, a software GPU, and disabled emulator
+audio. It is not a full-disc import, audio, completed race/cup, online, affected
+Adreno, or final physical-device acceptance test. No emulator FPS is presented
+as a phone performance result.
+
+## Files and source
+
+The application source is merged commit
+`6a2dffc30f8f0d55a7eb928c614c88e054240d14`, whose tree matches the reviewed and
+runtime-tested premerge commit `8336948b88641e75e2a3434ea173de942eb866f7`.
+Keep the APK, companion notices and checksums together. The private AAB is not a
+release download. Packaging documentation revisions are recorded separately in
+the companion provenance.
+
+The APK contains compiled translated game logic and allowlisted runtime
+resources, not a disc image, extracted game assets, Retro pack, saves, private
+logs or signing material. The repository source snapshot and pinned build
+instructions are provided separately from private game inputs. Notices and a
+repository snapshot alone do not certify complete Corresponding Source; retain
+the project's documented rights and source-distribution obligations.
+
+## Short owner acceptance test
+
+After a matching-signer update, retain 2x/Fill and existing saves. Open Original,
+select Single Player and a Grand Prix, then drive through the countdown and a
+lap. Repeat in Retro. Check audio, steering, Home/resume, the refreshed chooser,
+and retained licenses after reopening. Report whether menu motion is smoother,
+whether transitions still pause, and whether there is any new rendering or
+save regression. Do not change multiple settings during the comparison.

--- a/scripts/package-android-release-notices.py
+++ b/scripts/package-android-release-notices.py
@@ -11,15 +11,15 @@ import re
 import subprocess
 import zipfile
 
-TAG = "v0.4.13-android-preview.1"
-VERSION = "0.4.13-android-preview.1"
-CODE = 28
+TAG = "v0.4.14-android-preview.1"
+VERSION = "0.4.14-android-preview.1"
+CODE = 63
 # Exact candidate; changing notes must not relabel its compiled source as HEAD.
-APPROVED_SOURCE = "cecd69c504f66aa0d8a40f485406618b9b616791"
-APPROVED_APK = "e70ff84fb64ce52294ac13608530bdbed3e22395e5fab7a8ef85799c22de0607"
-APPROVED_AAB = "bb1143228a476c89be78eb55187ac855dae133c435b0ff24f58543e5f1f36855"
+APPROVED_SOURCE = "6a2dffc30f8f0d55a7eb928c614c88e054240d14"
+APPROVED_APK = "4e27897b9bb89e7b24fbe0b2e3dc66fae4efd549edaadf2f748ca22f376d87ff"
+APPROVED_AAB = "7d49f7dd7706b1b1f89fbaa4933f7ae4ac4a79c42ab96c567023b5646238f273"
 APPROVED_NATIVE = {
-    "lib/arm64-v8a/libmain.so": "be6833ba835fe5bbd0a93664bcaef50e7387a41b4834b26a8603a132eeca6029",
+    "lib/arm64-v8a/libmain.so": "1502c10b591809d3117b1e057d2273b53ec81fe76bf87d06d31dd1114286cf42",
     "lib/arm64-v8a/libkartpad_discio.so": "0e5bd27501b1aee71db63364f0673682e0cca3c0234d560d4c54ac87e01c0d0b",
     "lib/arm64-v8a/libSDL3.so": "d7a17c375adcb71818210581b885f59832d5f95b663aa7a7d493484a00a94753",
     "lib/arm64-v8a/libc++_shared.so": "c4c2fe5cbcb1fba0003a31fc7ab29a9bb12df6cc187ec45a806462540e83d93b",
@@ -115,7 +115,7 @@ def main() -> None:
     # A later release tag may include notes and this packager, not changed app code.
     changed = subprocess.check_output(["git", "diff", "--name-only", APPROVED_SOURCE, commit],
                                       cwd=REPO, text=True).splitlines()
-    if any(not name.startswith("docs/") and name != "scripts/package-android-release-notices.py"
+    if any(not name.startswith("docs/") and name not in ("README.md", "scripts/package-android-release-notices.py")
            for name in changed):
         parser.error("packaging source differs from candidate beyond documentation/packager")
     provenance = {
@@ -129,7 +129,7 @@ def main() -> None:
         "containsPrivateSigningMaterial": False, "maintainerAuthorizedFreeCommunityRelease": True,
         "upstreamRightsConfirmed": False, "profileableByShell": False, "debuggable": False,
         "physicalAcceptance": "Pending for this exact APK; earlier owner runs do not establish acceptance",
-        "emulatorAcceptance": "API 36 ARM64: actual public-signer fresh install/chooser, default validation off, incomplete-data guard, disc-picker cancellation, seeded Original intro rendering >=1201 frames; same-AAB alternate-signer diagnostics export. No positive full-disc import, sustained performance, Retro real-save or online-race acceptance claimed",
+        "emulatorAcceptance": "API 36 ARM64 software GPU, audio disabled: premerge release candidate with identical game payload passed public28 update preserving19 fixture files; Original and Retro race startup, acceleration/steering and Home return; Original report return and live resize; Retro fixture license reloaded after restart. Final merged-source APK update preserved25 fixture files. No completed race/cup, full import, audio, online, physical performance or affected-Adreno acceptance claimed",
         "noticesSHA256": {n: sha(b) for n, b in sorted(data.items())},
     }
     data["PROVENANCE.json"] = (json.dumps(provenance, indent=2, sort_keys=True) + "\n").encode()


### PR DESCRIPTION
Records the unpublished Android 0.4.14 preview candidate (code 63), its exact merged application source, final artifact fingerprints, completed packaging checks, and bounded emulator/performance evidence. Published download links remain unchanged.

Updates the strict notices packager to the reviewed candidate hashes; README.md is the only additional metadata path permitted. Includes a gated, unposted X draft. Physical release-configuration acceptance, required source-distribution completeness assessment, and the owner publication decision remain outstanding.

Validation: independent Astra Medium review of 37ce92d found no blocker; coordinator reviewed documentation-only c1b3fc5, ran git diff --check, and independently verified both distribution files against SHA256SUMS. Android owner reports unchanged audits passing and repeated APK derivation byte-identical. No new device or broad gameplay acceptance is claimed.
