### PR TITLE
Prepare accepted iOS 0.4.17 build 39 release

### DIFF
--- a/docs/releases/v0.4.17-ios.1-source.md
+++ b/docs/releases/v0.4.17-ios.1-source.md
@@ -1,0 +1,13 @@
+# Source and rebuild information
+
+The IPA's `KartPadBuilderProvenance.json` identifies the packaging commit, original compilation commit, accepted executable SHA-256, prepared-runtime hash and translation hash. `Payload/KartPad.app/kartpad-build.json` is the unchanged original compilation manifest. The packaging script compares the production input paths against that compilation commit before accepting this executable.
+
+KartPad source: https://github.com/chrissotraidis/kartpad
+
+Original compilation source: https://github.com/chrissotraidis/kartpad/tree/cf47944d1a841f60e7e774dd44e44dc99341fd92
+
+Use `docs/BUILDING.md`, `docs/INSTALL_IPA.md` and the builder documentation at the recorded source commit. Restore the pinned references and dependencies, supply your own supported game image, generate the real-title translation, prepare a fresh iOS runtime with `scripts/prepare-ios-game-runtime.sh`, then build with `scripts/build-ios-device-game-app.sh`. The generated function and aggregate-shard REL guards must pass verification before compiling. Required generated translation and game data are not included in this archive.
+
+This is source and rebuild guidance, not a claim that the release archive alone is a complete or independently verified corresponding-source distribution. The original binary was not recompiled for the version-only packaging update. A rebuilt executable will require its own audit and device acceptance rather than passing the build-39 exact-binary gate automatically.
+
+The archive includes KartPad licensing, third-party notices and dependency license texts. See `RIGHTS_AND_LICENSES.md` for the project's rights boundary.

--- a/docs/releases/v0.4.17-ios.1.md
+++ b/docs/releases/v0.4.17-ios.1.md
@@ -1,0 +1,11 @@
+# KartPad 0.4.17 for iPhone and iPad
+
+Build 39 includes the corrected compiled REL-report guard, viewport interpolation changes and Retro Rewind save-preserving updates. The guard is present in the aggregate translation shards used by the executable; the earlier build 36 release did not establish that protection.
+
+The maintainer installed this candidate in place on an iPhone 14 running iOS 26.6.2. Original and Retro saves, Mii data, identity and preferences were preserved, and configuration values remained unchanged. An active race was observed and the owner accepted the requested Original/Retro race-and-relaunch trial. This is not measured performance or online compatibility validation.
+
+Issue #196 remains open for the reported iPhone 17 Pro Max/iOS 27 setup. This release does not claim that matching-device confirmation.
+
+Requires iOS/iPadOS 16 or newer on ARM64. The IPA is unsigned: sign it with your existing compatible identity and install in place to preserve app data. Supply your own supported game image. No game image, saves or signing material are included.
+
+The accepted executable was compiled from `cf47944d1a841f60e7e774dd44e44dc99341fd92`. Packaging verifies that the release source has identical production inputs and retains the original compilation manifest. See `SOURCE_AND_REBUILD.md` inside the archive for the source and rebuild boundary.

--- a/scripts/audit-public-unsigned-ipa.py
+++ b/scripts/audit-public-unsigned-ipa.py
@@ -11,9 +11,9 @@ import zipfile
 from pathlib import Path, PurePosixPath
 
 
