### PR TITLE
Reconcile Apple releases and physical candidate evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ chooser, game-data management, packaging, and release workflows.
 | Platform | Download | Setup |
 | --- | --- | --- |
 | Android ARM64 | [0.4.16 Android 2 · code 65](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.16-android.2) | [Android 9+ with Vulkan](docs/INSTALL_ANDROID.md) |
-| iPhone / iPad | [0.4.15 · build 34](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.15-ios.1) | [iOS/iPadOS 16+; re-sign the IPA](docs/INSTALL_IPA.md) |
-| Apple Silicon Mac | [0.4.15 · build 34](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.15-macos.1) | [macOS 14+](docs/INSTALL_MACOS.md) |
+| iPhone / iPad | [0.4.17 · build 39](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.17-ios.1) | [iOS/iPadOS 16+; re-sign the IPA](docs/INSTALL_IPA.md) |
+| Apple Silicon Mac | [0.4.17 · build 39](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.17-macos.1) | [macOS 14+](docs/INSTALL_MACOS.md) |
 | Apple TV experimental preview | [0.4.11 · build 9](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.11-tvos.1) | [tvOS 17+; re-sign the IPA](docs/INSTALL_TVOS.md) |
 
 **Android 0.4.16 Android 2 is now available.** It refreshes the translated
@@ -63,12 +63,15 @@ These local mode comparisons are not an across-device or old-public-versus-new-p
 benchmark. Menu delays and device-specific graphics issues remain open. See the
 [measurements and release notes](docs/releases/v0.4.16-android.2.md).
 
-**iPhone/iPad 0.4.15** adds an actual log-review screen, an unchecked acknowledgment
-and an explanation when logs cannot be attached. It retains the newer chooser
-and setup help. **macOS 0.4.15** brings the Metal view-lifetime correction to Mac;
-it does not establish a tearing or performance fix. See the
-[iPhone/iPad](docs/releases/v0.4.15-ios.1.md) and
-[macOS](docs/releases/v0.4.15-macos.1.md) notes.
+**iPhone/iPad 0.4.17** supports Retro Rewind 6.12.8 and includes the corrected
+compiled REL-report guard. The owner accepted the bounded iPhone 14 trial;
+saves and configuration survived the in-place update. The affected iPhone 17
+Pro Max/iOS 27 test remains pending. See the
+[iPhone/iPad notes](docs/releases/v0.4.17-ios.1.md).
+**macOS 0.4.17** includes the viewport interpolation correction and compiled
+REL-report guard for Retro Rewind 6.12.8. Local Original/Retro rendering, audio
+and keyboard smoke checks passed; the reported two-player scene remains a
+separate test. See the [Mac notes](docs/releases/v0.4.17-macos.1.md).
 
 Download the checksums and accompanying notices with each package. The releases
 also include the [source bundle and rebuild instructions](docs/artifacts/2026-09-10/android-source-delivery.md). **Update in
@@ -109,7 +112,7 @@ known issues. Android's suggested starting point is **1x Native**. Sustained
 <details>
 <summary>Can I download an IPA or playable app?</summary>
 
