### PR TITLE
Stop repeating obsolete Android network test plan

### DIFF
--- a/docs/artifacts/2026-09-12/maintenance-selector-issue123.md
+++ b/docs/artifacts/2026-09-12/maintenance-selector-issue123.md
@@ -1,0 +1,21 @@
+# Maintenance selector correction for Android issue #123
+
+The hourly selector previously assigned issue #123 to
+`scripts/test-android-network-receive-window.sh`. That was stale work: the
+Android-only 500 ms receive-window candidate reached the Retro WFC dashboard,
+then still disconnected before a Retro VS race. Its host contract can pass
+without changing the unresolved lobby-to-race boundary.
+
+The selector now reports #123 as externally blocked and points only to the
+fresh-source trace and physical Retro VS session gate recorded in
+`EXTERNAL_NEXT_ACTIONS`. It no longer returns an executable local test plan for
+the obsolete receive-window candidate.
+
+Validation:
+
+- `python3 -B -m unittest -v tests.test_maintenance_loop.PriorityExecutionTests.test_issue123_does_not_repeat_obsolete_receive_window_plan`
+- `python3 -B -m unittest -v tests.test_maintenance_loop`
+
+This is a maintenance-process correction, not an Android network fix. The
+issue remains open until a fresh trace attributes the lobby-to-race transition
+and the same candidate passes physical WFC race, results, return and re-entry.

--- a/scripts/maintenance-loop.py
+++ b/scripts/maintenance-loop.py
@@ -418,10 +418,13 @@ def score(issue: dict[str, Any], now: dt.datetime) -> tuple[int, list[str]]:
 
 def test_plan(issue_number: int) -> tuple[list[str] | None, str]:
     if issue_number == 123:
-        return (
-            ["scripts/test-android-network-receive-window.sh"],
-            "Android blocking-receive contract for the Pixel online-menu stall candidate; physical WFC race/reconnect acceptance remains required",
-        )
+        # The Android-only 500 ms receive-window candidate reached the WFC
+        # dashboard but still disconnected before a Retro VS race.  Re-running
+        # its host contract cannot change that evidence and made the hourly
+        # selector spend cycles on an externally blocked issue.  Keep #123 in
+        # the queue for the required fresh-source trace and physical session,
+        # but do not present obsolete local work as an executable plan.
+        return None, EXTERNAL_NEXT_ACTIONS[123]
     if issue_number == 200:
         return (
             [

--- a/tests/test_maintenance_loop.py
+++ b/tests/test_maintenance_loop.py
@@ -721,6 +721,13 @@ class MaintenanceLoopTests(unittest.TestCase):
 
 
 class PriorityExecutionTests(unittest.TestCase):
+    def test_issue123_does_not_repeat_obsolete_receive_window_plan(self):
+        plan, purpose = MAINTENANCE_LOOP.test_plan(123)
+
+        self.assertIsNone(plan)
+        self.assertIn("fresh-source", purpose)
+        self.assertIn("physical Retro VS disconnect", purpose)
+
     def test_committed_priority_queue_has_resolvable_checkpoints(self):
         work = MAINTENANCE_LOOP.load_priorities(MAINTENANCE_LOOP.DEFAULT_PRIORITIES)
         self.assertTrue(work)


### PR DESCRIPTION
## Problem
The maintenance selector still assigned issue #123 to the old Android 500 ms receive-window contract. That candidate reached the WFC dashboard but still disconnected before Retro VS, so repeating the host test could not advance the issue.

## Change
- Mark #123 as externally gated in `test_plan()` instead of returning the obsolete receive-window script.
- Preserve the fresh-source trace and physical Retro VS race/re-entry gate as the next action.
- Add a regression test and dated evidence note.

## Validation
- `python3 -B -m unittest -v tests.test_maintenance_loop.PriorityExecutionTests.test_issue123_does_not_repeat_obsolete_receive_window_plan`
- `python3 -B -m unittest -v tests.test_maintenance_loop` (51 passed)

This is a maintenance-process correction; it does not claim an Android network fix or close #123.
