### PR TITLE
Keep hourly maintenance on the continuing coordinator task

### DIFF
--- a/docs/MAINTENANCE-AUTOMATION.md
+++ b/docs/MAINTENANCE-AUTOMATION.md
@@ -11,12 +11,13 @@ Those documents must link to the board for current ownership/build/test state.
 
 ## Operating plan
 
-- One local hourly cron for this project. Secondary Luna Medium
-  (`secondary/gpt-5.6-luna`, medium reasoning) handles intake, classification,
-  public replies, prioritization and records. Its explicit automation
-  configuration is authoritative; a run-start check must stop work if the
-  actual route is not secondary Luna at medium/high. It does not substitute
-  for engineering.
+- One hourly heartbeat attached to the continuing coordinator task, preserving
+  its goal, context and ownership. Do not create a fresh project task each wake.
+  Secondary Luna Medium (`secondary/gpt-5.6-luna`, medium reasoning) handles
+  intake, classification, public replies, prioritization and records. Set the
+  target task's model explicitly: the heartbeat inherits it. A run-start check
+  must stop work if the actual route is not secondary Luna at medium/high.
+  Scheduling and model routing remain separate checks.
 - When fresh support evidence exists, one secondary Luna Medium intake worker
   (secondary Sol Medium if Luna is not callable) reconciles it and drafts replies.
   Otherwise no intake worker. The coordinator reviews/posts using shared receipts
@@ -42,7 +43,9 @@ Those documents must link to the board for current ownership/build/test state.
   as #184 may proceed while stability work is externally blocked; keep a clear
   scope and do not displace a ready high-severity regression.
 
-The former schedules were replaced by the single explicit secondary-Luna cron on 12 September.
+On 12 September the single hourly schedule was attached to the existing
+coordinator as a heartbeat. Secondary Luna Medium is set on the target task;
+the scheduler resumes that task rather than starting standalone coordinator runs.
 The replacement uses this versioned runbook and tested local action receipts;
 creating another independent hardware/reply loop would duplicate ownership.
 Activation and the first run are recorded in the dated

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -198,10 +198,14 @@ reasoning by default; high is reserved for unusually ambiguous issue intake.
 Luna owns GitHub replies, family assignment, prioritization, documentation and
 loop state.
 
-The active `kartpad-coordinated-maintenance` automation is a local hourly cron
-with explicit `model = secondary/gpt-5.6-luna`, `reasoning_effort = medium`,
-and the KartPad project target. It is not a heartbeat with implicit model
-inheritance. A run-start identity check remains required as an execution guard.
+The active `kartpad-coordinated-maintenance` automation is an hourly heartbeat
+attached to the continuing KartPad coordinator task. Each wake resumes that task's
+goal, context and ownership; do not replace it with standalone project runs.
+The heartbeat inherits the target task's model, so keep that task on
+`secondary/gpt-5.6-luna` with medium reasoning. The heartbeat configuration alone
+does not prove model routing; verify the actual execution identity at every wake.
+Retain an unfinished goal and continue its next executable gate. A dependency
+checkpoint is not completion of a goal to fix the affected product path.
 
 At the start of every scheduled run, record the actual model, reasoning level
 and account route in the local cycle artifact. If the run is not actually on

--- a/docs/SUPPORT-AGENTS.md
+++ b/docs/SUPPORT-AGENTS.md
@@ -24,6 +24,10 @@ evidence; they do not replace current issue comments or assign recurring work.
 
 ## Work each wake
 
+The hourly heartbeat resumes the same coordinator task and its goal. Keep its
+model set to secondary Luna Medium and verify the execution route at wakeup;
+do not start another coordinator or discard an unfinished goal.
+
 1. Check the existing coordinator claim, workers, worktrees and actual processes.
    Retain live owners. Read the hub and current priorities, then run the selector:
 


### PR DESCRIPTION
The hourly maintenance schedule previously targeted standalone project runs. It now resumes the existing continuing maintenance task, preserving its goal, context and ownership. Update the operating docs to match the verified heartbeat target and prevent a future coordinator from recreating the old cron arrangement.

The target task is set to secondary Luna Medium. The heartbeat inherits that task's model, so actual routing must still be checked at each wake; the schedule configuration alone does not prove routing. Preserve unfinished goals and do not count dependency checkpoints as completed product fixes.

Validation: the existing automation was updated in place and its persisted ACTIVE/hourly heartbeat target was verified. All 61 focused maintenance tests and whitespace checks passed. This PR changes three operating documents only; no runtime, build or release files change.
