### PR TITLE
Release Android 0.4.16 with Retro Rewind 6.12.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ chooser, game-data management, packaging, and release workflows.
   <img alt="Ahead-of-time static recompilation" src="https://img.shields.io/badge/PowerPC-static%20recompilation-FF9F0A">
   <img alt="macOS development target" src="https://img.shields.io/badge/macOS%20target-14%2B-0A84FF">
   <img alt="iPhone and iPad 0.4.14" src="https://img.shields.io/badge/iPhone%20%2F%20iPad-0.4.14-0A84FF">
-  <img alt="Retro Rewind supported" src="https://img.shields.io/badge/Retro%20Rewind-6.12.7-FF375F">
+  <img alt="Retro Rewind supported" src="https://img.shields.io/badge/Retro%20Rewind-6.12.8-FF375F">
   <img alt="Game data not included" src="https://img.shields.io/badge/game%20data-not%20included-FF453A">
 </p>
 
@@ -44,19 +44,24 @@ chooser, game-data management, packaging, and release workflows.
 
 | Platform | Download | Setup |
 | --- | --- | --- |
-| Android ARM64 | [0.4.14 preview 1 · code 63](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.14-android-preview.1) | [Android 9+ with Vulkan](docs/INSTALL_ANDROID.md) |
+| Android ARM64 | [0.4.16 Android 2 · code 65](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.16-android.2) | [Android 9+ with Vulkan](docs/INSTALL_ANDROID.md) |
 | iPhone / iPad | [0.4.15 · build 34](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.15-ios.1) | [iOS/iPadOS 16+; re-sign the IPA](docs/INSTALL_IPA.md) |
 | Apple Silicon Mac | [0.4.15 · build 34](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.15-macos.1) | [macOS 14+](docs/INSTALL_MACOS.md) |
 | Apple TV experimental preview | [0.4.11 · build 9](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.11-tvos.1) | [tvOS 17+; re-sign the IPA](docs/INSTALL_TVOS.md) |
 
-**Android 0.4.14 is now available.** It adds the refreshed game chooser,
+**Android 0.4.16 Android 2 is now available.** It refreshes the translated
+Retro Rewind 6.12.8 graph and retains the console-serial correction required by
+Retro WFC profiles. Physical Pixel 9 Pro XL acceptance confirmed launch,
+touch controls, Retro WFC login and worldwide lobby entry. Frame drops and
+stutter during online connection and gameplay remain known issues; sustained
+60 FPS is not claimed. It adds the refreshed game chooser,
 reviewed-log reporting, Retro pack-update save protection and native rendering
 improvements. Local Pixel 9 Pro XL tests at 2x/Fill measured about **58 FPS versus
 40–50 FPS** in the warm Grand Prix menu with the change enabled versus disabled;
 race gains were smaller. The owner accepted the final payload on hardware.
 These local mode comparisons are not an across-device or old-public-versus-new-public
 benchmark. Menu delays and device-specific graphics issues remain open. See the
-[measurements and release notes](docs/releases/v0.4.14-android-preview.1.md).
+[measurements and release notes](docs/releases/v0.4.16-android.2.md).
 
 **iPhone/iPad 0.4.15** adds an actual log-review screen, an unchecked acknowledgment
 and an explanation when logs cannot be attached. It retains the newer chooser
