### PR TITLE
Align strict macOS app audit with 0.4.15

### DIFF
--- a/scripts/audit-macos-package.sh
+++ b/scripts/audit-macos-package.sh
@@ -22,8 +22,8 @@ icon_name="$(plutil -extract CFBundleIconFile raw "${plist}")"
 executable="${contents}/MacOS/${executable_name}"
 
 test "${bundle_identifier}" = "dev.kartpad.app"
-test "$(plutil -extract CFBundleShortVersionString raw "${plist}")" = "0.4.11"
-test "$(plutil -extract CFBundleVersion raw "${plist}")" = "26"
+test "$(plutil -extract CFBundleShortVersionString raw "${plist}")" = "0.4.15"
+test "$(plutil -extract CFBundleVersion raw "${plist}")" = "34"
 test "$(plutil -extract NSBluetoothAlwaysUsageDescription raw "${plist}")" = \
   "KartPad uses Bluetooth to pair and connect an experimental Wii Remote and Nunchuk."
 test -x "${executable}"


### PR DESCRIPTION
The strict macOS app audit still required 0.4.11/build 26 after the release metadata update, which rejected the new package. Update its two expected values to 0.4.15/build 34. The actual rebuilt app now passes the full package and signature audit; no runtime changes.