-RELEASE_TAG = "v0.4.15-ios.1"
-APP_VERSION = "0.4.15"
-APP_BUILD = "34"
+from ios_release import (
+    RELEASE_TAG, APP_VERSION, APP_BUILD, accepted_build, verify_source_equivalence,
+)
 FORBIDDEN_SUFFIXES = {
     ".iso", ".gcm", ".gcz", ".ciso", ".wbfs", ".wia", ".rvz",
     ".gci", ".sav", ".log", ".mobileprovision", ".p12", ".p8",
@@ -25,6 +25,8 @@ REQUIRED_ENTRIES = {
     "KartPadBuilderProvenance.json",
     "INSTALL_IPA.md",
     "RELEASE_NOTES.md",
+    "SOURCE_AND_REBUILD.md",
+    "Payload/KartPad.app/kartpad-build.json",
     "LICENSES/GPL-3.0.txt",
     "RIGHTS_AND_LICENSES.md",
     "THIRD_PARTY_NOTICES.md",
@@ -56,6 +58,8 @@ def main() -> int:
     expected_commit = args.source_commit or subprocess.check_output(
         ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True
     ).strip()
+
+    verify_source_equivalence(repo, expected_commit)
 
     with zipfile.ZipFile(ipa) as archive:
         bad_member = archive.testzip()
@@ -112,6 +116,9 @@ def main() -> int:
                 if mode and extracted.is_file():
                     extracted.chmod(mode)
             app = root / "Payload/KartPad.app"
+            for key, expected in accepted_build(app).items():
+                if provenance.get(key) != expected:
+                    fail(f"unexpected compilation provenance {key}")
             subprocess.run(
                 [str(repo / "scripts/audit-ios-game-app.sh"), str(app), "IOS"],
                 check=True,

--- a/scripts/ios_release.py
+++ b/scripts/ios_release.py
@@ -1,0 +1,53 @@
+"""Identity and provenance checks for the accepted iOS community release."""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+
+RELEASE_TAG = "v0.4.17-ios.1"
+APP_VERSION = "0.4.17"
+APP_BUILD = "39"
+COMPILED_SOURCE = "cf47944d1a841f60e7e774dd44e44dc99341fd92"
+EXECUTABLE_SHA256 = "4d3035a322538c88f5d9412439fa8d7b471623cc9ef38c5fe637eecdaf077811"
+RUNTIME_SHA256 = "8351179cbf2e3f6a89599448a3109d3a8d880c06bc7717f4362e6a81fda9c1c2"
+TRANSLATION_SHA256 = "f5b67171325d4b98ccee74752268d689952d054f78f001b9083e42507dff8e0b"
+# Compare production inputs, excluding release notes and packaging-only changes.
+PRODUCTION_PATHS = (
+    "apple/ios", "apple/mobile", "apple/shared", "apple/third_party",
+    "runtime", "patches", "builder", "CMakeLists.txt",
+    "scripts/prepare-ios-game-runtime.sh", "scripts/build-ios-device-game-app.sh",
+    "scripts/inject-retro-rel-report-guard.py", "scripts/write-build-provenance.py",
+    "scripts/generate-ios-icon-assets.sh", "scripts/verify-sunpad-overlay-snapshot.sh",
+)
+
+
+def accepted_build(app: Path) -> dict:
+    """Reject stale candidates while retaining the original compilation manifest."""
+    manifest = json.loads((app / "kartpad-build.json").read_text())
+    if manifest.get("source_revision") != COMPILED_SOURCE or manifest.get("source_dirty") is not False:
+        raise ValueError("expected the clean accepted compilation source")
+    if manifest.get("prepared_runtime", {}).get("sha256") != RUNTIME_SHA256:
+        raise ValueError("unexpected prepared runtime hash")
+    if manifest.get("translation", {}).get("sha256") != TRANSLATION_SHA256:
+        raise ValueError("unexpected translation hash")
+    if hashlib.sha256((app / "KartPad").read_bytes()).hexdigest() != EXECUTABLE_SHA256:
+        raise ValueError("expected the hardware-accepted unsigned executable")
+    return {
+        "compiledSourceCommit": COMPILED_SOURCE,
+        "preparedRuntimeSHA256": RUNTIME_SHA256,
+        "translationSHA256": TRANSLATION_SHA256,
+        "compilationManifestSHA256": hashlib.sha256((app / "kartpad-build.json").read_bytes()).hexdigest(),
+        "productionInputPaths": list(PRODUCTION_PATHS),
+        "productionInputsEquivalent": True,
+    }
+
+
+def verify_source_equivalence(repo: Path, packaging_commit: str) -> None:
+    changed = subprocess.check_output(
+        ["git", "-C", str(repo), "diff", "--name-only", COMPILED_SOURCE,
+         packaging_commit, "--", *PRODUCTION_PATHS], text=True,
+    ).strip()
+    if changed:
+        raise ValueError(f"production inputs differ from accepted compilation: {changed}")

--- a/scripts/ios_release.py
+++ b/scripts/ios_release.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from pathlib import Path
 import subprocess
 
@@ -16,10 +17,17 @@ TRANSLATION_SHA256 = "f5b67171325d4b98ccee74752268d689952d054f78f001b9083e42507d
 # Compare production inputs, excluding release notes and packaging-only changes.
 PRODUCTION_PATHS = (
     "apple/ios", "apple/mobile", "apple/shared", "apple/third_party",
-    "runtime", "patches", "builder", "CMakeLists.txt",
+    "runtime", "builder", "CMakeLists.txt",
     "scripts/prepare-ios-game-runtime.sh", "scripts/build-ios-device-game-app.sh",
     "scripts/inject-retro-rel-report-guard.py", "scripts/write-build-provenance.py",
     "scripts/generate-ios-icon-assets.sh", "scripts/verify-sunpad-overlay-snapshot.sh",
+)
+# The preparation script is itself compared, so its patch list must also match.
+PRODUCTION_PATHS += tuple(
+    "patches/" + name for name in sorted(set(re.findall(
+        r"[A-Za-z0-9_-]+\.patch",
+        (Path(__file__).parent / "prepare-ios-game-runtime.sh").read_text(),
+    )))
 )
 
 

--- a/scripts/package-public-unsigned-ipa.py
+++ b/scripts/package-public-unsigned-ipa.py
@@ -8,9 +8,9 @@ import sys
 from pathlib import Path
 
 
-RELEASE_TAG = "v0.4.15-ios.1"
-APP_VERSION = "0.4.15"
-APP_BUILD = "34"
+from ios_release import (
+    RELEASE_TAG, APP_VERSION, APP_BUILD, accepted_build, verify_source_equivalence,
+)
 
 
 def fail(message: str) -> None:
@@ -26,8 +26,10 @@ def main() -> int:
         "output",
         type=Path,
         nargs="?",
-        help="Output IPA path (defaults to artifacts/KartPad-v0.4.15-ios.1-unsigned.ipa)",
+        help="Output IPA path (defaults to artifacts/KartPad-v0.4.17-ios.1-unsigned.ipa)",
     )
+    parser.add_argument("--dependency-build", type=Path, help="Original Xcode build containing dependency license files")
+    parser.add_argument("--reference-root", type=Path, help="Pinned reference checkout root (normally repo/ref)")
     args = parser.parse_args()
 
     repo = Path(__file__).resolve().parents[1]
@@ -38,7 +40,7 @@ def main() -> int:
     output = (
         args.output.resolve()
         if args.output
-        else repo / "artifacts/KartPad-v0.4.15-ios.1-unsigned.ipa"
+        else repo / "artifacts/KartPad-v0.4.17-ios.1-unsigned.ipa"
     )
     if subprocess.check_output(
         ["git", "-C", str(repo), "status", "--porcelain", "--untracked-files=all"],
@@ -67,24 +69,28 @@ def main() -> int:
     ).returncode == 0:
         fail("public IPA input app is still signed")
 
-    xcode_build = app.parents[1]
+    compiled = accepted_build(app)
+    verify_source_equivalence(repo, source_commit)
+    xcode_build = args.dependency_build or app.parents[1]
+    reference_root = args.reference_root or repo / "ref"
     additional_entries = {
         "INSTALL_IPA.md": repo / "docs/INSTALL_IPA.md",
-        "RELEASE_NOTES.md": repo / "docs/releases/v0.4.15-ios.1.md",
+        "RELEASE_NOTES.md": repo / "docs/releases/v0.4.17-ios.1.md",
+        "SOURCE_AND_REBUILD.md": repo / "docs/releases/v0.4.17-ios.1-source.md",
         "MULTIPLAYER.md": repo / "docs/MULTIPLAYER.md",
         "LICENSE": repo / "LICENSE",
         "LICENSES/GPL-3.0.txt": repo / "LICENSES/GPL-3.0.txt",
         "RIGHTS_AND_LICENSES.md": repo / "RIGHTS_AND_LICENSES.md",
         "THIRD_PARTY_NOTICES.md": repo / "THIRD_PARTY_NOTICES.md",
         "ThirdPartyLicenses/Abseil-Apache-2.0.txt": xcode_build / "_deps/abseil-cpp-src/LICENSE",
-        "ThirdPartyLicenses/Aurora-MIT.txt": repo / "ref/upstream/Wiicompiled/aurora-main/LICENSE",
-        "ThirdPartyLicenses/Dolphin-COPYING.txt": repo / "ref/upstream/dolphin/COPYING",
-        "ThirdPartyLicenses/Dolphin-Externals.md": repo / "ref/upstream/dolphin/Externals/licenses.md",
+        "ThirdPartyLicenses/Aurora-MIT.txt": reference_root / "upstream/Wiicompiled/aurora-main/LICENSE",
+        "ThirdPartyLicenses/Dolphin-COPYING.txt": reference_root / "upstream/dolphin/COPYING",
+        "ThirdPartyLicenses/Dolphin-Externals.md": reference_root / "upstream/dolphin/Externals/licenses.md",
         "ThirdPartyLicenses/FreeType.txt": xcode_build / "_deps/freetype-src/LICENSE.TXT",
-        "ThirdPartyLicenses/Minizip-NG.txt": repo / "ref/upstream/dolphin/Externals/minizip-ng/minizip-ng/LICENSE",
+        "ThirdPartyLicenses/Minizip-NG.txt": reference_root / "upstream/dolphin/Externals/minizip-ng/minizip-ng/LICENSE",
         "ThirdPartyLicenses/SDL3-Zlib.txt": xcode_build / "_deps/sdl-src/LICENSE.txt",
         "ThirdPartyLicenses/Tracy-BSD-3-Clause.txt": xcode_build / "_deps/tracy-src/LICENSE",
-        "ThirdPartyLicenses/WiiCompiled-GPL-3.0.txt": repo / "ref/upstream/Wiicompiled/LICENSE",
+        "ThirdPartyLicenses/WiiCompiled-GPL-3.0.txt": reference_root / "upstream/Wiicompiled/LICENSE",
         "ThirdPartyLicenses/fmt-MIT.txt": xcode_build / "_deps/fmt-src/LICENSE",
         "ThirdPartyLicenses/imgui-MIT.txt": xcode_build / "_deps/imgui-src/LICENSE.txt",
         "ThirdPartyLicenses/libpng.txt": xcode_build / "_deps/png-src/LICENSE",
@@ -96,6 +102,7 @@ def main() -> int:
         fail(f"missing release notices: {', '.join(missing_notices)}")
     provenance = {
         "schemaVersion": 1,
+        **compiled,
         "releaseTag": RELEASE_TAG,
         "sourceCommit": source_commit,
         "appVersion": APP_VERSION,

--- a/tests/test_ios_release_provenance.py
+++ b/tests/test_ios_release_provenance.py
@@ -1,0 +1,39 @@
+import importlib.util
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+spec = importlib.util.spec_from_file_location("ios_release", Path(__file__).resolve().parents[1] / "scripts/ios_release.py")
+release = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(release)
+
+
+class SourceEquivalenceTests(unittest.TestCase):
+    def test_documentation_allowed_but_runtime_change_rejected(self):
+        with tempfile.TemporaryDirectory() as temp:
+            repo = Path(temp)
+            def git(*args):
+                return subprocess.check_output(["git", "-C", temp, *args], stderr=subprocess.DEVNULL, text=True).strip()
+            git("init")
+            git("config", "user.name", "Test")
+            git("config", "user.email", "test@example.invalid")
+            (repo / "runtime").mkdir()
+            (repo / "runtime/code.cpp").write_text("accepted")
+            git("add", "."); git("commit", "-m", "accepted")
+            original = release.COMPILED_SOURCE
+            release.COMPILED_SOURCE = git("rev-parse", "HEAD")
+            try:
+                (repo / "README.md").write_text("release notes")
+                git("add", "."); git("commit", "-m", "documentation")
+                release.verify_source_equivalence(repo, "HEAD")
+                (repo / "runtime/code.cpp").write_text("changed")
+                git("add", "."); git("commit", "-m", "runtime")
+                with self.assertRaisesRegex(ValueError, "production inputs differ"):
+                    release.verify_source_equivalence(repo, "HEAD")
+            finally:
+                release.COMPILED_SOURCE = original
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Prepares iOS 0.4.17/build 39 from the accepted iPhone14 candidate. Packaging and audit now share one version definition, reject executables other than the accepted unsigned binary, preserve the original cf47944 compilation manifest, and verify production input equivalence against the packaging commit. The iOS preparation script determines which patches belong to that comparison, so unrelated Android and macOS release changes do not invalidate it.

Adds current release notes, dependency-root options for packaging an existing audited app, and embedded source/rebuild guidance. Original and Retro saves survived in-place installation on iPhone14/iOS26.6.2; an active race was observed and the owner accepted the requested race/relaunch trial. The matching iPhone17/iOS27 issue196 gate stays open.

Validation: focused regression verifies that documentation changes are accepted but runtime changes are rejected; exact app and IPA audits pass; packaging is deterministic across two runs. This PR does not change the installed phone, game runtime, README or install guide, and does not publish a release.