-Yes—use the [platform downloads above](#downloads). The current official iPhone/iPad build is **0.4.14 build 33**; Mac and Apple TV have separate packages. Apple IPAs need re-signing. Every package requires your own supported game data. A [Personal IPA Builder](docs/BUILDER.md) is also available.
+Yes—use the [platform downloads above](#downloads). The current public iPhone/iPad build is **0.4.17 build 39**; Mac and Apple TV have separate packages. Apple IPAs need re-signing. Every package requires your own supported game data. A [Personal IPA Builder](docs/BUILDER.md) is also available.
 
 </details>
 

--- a/docs/INSTALL_IPA.md
+++ b/docs/INSTALL_IPA.md
@@ -1,12 +1,13 @@
 # Install the KartPad unsigned IPA
 
-KartPad `v0.4.15-ios.1` (0.4.15, build 34) is the current unsigned ARM64 IPA
-for iPhone and iPad. It is a free community release, not an App Store or
-TestFlight build. Re-sign it with your existing Apple identity or compatible
-personal sideloading tool before installing. It adds reviewed-log acknowledgment
-and an inability explanation while retaining the newer chooser and help. See the
-[release notes](releases/v0.4.15-ios.1.md). Focused UIKit and package checks passed;
-new full-game physical Apple acceptance is not claimed for this reporting update.
+KartPad `v0.4.17-ios.1` (0.4.17, build 39) is the current unsigned ARM64 IPA
+for iPhone and iPad, with the official Retro Rewind 6.12.8 profile. Re-sign it
+with your existing compatible Apple identity and update in place.
+
+This build includes the corrected compiled REL-report guard. The owner accepted
+the bounded iPhone 14 race-and-relaunch trial, with saves and configuration
+preserved. The separate iPhone 17 Pro Max/iOS 27 report still needs matching
+hardware confirmation. See the [release notes](releases/v0.4.17-ios.1.md).
 
 The IPA declares **iOS/iPadOS 16 or newer** and an ARM64 device with Metal.
 The generic ARM64 startup correction is retained. The A10X reporter confirmed
@@ -20,11 +21,10 @@ Older IPAs should remain offline. This does not erase incorrect serial history
 already held by a server or clear bans; affected accounts may need service-admin
 help. Never reset identities or delete saves as a workaround.
 
-1. Download `KartPad-v0.4.15-ios.1-unsigned.ipa` and `SHA256SUMS` from the
-   [official iPhone/iPad release](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.15-ios.1).
-2. Run `shasum -a 256 KartPad-v0.4.15-ios.1-unsigned.ipa` on a Mac and
-   compare it with the IPA row in `SHA256SUMS`. The notices and shared source
-   have separate rows; the source download is optional for normal installation.
+1. Download `KartPad-v0.4.17-ios.1-unsigned.ipa` and `SHA256SUMS-ios` from the
+   [official iPhone/iPad release](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.17-ios.1).
+2. Run `shasum -a 256 KartPad-v0.4.17-ios.1-unsigned.ipa` on a Mac and
+   compare it with the IPA row in `SHA256SUMS-ios`. The source download is optional for normal installation.
 3. Re-sign and install it with AltStore Classic plus AltServer or another
    compatible IPA-signing workflow. AltStore PAL cannot import arbitrary
    unsigned IPA files.
@@ -33,7 +33,7 @@ help. Never reset identities or delete saves as a workaround.
    DATA folder also works; convert RVZ before importing.
 5. Choose **Mario Kart Wii** for the original game or **Retro Rewind** for the
    optional expanded game. KartPad can download, verify, and install the
-   official version-locked Retro Rewind 6.12.7 full pack.
+   official version-locked Retro Rewind 6.12.8 full pack.
 
 Choose **Help** on the game chooser for the two-step setup instructions and
 GitHub guides. The normal landscape iPhone chooser fits without scrolling;

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,7 +3,7 @@
 [Coordinator runbook and implementation plan](MAINTENANCE-AUTOMATION.md) ·
 [Canonical active queue](MAINTENANCE-BOARD.md).
 
-Updated: 10 September 2026. This page summarizes acceptance, not a full test log.
+Updated: 13 September 2026. This page summarizes acceptance, not a full test log.
 Use the [maintenance board](MAINTENANCE-BOARD.md) for candidate ownership and
 next actions, and [known issues](KNOWN-ISSUES.md) for current reports.
 
@@ -11,9 +11,9 @@ next actions, and [known issues](KNOWN-ISSUES.md) for current reports.
 
 | Platform | Package | Acceptance boundary |
 | --- | --- | --- |
-| Android | [0.4.14 preview 1, code 63](releases/v0.4.14-android-preview.1.md) | Owner-accepted payload, refreshed chooser, reporting, pack-update save protection and measured local rendering improvement; broader GPU/performance and cup behavior remain open |
-| iPhone / iPad | [0.4.15, build 34](releases/v0.4.15-ios.1.md) | New log-review acknowledgment/inability flow; retains accepted chooser. Full compile/archive and focused UIKit checks passed; no new full-game physical or performance acceptance claimed |
-| Apple Silicon Mac | [0.4.15, build 34](releases/v0.4.15-macos.1.md) | Metal view-lifetime correction, complete build/archive and native helper checks; tearing and external-display reports remain open |
+| Android | [0.4.16 Android 2, code 65](releases/v0.4.16-android.2.md) | Physical Pixel launch, touch, Retro WFC login and worldwide lobby entry; complete race/results/reconnect, broader GPU/performance and cup behavior remain open |
+| iPhone / iPad | [0.4.17, build 39](releases/v0.4.17-ios.1.md) | Corrected compiled REL guard, owner-accepted bounded iPhone 14 trial and preserved saves/configuration; iPhone 17 Pro Max/iOS 27 and online acceptance remain open |
+| Apple Silicon Mac | [0.4.17, build 39](releases/v0.4.17-macos.1.md) | Fresh build, viewport/REL checks and isolated Original/Retro rendering, audio and keyboard smoke; exact reporter two-player scene, full races and controller overhaul remain unaccepted |
 | Apple TV experimental | [0.4.11, build 9](releases/v0.4.11-tvos.1.md) | Published identity-fix and compiler-hardened package; exact-build hardware acceptance remains open |
 
 [Download and install](../README.md#downloads). All listed packages include the
@@ -23,6 +23,13 @@ identity history or bans. Older affected packages should stay offline.
 The September 10 releases include the [joint source delivery](artifacts/2026-09-10/android-source-delivery.md)
 and [verified download ledger](artifacts/2026-09-10/platform-release-verification.md).
 Historical local candidates are retained in their dated records.
+
+## Current device acceptance
+
+The owner accepted the bounded iPhone 14 trial of **0.4.17/build 39** on
+13 September. Saves, identity and configuration were preserved during the
+in-place upgrade. The unsigned IPA delivers that executable with the original compilation
+manifest retained. This does not close the iPhone 17 Pro Max/iOS 27 report. See the [candidate handoff](artifacts/2026-09-13/platform-candidate-handoff.md).
 
 ## Established results and remaining limits
 

--- a/docs/artifacts/2026-09-13/platform-candidate-handoff.md
+++ b/docs/artifacts/2026-09-13/platform-candidate-handoff.md
@@ -1,0 +1,58 @@
+# Platform candidate handoff — 13 September 2026
+
+## iPhone and iPad candidate
+
+KartPad 0.4.17/build 39 was installed in place on the owner's iPhone 14 running
+iOS 26.6.2. The owner answered the Original/Retro race-and-relaunch request with
+“it works its fine”; a live race was also visually observed. This establishes
+owner acceptance of this bounded trial, not measured performance or online
+race/reconnect acceptance. The iPad was not changed in this pass.
+
+The executable was compiled from cf47944d1a841f60e7e774dd44e44dc99341fd92.
+Comparison against packaging source 1bfccebb531ba9407227829c6871048427c32de6
+verified identical Apple/runtime/patch/profile/build inputs. The original
+compilation manifest was retained, and a separate equivalence manifest records
+the version-only packaging update. The corrected compiled REL guard and
+viewport interpolation source are included.
+
+The same app identifier and signing team were retained. Existing game data
+was already present, so no image replacement was needed. Protected saves,
+identity, Mii, rating and preferences were backed up and read back: 25 of 26
+files were identical; the configuration file only changed formatting and
+parsed to identical values. No app uninstall, data reset or identity migration
+was performed.
+
+The initial private handoff was packaged twice byte-identically; the official
+release is packaged separately with current notes, source guidance and licenses.
+The exact public checksum is recorded in the release's SHA256SUMS-ios file.
+The original compilation manifest is retained, and the release scripts reject
+an unexpected executable or changed production source inputs.
+
+Issue #196 still needs the affected iPhone 17 Pro Max/iOS 27 test; the iPhone 14
+result does not close it. The older public build 36 release notes were corrected
+to disclose its incomplete aggregate-shard guard.
+
+## macOS
+
+Version 0.4.17/build 39 includes the viewport interpolation and compiled REL
+corrections. A fresh build, strict app audit, focused regressions and isolated
+Original/Retro rendering, audio and keyboard-navigation checks passed. The
+package was produced twice byte-identically. Full races, the reporter's exact
+two-player scene and the separate PR #112 controller overhaul are not accepted
+by this smoke test.
+
+During smoke setup, a defaults command changed the live app's last-selected
+profile to Original despite the intended isolation. No save data was touched;
+the previous selection was not captured, so it was not guessed or restored.
+The remaining smoke test used a separate app identity and portable data.
+
+## Android
+
+The code-78 device candidate is built from current reviewed production source,
+with the PR #240 correction to duplicate test-stub patch application. This
+build preparation correction leaves production rendering code unchanged.
+Public Android remains 0.4.16 Android 2/code 65 until an accepted,
+community-signed successor is published. The owner's test APK uses the same
+debug signer as their installed app to preserve its data; it is separate from
+the community-signed public update. Physical candidate results will be recorded
+after installation and owner testing.


### PR DESCRIPTION
The download table and installation guide still linked older Apple packages, and public build 36 was described as fixing a crash that remained in its compiled shard. Point to the current 0.4.17 Apple releases and record the bounded iPhone owner trial and Mac smoke evidence, with the affected iOS 27 and split-screen gates still open.

Record the data-preserving Android test handoff separately from its public release, retain compilation-versus-packaging provenance, and disclose the Mac test's selected-profile side effect. No runtime or device state is changed by this documentation PR.

Validation: all local links in the four changed documents resolve; git diff --check passes. Exact package/device evidence was checked with the platform owners.