@@ -75,7 +80,7 @@ Private Android previews use a different signer and need a backed-up migration.
 [Frequently asked questions](#frequently-asked-questions) · [Controls](docs/MULTIPLAYER.md) · [Save transfer and troubleshooting](docs/SUPPORT.md)
 
 - Choose **Mario Kart Wii** or **Retro Rewind** when KartPad opens. Retro
-  Rewind 6.12.7 content installs separately; KartPad requires a matching native
+  Rewind 6.12.8 content installs separately; KartPad requires a matching native
   profile when the mod updates. Follow your platform's setup guide above.
 - Touch controls, motion steering and controllers are available on mobile;
   Mac also supports keyboard input. Touch layouts can be moved, resized and
@@ -87,7 +92,9 @@ Private Android previews use a different signer and need a backed-up migration.
   [support guide](docs/SUPPORT.md) and [known issues](docs/KNOWN-ISSUES.md).
 
 Android Original gameplay with a Razer Kishi was accepted on Pixel 9 Pro XL;
-Retro WFC login, worldwide matchmaking and live racing were owner-reported.
+the current Android release adds owner-confirmed Retro WFC login and worldwide
+lobby entry on that device. Frame drops, stutter, complete results and reconnect
+remain open.
 The iPad release candidate has owner-accepted controller gameplay and menu
 checks. These results do not establish every device, complete online results or
 reconnect behavior. Native private-room hosting and Wiimmfi support for
@@ -116,14 +123,19 @@ Android has a playable ARM64/Vulkan APK for Android 9+, plus an explicitly unsta
 <details>
 <summary>Does online multiplayer work?</summary>
 
-The owner reported Retro WFC login, matchmaking and live racing on Android. Separate isolated-server tests covered race results and lobby return. Those results do not establish complete production online behavior on every platform or preview. Native room hosting and Original Wiimmfi compatibility remain unfinished; entering a server address does not implement them. See [online status](docs/ONLINE.md) and [friend-room guidance](docs/MULTIPLAYER.md#private-friend-rooms).
+The owner confirmed Retro WFC login and worldwide lobby entry on the current
+Android build. Separate isolated-server tests covered race results and lobby
+return, but complete production online behavior, reconnect and every device are
+not established. Native room hosting and Original Wiimmfi compatibility remain
+unfinished; entering a server address does not implement them. See [online
+status](docs/ONLINE.md) and [friend-room guidance](docs/MULTIPLAYER.md#private-friend-rooms).
 
 </details>
 
 <details>
 <summary>Does KartPad support Retro Rewind, and what if it updates?</summary>
 
-Yes, with the separately installed **6.12.7** content and matching compiled profile. A newer Retro pack can require a new KartPad build; replacing files alone does not update translated game code. Apple checks the version before launch; Android checks the official version during installation and validates installed content at launch. Follow your [platform setup guide](#downloads) if a compatibility update is requested.
+Yes, with the separately installed **6.12.8** content and matching compiled profile. A newer Retro pack can require a new KartPad build; replacing files alone does not update translated game code. Apple checks the version before launch; Android checks the official version during installation and validates installed content at launch. Follow your [platform setup guide](#downloads) if a compatibility update is requested.
 
 </details>
 

--- a/android/README.md
+++ b/android/README.md
@@ -1,14 +1,13 @@
 # KartPad Android
 
-Android is now a supported community platform. The first release is
-[`v0.4.10-android.1`](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.10-android.1),
-based on the physically tested Preview 15 runtime: Original gameplay with
-Razer Kishi, automatic touch hiding, and owner-reported Retro Rewind 6.12.7
-Retro WFC worldwide race play on Pixel 9 Pro XL. Read
+Android is now a supported community platform. The current release is
+[`v0.4.16-android.2`](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.16-android.2),
+based on the physically tested 6.12.8 runtime: Original gameplay with touch
+controls and owner-confirmed Retro WFC login/lobby entry on Pixel 9 Pro XL. Read
 [installation, update safety and known limits](../docs/INSTALL_ANDROID.md).
 Sustained 60 FPS and complete device/controller coverage are not claimed.
 
-[Android 0.4.14 preview 1](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.14-android-preview.1)
+[Android 0.4.16 Android 2](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.16-android.2)
 is the current owner-accepted community update. Its refreshed chooser, reporting,
 Retro save protection and rendering changes have bounded measurements and tests
 in the release notes. The source archive and
@@ -25,7 +24,7 @@ private translated graph; the installed app's size is not the build-space cost.
 ```sh
 git clone https://github.com/chrissotraidis/kartpad.git
 cd kartpad
-git checkout v0.4.14-android-preview.1
+git checkout v0.4.16-android.2
 ./scripts/build-user-ipa.sh bootstrap
 ./scripts/bootstrap-android-host.sh
 ./scripts/check-android-host.sh
@@ -37,7 +36,7 @@ accepts SDK licenses or edits unrelated shell/system configuration. If a license
 is pending, review and accept it yourself before continuing.
 
 Translate **only your own supported RMCP01 revision 0 image**. The shared
-bootstrap prepares the following pinned Retro 6.12.7 input paths:
+bootstrap prepares the following pinned Retro 6.12.8 input paths:
 
 ```sh
 mkdir -p private/self-build/retro-rewind/translation/build_shards
@@ -45,16 +44,16 @@ cp tools/android63-base-common-shards.json \
   private/self-build/retro-rewind/translation/build_shards/base_common_shard_map.json
 ./scripts/translate-retro-rewind.sh \
   --image /absolute/path/to/your-owned-game.wbfs \
-  --retro-root private/builder/retro-rewind-downloads/6.12.7-extracted/RetroRewind6 \
+  --retro-root private/builder/retro-rewind-downloads/6.12.8-extracted/RetroRewind6 \
   --payload private/builder/retro-rewind-downloads/payload.RMCPD00.bin
 
-KARTPAD_ANDROID_VERSION_NAME=0.4.14-android-preview.1 \
-KARTPAD_ANDROID_VERSION_CODE=63 \
+KARTPAD_ANDROID_VERSION_NAME=0.4.16-android.2 \
+KARTPAD_ANDROID_VERSION_CODE=65 \
 KARTPAD_ANDROID_PACKAGE_FORMAT=aab \
   ./scripts/build-android-game-app.sh private/self-build/retro-rewind/translation
 
-KARTPAD_ANDROID_EXPECTED_VERSION_NAME=0.4.14-android-preview.1 \
-KARTPAD_ANDROID_EXPECTED_VERSION_CODE=63 \
+KARTPAD_ANDROID_EXPECTED_VERSION_NAME=0.4.16-android.2 \
+KARTPAD_ANDROID_EXPECTED_VERSION_CODE=65 \
   ./scripts/audit-android-bundle.sh android/app/build/outputs/bundle/release/app-release.aab
 ```
 
@@ -67,7 +66,7 @@ patches: the wrapper reuses an existing prepared source directory.
 For a locally installable debug-signed APK, use the same build command with
 `KARTPAD_ANDROID_PACKAGE_FORMAT=apk`; it writes
 `android/app/build/outputs/apk/debug/app-debug.apk`. Audit it with
-`KARTPAD_ANDROID_EXPECTED_VERSION_NAME=0.4.14-android-preview.1 ./scripts/audit-android-package.sh PATH.apk`.
+`KARTPAD_ANDROID_EXPECTED_VERSION_NAME=0.4.16-android.2 ./scripts/audit-android-package.sh PATH.apk`.
 That debug build is for personal testing, not public distribution, and cannot
 update a differently signed public app. A source-only fixture is not the game.
 
@@ -79,14 +78,14 @@ Keep signing keys backed up securely outside Git: future in-place updates need
 the same key. The unsigned AAB stays local; this is not a Google Play release.
 
 ```sh
-KARTPAD_ANDROID_EXPECTED_VERSION_NAME=0.4.14-android-preview.1 \
-KARTPAD_ANDROID_EXPECTED_VERSION_CODE=63 \
+KARTPAD_ANDROID_EXPECTED_VERSION_NAME=0.4.16-android.2 \
+KARTPAD_ANDROID_EXPECTED_VERSION_CODE=65 \
 KARTPAD_ANDROID_KEYSTORE=/absolute/private/path/kartpad-release.p12 \
 KARTPAD_ANDROID_KEY_ALIAS=kartpad-release \
 KARTPAD_ANDROID_PASSWORD_FILE=/absolute/private/path/password.txt \
   ./scripts/derive-android-release-apk.sh \
     android/app/build/outputs/bundle/release/app-release.aab \
-    artifacts/KartPad-v0.4.14-android-preview.1-arm64.apk
+    artifacts/KartPad-v0.4.16-android.2-arm64.apk
 ```
 
 The keystore and key must use the same password for this simple PKCS12 flow.

--- a/android/app/src/main/java/dev/kartpad/android/RetroRewindRelease.java
+++ b/android/app/src/main/java/dev/kartpad/android/RetroRewindRelease.java
@@ -4,20 +4,20 @@ package dev.kartpad.android;
 final class RetroRewindRelease {
     private RetroRewindRelease() {}
 
-    static final String VERSION = "6.12.7";
+    static final String VERSION = "6.12.8";
     static final String VERSION_MANIFEST_URL = "https://update.rwfc.net/RetroRewind/RetroRewindVersion.txt";
     static final String ROOT = "RetroRewind6";
-    static final String ARCHIVE_URL = "https://cdn.update.rwfc.net/RetroRewind/zip/6.12.7-full.zip";
-    static final String ARCHIVE_SHA256 = "ade59f3ae217944bd7c3535b3bae79d5aa7b521ba00c581a16c7c2e3ce54c349";
+    static final String ARCHIVE_URL = "https://cdn.update.rwfc.net/RetroRewind/zip/6.12.8-full.zip";
+    static final String ARCHIVE_SHA256 = "9dc9f689b2d1bc03f7b9f49e9013f31d2ab31e9b800aa2da1f6badbd2ecf21dc";
     static final String CODE_PUL_PATH = "Binaries/Code.pul";
-    static final String CODE_PUL_SHA256 = "3a1e60f6c94e435ff672167816dbe040d0f48874bfa093ada39e468655baef72";
+    static final String CODE_PUL_SHA256 = "88cd25ff08121f7c4ddb40538703f40c270f414f2dbc55a6b4b6767e62db7253";
     static final String XML_PATH = "xml/RetroRewind6.xml";
     static final String XML_SHA256 = "faf88234f81e16a85403d2a86d25e2ef4b261aedb553a312b532e60a11b28200";
     static final String PAYLOAD_URL = "http://nas.play.rwfc.net/payload?g=RMCPD00";
     static final String PAYLOAD_SHA256 = "fd8f26d6af26f1a0cfaecd1e472fe744a25d75f5136910533b7c75e3eca2f1d2";
-    static final long ARCHIVE_BYTES = 1859041688L;
+    static final long ARCHIVE_BYTES = 1859035109L;
     static final long MAXIMUM_EXPANDED_BYTES = 2200000000L;
-    static final long CODE_PUL_BYTES = 1723048L;
+    static final long CODE_PUL_BYTES = 1704868L;
     static final long XML_BYTES = 21047L;
     static final long PAYLOAD_BYTES = 28968L;
 }

--- a/builder/profiles/mkwii-rmcp01-rev0.json
+++ b/builder/profiles/mkwii-rmcp01-rev0.json
@@ -68,19 +68,19 @@
     "expectedRetroFunctions": 4188
   },
   "retroRewind": {
-    "version": "6.12.7",
+    "version": "6.12.8",
     "versionManifestUrl": "https://update.rwfc.net/RetroRewind/RetroRewindVersion.txt",
     "root": "RetroRewind6",
     "archive": {
-      "url": "https://cdn.update.rwfc.net/RetroRewind/zip/6.12.7-full.zip",
-      "bytes": 1859041688,
-      "sha256": "ade59f3ae217944bd7c3535b3bae79d5aa7b521ba00c581a16c7c2e3ce54c349",
+      "url": "https://cdn.update.rwfc.net/RetroRewind/zip/6.12.8-full.zip",
+      "bytes": 1859035109,
+      "sha256": "9dc9f689b2d1bc03f7b9f49e9013f31d2ab31e9b800aa2da1f6badbd2ecf21dc",
       "maximumExpandedBytes": 2200000000
     },
     "codePul": {
       "path": "Binaries/Code.pul",
-      "bytes": 1723048,
-      "sha256": "3a1e60f6c94e435ff672167816dbe040d0f48874bfa093ada39e468655baef72"
+      "bytes": 1704868,
+      "sha256": "88cd25ff08121f7c4ddb40538703f40c270f414f2dbc55a6b4b6767e62db7253"
     },
     "riivolutionXml": {
       "path": "xml/RetroRewind6.xml",

--- a/docs/INSTALL_ANDROID.md
+++ b/docs/INSTALL_ANDROID.md
@@ -2,19 +2,20 @@
 
 ## Current update
 
-[**0.4.14 preview 1 / code 63**](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.14-android-preview.1)
-is the current owner-accepted Android community update. It adds the refreshed
-chooser, reviewed-log reporting, Retro pack-update save protection and native
-frame overlap. It retains checked rating transfer and the public signing identity.
-See the [measured improvements and remaining limits](releases/v0.4.14-android-preview.1.md).
+[**0.4.16 Android 2 / code 65**](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.16-android.2)
+is the current owner-accepted Android community update. It refreshes the
+translated Retro Rewind 6.12.8 graph and retains the numeric console-serial
+correction. Physical Pixel 9 Pro XL testing confirmed launch, touch controls,
+Retro WFC login and worldwide lobby entry. See the
+[release notes](releases/v0.4.16-android.2.md).
 Menu transitions, graphics corruption on some GPUs, online stalls and cup crashes
 are not declared resolved. Download the APK, notices and checksums; the source
 archive is available for rebuilding and modification.
 
 ## Download and first launch
 
-1. Open the [current Android release](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.14-android-preview.1).
-   Download `KartPad-v0.4.14-android-preview.1-arm64.apk`, `SHA256SUMS`, and the companion
+1. Open the [current Android release](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.16-android.2).
+   Download `KartPad-v0.4.16-android.2-arm64.apk`, `SHA256SUMS`, and the companion
    notices ZIP. APK is Android's installable format; IPA is Apple-only. The AAB
    is a developer bundle and is not needed for installation (it is not published).
 2. Use an ARM64 phone/tablet with Vulkan and Android 9/API 28 or newer. The
@@ -31,7 +32,7 @@ archive is available for rebuilding and modification.
    not sufficient: the exact profile's identity checks must pass. Keep the
    original image backed up; neither the APK nor this repository supplies it.
 5. Choose Retro Rewind to download, verify and install the separately hosted
-   official **6.12.7** pack. Use matching current content; if KartPad reports a
+   official **6.12.8** pack. Use matching current content; if KartPad reports a
    newer incompatible profile, wait for a matching KartPad update. Never bypass
    the checks or replace executable files manually.
 
@@ -52,7 +53,8 @@ Never uninstall or clear storage as an update step.
 debug certificate. Android will reject the public release as an in-place update
 over those previews. Do not uninstall to force it through: preserve the working
 preview and its app data, and plan a deliberate backed-up migration separately.
-The first public package is code 21; the testing preview is code 28.
+The first public package was code 21; the testing preview was code 28. The
+current public package is code 65.
 Changing a package signature is not a save migration.
 Self-built APKs similarly cannot update public builds unless the signer matches.
 
@@ -81,8 +83,9 @@ performance permits. Original 4:3 is the conservative aspect setting; widescreen
 and Fill Screen remain experimental. Pixel play at 3x was accepted, but the
 initial pipeline-compilation queue can cause pronounced hitches, and warm or
 track-dependent slowdown remains. This release does not promise sustained 60 FPS.
-Retro WFC login, worldwide matchmaking and live race play were owner-reported;
-complete results, reconnect and network-transition coverage remain open.
+Retro WFC login and worldwide lobby entry were accepted on the exact tested
+device. Complete results, reconnect and network-transition coverage remain open;
+frame drops and stutter remain known performance issues.
 
 ## Save location and PC transfer
 

--- a/docs/ONLINE.md
+++ b/docs/ONLINE.md
@@ -35,6 +35,14 @@ reverse existing service bans. Affected histories require service-admin review,
 not save deletion or identity regeneration. See the
 [backport evidence](iterations/issue94-csnum-hotfix.md).
 
+The 6.12.8 Android candidate was also checked against the recovered production
+service. A preserved profile first authenticated with the last working legacy
+serial behavior on the same network; the corrected numeric build then logged in
+and reached the worldwide lobby without clearing app data. This validates the
+profile migration path, not every historical account: a 22005 response still
+indicates a server-side CSNum/profile mismatch and may require service-admin
+reconciliation. The tested device continued to show frame drops and stutter.
+
 ## Historical production Retro WFC boundary on 6 September 2026
 
 Retro WFC's public health endpoint and room feed are reachable again and report

--- a/docs/releases/v0.4.16-android.2.md
+++ b/docs/releases/v0.4.16-android.2.md
@@ -26,3 +26,8 @@ issue #94. It is the Android companion to the current 6.12.8 release line.
 The APK contains translated game logic but no game image, extracted game
 assets, saves, signing material, or console identifiers. Install it in place
 over the same public signer; do not uninstall or clear app data.
+
+## Published artifact
+
+- `KartPad-v0.4.16-android.2-arm64.apk`: 110,192,025 bytes
+- SHA-256: `91d40a4ce9eb6b688e62c2c7fe76978697f89b5d048ca0daa223aa28bff323db`

--- a/docs/releases/v0.4.16-android.2.md
+++ b/docs/releases/v0.4.16-android.2.md
@@ -1,0 +1,28 @@
+# KartPad v0.4.16 Android 2
+
+This Android release refreshes the translated Retro Rewind profile to the
+official 6.12.8 pack and retains the numeric console-serial correction from
+issue #94. It is the Android companion to the current 6.12.8 release line.
+
+## Acceptance
+
+- Physical Pixel 9 Pro XL: launch, touch controls, Original launch, and Retro
+  Rewind launch were confirmed.
+- Retro WFC: login succeeded and the worldwide lobby was reached after the
+  preserved legacy-profile migration path. No app data, save, or identity was
+  cleared or regenerated.
+- Performance: frame drops and stutter remain present during online connection
+  and gameplay. Sustained 60 FPS, complete race results, reconnect, and
+  network-transition behavior are not claimed by this release.
+
+## Retro Rewind inputs
+
+- Version: `6.12.8`
+- `Binaries/Code.pul`: 1,704,868 bytes,
+  SHA-256 `88cd25ff08121f7c4ddb40538703f40c270f414f2dbc55a6b4b6767e62db7253`
+- Pinned WFC payload: 28,968 bytes,
+  SHA-256 `fd8f26d6af26f1a0cfaecd1e472fe744a25d75f5136910533b7c75e3eca2f1d2`
+
+The APK contains translated game logic but no game image, extracted game
+assets, saves, signing material, or console identifiers. Install it in place
+over the same public signer; do not uninstall or clear app data.

--- a/scripts/build-android-game-app.sh
+++ b/scripts/build-android-game-app.sh
@@ -65,6 +65,12 @@ if [[ ! -d "$runtime_source" ]]; then
   "$repo_root/scripts/prepare-android-game-runtime.sh" \
     "$translation_root" "$runtime_source" "$runtime_build" "$runtime_product"
 fi
+if [[ ! -f "$runtime_source/include/sc_serial_contract.h" ||
+      ! -f "$runtime_source/src/hle/sc.cpp" ]] ||
+   ! grep -Fq 'RuntimeScSerial::Write' "$runtime_source/src/hle/sc.cpp"; then
+  echo "ERROR: prepared runtime is missing the numeric console-serial ABI guard; use a fresh runtime source" >&2
+  exit 1
+fi
 if [[ ! -f "$(dirname "$runtime_source")/generated/data_sections_init.cpp" ]]; then
   echo "ERROR: prepared runtime is not paired with its ignored generated graph" >&2
   exit 1


### PR DESCRIPTION
# KartPad v0.4.16 Android 2

This Android release refreshes the translated Retro Rewind profile to the
official 6.12.8 pack and retains the numeric console-serial correction from
issue #94. It is the Android companion to the current 6.12.8 release line.

## Acceptance

- Physical Pixel 9 Pro XL: launch, touch controls, Original launch, and Retro
  Rewind launch were confirmed.
- Retro WFC: login succeeded and the worldwide lobby was reached after the
  preserved legacy-profile migration path. No app data, save, or identity was
  cleared or regenerated.
- Performance: frame drops and stutter remain present during online connection
  and gameplay. Sustained 60 FPS, complete race results, reconnect, and
  network-transition behavior are not claimed by this release.

## Retro Rewind inputs

- Version: `6.12.8`
- `Binaries/Code.pul`: 1,704,868 bytes,
  SHA-256 `88cd25ff08121f7c4ddb40538703f40c270f414f2dbc55a6b4b6767e62db7253`
- Pinned WFC payload: 28,968 bytes,
  SHA-256 `fd8f26d6af26f1a0cfaecd1e472fe744a25d75f5136910533b7c75e3eca2f1d2`

The APK contains translated game logic but no game image, extracted game
assets, saves, signing material, or console identifiers. Install it in place
over the same public signer; do not uninstall or clear app data.

## Published artifact

- `KartPad-v0.4.16-android.2-arm64.apk`: 110,192,025 bytes
- SHA-256: `91d40a4ce9eb6b688e62c2c7fe76978697f89b5d048ca0daa223aa28bff323db`
