### PR TITLE
Avoid duplicate Android Aurora test stubs

### DIFF
--- a/patches/aurora-first-genmode-write.patch
+++ b/patches/aurora-first-genmode-write.patch
@@ -67,21 +67,3 @@
  TEST_F(GXFifoTest, BpMask_AppliesOnlyToNextWrite) {
    std::vector<u8> bytes;
    auto mask = bp_cmd(0xFE, 1u << 19);
---- a/aurora-main/tests/gx_test_stubs.cpp
-+++ b/aurora-main/tests/gx_test_stubs.cpp
-@@ -25,6 +25,7 @@
- #include <fmt/format.h>
- 
- namespace {
-+aurora::Module Log("gx_test_stubs");
- aurora::Vec2<uint32_t> s_logicalFbSize{640, 480};
- aurora::Vec2<uint32_t> s_renderTargetSize{640, 480};
- uint32_t s_currentFrame = 0;
-@@ -59,6 +60,7 @@
- } // namespace aurora
- 
- namespace aurora::window {
-+SDL_Window* get_sdl_window() { return nullptr; }
- void set_present_surface_fill(bool) {}
- } // namespace aurora::window
- 


### PR DESCRIPTION
Android preparation applies the shared viewport patch before the Android-only first-GEN_MODE patch. Both added the same test logger and SDL window stub, stopping fresh preparation before native compilation.

Keep the shared viewport patch intact for Mac and remove only the duplicate test-stub section from the Android-only patch. Production viewport and GEN_MODE code are unchanged.

Validation: fresh common dual-runtime preparation, clean application of the corrected Android patch, exactly one logger/window stub definition, preserved GEN_MODE initialization, and git diff --check. Parent independently reviewed the 18-line deletion and patch order.
