### PR TITLE
Clarify shipped fixes and current acceptance gates

### DIFF
--- a/docs/MAINTENANCE-BOARD.md
+++ b/docs/MAINTENANCE-BOARD.md
@@ -1,6 +1,6 @@
 # Maintenance work and test board
 
-Snapshot: 12 September 2026. Current GitHub refresh: 43 open issues. Start at the
+Snapshot: 13 September 2026. Current GitHub refresh: 45 open issues. Start at the
 [support-agent hub](SUPPORT-AGENTS.md). The [priority source](maintenance-priorities.json)
 owns ordering, readiness, exact next actions and acceptance; this board records
 support decisions and evidence. Refresh GitHub and local ownership before acting.
@@ -20,7 +20,7 @@ the next actions below supersede those dated assignments.
 | --- | --- | --- |
 | 0 / `retro-save-loss` | #169 / 1 | `awaiting-reporter`: classify lost progress and ordinary exit versus pack replacement from the existing request. Do not deliberately lose more data. |
 | 1 / `android-exits` | #143, #200, #205, #208–210, #128, #131, #207, #215, #216 / 9 | `awaiting-reporter`: one matching exit classification per distinct launch/cup/race subcase. #208 is canonical for #209/#210; similar wording does not establish a common runtime defect. |
-| 1 / `ios27-startup` | #196 / 1 | `awaiting-owner`: signing/release operator prepares a clean, uniquely versioned corrected candidate; matching iPhone 17 Pro Max/iOS 27 tester accepts launch, race and relaunch in both profiles. Regenerate from the [guard/control-flow correction](artifacts/2026-09-12/issue196-rel-report-build-integrity.md); the old private aggregate must not be promoted. |
+| 1 / `ios27-startup` | #196 / 1 | `awaiting-reporter`: corrected [0.4.17/build39 IPA](https://github.com/chrissotraidis/kartpad/releases/tag/v0.4.17-ios.1) published and owner-accepted on iPhone14; matching iPhone17 Pro Max/iOS27 Original/Retro race/relaunch result remains. Do not repeat completed build/simulator work. |
 | 2 / `android-online` | #206 / 1 | `awaiting-reporter`: await #206's already requested Wi-Fi endurance confirmation beyond the prior four/five-race window. #123 is closed upstream and remains historical evidence only; closure is not technical online acceptance. |
 | 3 / `adreno-geometry` | #102, #104, #120, #137, #166, #193, #211 / 7 | `awaiting-owner`: release operator and affected-device tester establish compatible signing/delivery for the retained dynamic/literal/dynamic character-draw comparison. No GPU-wide cause or correction is established. |
 | 4 / `warmed-performance` | #198, #167, #103, #169, #195, #204, #207, #135 / 8 | `awaiting-owner`: #198 tester is willing. The prepared profiler needs compatible signing or an approved data-preserving route **and** private delivery before capture. Retained Debug-signed APK is not a public-app in-place upgrade. |
@@ -38,7 +38,7 @@ when creating/updating a handoff. A request is not evidence that a test started.
 
 | Request / evidence | Disposition and next gate |
 | --- | --- |
-| [#196 published build audit](https://github.com/chrissotraidis/kartpad/issues/196#issuecomment-5642179928) and [simulator result](https://github.com/chrissotraidis/kartpad/issues/196#issuecomment-5640549937) | Public v0.4.16-ios.2/build 36 still contains the reported aggregate-shard load. Historical simulator passes do not accept the new correction: a [host regression](artifacts/2026-09-12/issue196-rel-report-build-integrity.md) exposed missing loop initialization/count-check code in that private aggregate. Regenerate a new signed candidate; matching hardware acceptance remains unperformed. |
+| [#196 corrected release handoff](https://github.com/chrissotraidis/kartpad/issues/196#issuecomment-5649940869) | Build36 retains the historical fault; published0.4.17/build39 contains the corrected compiled guard. Clean simulator checks, iPhone14 owner trial and public package audits completed. Matching iPhone17/iOS27 acceptance remains pending. |
 | [#123 closed upstream](https://github.com/chrissotraidis/kartpad/issues/123) and [last maintainer response](https://github.com/chrissotraidis/kartpad/issues/123#issuecomment-5644306282) | GitHub records `CLOSED` / `COMPLETED` at 2026-09-12T07:41:52Z. The final comment separates a music workaround for menu lag from reported online-race frame drops. This is a support-state reconciliation, not a technical fix or race/results/reconnect acceptance; do not assign more #123 work unless it is reopened with new evidence. |
 | [#206 cellular/Wi-Fi comparison](https://github.com/chrissotraidis/kartpad/issues/206#issuecomment-5642749400) | `awaiting-reporter`: [acknowledgement posted](https://github.com/chrissotraidis/kartpad/issues/206#issuecomment-5642834780). On Samsung SM-S921W / Android 14 / build 65, mobile data worked once while Wi-Fi reportedly works normally. This is sufficient to isolate a network-dependent subcase; it does not prove a NAT, carrier or guest-runtime cause. Await the already requested confirmation that Wi-Fi passes beyond the prior four/five-race window before claiming a stable workaround; do not repeat the acknowledgement, known build/device questions or generic log request. |
 | [#211 Retro screenshot response](https://github.com/chrissotraidis/kartpad/issues/211#issuecomment-5642589742) | `needs-one-detail`: Galaxy S24 Ultra and corruption in both profiles are supplied. Current in-app build and official pack version remain requested. Do not ask the handset again or infer GPU/driver. |
@@ -67,7 +67,7 @@ current comments and the linked source scope before promoting one into active wo
 | Retro installation/version | #192 download/import and #194 updater design. Verify current app/official pack and last completed step; separate executable compatibility from a request for automatic updates. |
 | Input/system UI | #119 bars, #184 mapping, #197 menu input, #202 aspect/display. Match physical/touch and chooser/gameplay paths; no renderer patch for an unclassified button/inset report. #184 has a bounded feature scope in [future features](FUTURE-FEATURES.md#android-d-pad-and-shoulder-remapping). |
 | External display | #100 and #199. Match local-only, wired and AirPlay transitions/recovery separately. Existing Metal/source checks are not affected-display acceptance. |
-| Apple controls/projection/multiplayer | #5, #91, #101, #127; open PRs [#112](https://github.com/chrissotraidis/kartpad/pull/112) and [#157](https://github.com/chrissotraidis/kartpad/pull/157). Reconcile current heads, candidate ownership and exact controller/split-screen scene before another build. |
+| Apple controls/projection/multiplayer | #5, #91, #101, #127; open PR [#112](https://github.com/chrissotraidis/kartpad/pull/112); [#157](https://github.com/chrissotraidis/kartpad/pull/157) shipped in Mac0.4.17. Reconcile current heads, candidate ownership and exact controller/split-screen scene before another build. |
 | Apple performance | #135. A10X startup is already accepted; remaining frame-rate concern needs its own affected-device comparison, separate from Android CPU/GPU hypotheses. |
 | Save/rating lifecycle | #105 manual transfer is accepted; automatic two-way sync and Mii scope remain distinct. #169 lost progress must be classified separately from performance and system bars. |
 | Feature/compatibility | #90 Original Wiimmfi, #91 controller/DSU, #203 disc revision/NAND/cheats. Define requested behavior, supported input and implementation boundary; do not request generic logs for missing features. |
@@ -86,3 +86,16 @@ current comments and the linked source scope before promoting one into active wo
 For every update, distinguish source corrected, candidate, host/simulator,
 physical/reporter acceptance and release. Commit reviewed public queue changes
 in the maintenance loop; no status-page edit establishes that a build is stable.
+
+## September 13 delivery and controls update
+
+The Community Release signing key has been located and its certificate verified.
+Earlier missing-key preflight conclusions were incorrect; private credentials
+remain outside this record. This removes the signing-location dependency, not
+the requirement to derive and audit each diagnostic/public candidate.
+
+Apple0.4.17 downloads are published. Android code78 passed the owner's bounded
+Retro race/touch trial; possible Retro WFC menu lag remains uncertain. Two
+licenses are accepted by the owner and must not be merged/reset. FPS-size and
+responsive-editor work (#238) is in progress; see the
+[controls audit](artifacts/2026-09-13/android-controls-request-audit.md).

--- a/docs/artifacts/2026-09-13/android-controls-request-audit.md
+++ b/docs/artifacts/2026-09-13/android-controls-request-audit.md
@@ -1,0 +1,30 @@
+# Android controls and device acceptance — 13 September 2026
+
+The owner accepts code78 after a playable random Retro single-player race and
+reports touch settings working. The owner sees two online licenses and explicitly
+accepts leaving them intact. No license deletion, merge or identity reset is
+justified. Retro WFC menus may feel slower than before, but this is uncertain,
+not a measured regression or online race/results/reconnect acceptance.
+
+| Request | Actual state and next action |
+| --- | --- |
+| #184 shoulder to D-pad Up | PR219 merged; code78 includes it, public code65 does not. General race acceptance is not a physical remapping test. |
+| #238 Show D-pad control | Latest reporter sees dim D-pad but only Back, no Show. Editor has fixed800dp children plus padding. Responsive editor correction and small-landscape verification are next; instructions alone are not a solution. |
+| FPS size | New owner request: existing Show FPS boolean is insufficient. Add persistent size submenu without changing render resolution or touch scale. |
+| #119 notification/navigation bars | Correction shipped since build23, reporter acceptance pending. Verify launch/menu/resume; do not advertise as newly implemented. |
+| #202 Thor fullscreen | Surface/inset boundary remains unresolved, distinct from transient bars. No projection change without reproduction. |
+| #197 ipega menu input | Touch/controller failure after controller use remains open. Needs touch-only to controller-use/disconnect to touch handoff test. |
+| #5 and #91 | Mainly Mac Wii controllers and tvOS DSU; separate from Android touch editor scope. |
+| #162 motion steering | Reporter closed after finding existing setting. No new feature needed. |
+
+## Signing correction
+
+The established community release identity was located and its certificate
+matches the published Android signer. Earlier missing-key reports were wrong:
+the search omitted PKCS12 files. Credential contents and paths remain private.
+Public APK derivation can proceed once the final candidate is accepted and its
+clean release provenance, signer, archive and notices checks pass.
+
+The code78 pre/post inventory checked identical paths, not byte hashes.
+Preserve that distinction in any release notes. Two observed licenses alone do
+not establish a new identity created by this upgrade.

--- a/docs/maintenance-priorities.json
+++ b/docs/maintenance-priorities.json
@@ -26,8 +26,6 @@
         200,
         205,
         208,
-        209,
-        210,
         128,
         131,
         207,
@@ -51,13 +49,13 @@
         196
       ],
       "state": "awaiting-reporter",
-      "next_action": "Release/signing operator must regenerate translation and prepare a fresh runtime from a clean immutable source containing the REL report build-integrity correction. The old private aggregate lost its initial section-count check and must not be promoted; see docs/artifacts/2026-09-12/issue196-rel-report-build-integrity.md. Verify guarded compiled control flow, use a unique signed build, then have the matching iPhone 17 Pro Max/iOS 27 tester perform in-place data-preserving Original and Retro launch/race/relaunch checks. Do not rebuild from the dirty checkout or treat historical simulator passes as acceptance of the new candidate.",
+      "next_action": "The corrected 0.4.17/build39 IPA is published and owner-accepted on iPhone14. Await the already requested in-place Original/Retro launch/race/relaunch result on the affected iPhone17 Pro Max/iOS27. Use https://github.com/chrissotraidis/kartpad/issues/196#issuecomment-5649940869; do not regenerate or repeat simulator checks without new source/evidence.",
       "dependency": {
-        "owner": "release/signing operator and matching iOS 27 tester",
-        "needs": "A provisioning-capable signed candidate from a clean immutable source boundary and an attached/matched iPhone 17 Pro Max running iOS 27"
+        "owner": "issue-196 affected-device reporter",
+        "needs": "Install the published unsigned IPA with the existing compatible identity and return the requested matching-device result; no uninstall or reset."
       },
       "acceptance": "The same corrected candidate preserves existing data and passes both Original and Retro launch, race and relaunch on the matching iPhone 17 Pro Max/iOS 27 target. Package/reporter/release acceptance remain separate.",
-      "checkpoint": "docs/artifacts/2026-09-12/issue196-rel-report-build-integrity.md",
+      "checkpoint": "docs/artifacts/2026-09-13/platform-candidate-handoff.md",
       "priority_reason": "A game that cannot launch cannot meet offline or online acceptance."
     },
     {
@@ -89,7 +87,7 @@
         211
       ],
       "state": "awaiting-owner",
-      "next_action": "Android release/signing operator and an affected-device reporter must confirm a matching signer and tester handoff. Then build exactly the retained merge-guard source, audit the APK, and run dynamic-to-literal-to-dynamic on one failing character draw without clearing data; never reuse the overwritten .5 or scratch startup APK.",
+      "next_action": "The established Community Release key is available and its certificate matches. Prepare and audit the retained diagnostic candidate for a compatible signed private handoff, then run the affected-device dynamic-to-literal-to-dynamic comparison. Do not treat ordinary code78 race acceptance as an Adreno graphics fix or reuse overwritten/scratch candidates.",
       "dependency": {
         "owner": "Android release/signing operator and affected-device reporter",
         "needs": "A matching-signer private handoff with confirmed S24/Adreno or Adreno 8xx target, current build/profile and permission to run the bounded three-phase comparison"
@@ -112,7 +110,7 @@
         135
       ],
       "state": "awaiting-owner",
-      "next_action": "The #198 profileable APK, symbols and capture instructions are prepared, but its Android Debug signer differs from the public Community Release signer. The release operator must establish a compatible signed candidate or an explicitly approved data-preserving test route and an approved private transfer channel before the already willing reporter captures the documented approximately 20-second 99-Hz warmed Helio G85 profile. Do not claim the retained APK upgrades the public app in place, publish it, rebuild speculatively, uninstall, clear data or ask willingness again.",
+      "next_action": "The established Community Release key is available and verified. Derive an audited compatible-signer profiler candidate and arrange the approved private handoff before the already willing #198 reporter performs the documented warmed Helio G85 capture. The retained debug APK itself is not a public-app update; no uninstall, data clear or repeated willingness request.",
       "acceptance": "A matched warmed affected-device comparison shows a useful frame-time improvement with guest semantics and stability preserved. No FPS claim from a host microbenchmark.",
       "checkpoint": "docs/MAINTENANCE-BOARD.md",
       "priority_reason": "Measure a slow warmed scene before optimizing; do not generalize one device to all GPUs.",
@@ -123,8 +121,8 @@
     }
   ],
   "priority_review": {
-    "date": "2026-09-12",
-    "reason": "User made stable online play across builds the central objective; startup/data loss remain prerequisites. New report volume alone does not override evidence or a feasible acceptance gate.",
+    "date": "2026-09-13",
+    "reason": "Reflect published corrected Apple builds, restored Android signing capability and closed duplicates. Owner code78 offline acceptance does not resolve online latency, other GPU reports or affected iOS27 acceptance.",
     "evidence": "docs/MAINTENANCE-BOARD.md"
   }
 }

--- a/docs/releases/v0.4.17-ios.1.md
+++ b/docs/releases/v0.4.17-ios.1.md
@@ -1,11 +1,18 @@
-# KartPad 0.4.17 for iPhone and iPad
+# KartPad 0.4.17 for iPhone and iPad — build 39
 
-Build 39 includes the corrected compiled REL-report guard, viewport interpolation changes and Retro Rewind save-preserving updates. The guard is present in the aggregate translation shards used by the executable; the earlier build 36 release did not establish that protection.
+This is the current recommended iPhone/iPad download, with Retro Rewind 6.12.8 support.
 
-The maintainer installed this candidate in place on an iPhone 14 running iOS 26.6.2. Original and Retro saves, Mii data, identity and preferences were preserved, and configuration values remained unchanged. An active race was observed and the owner accepted the requested Original/Retro race-and-relaunch trial. This is not measured performance or online compatibility validation.
+## Fixed in this update
 
-Issue #196 remains open for the reported iPhone 17 Pro Max/iOS 27 setup. This release does not claim that matching-device confirmation.
+- **Compiled REL-report crash path (#196):** the bounds guard now covers the aggregate code actually used by the executable and preserves its loop initialization and cleanup. Public build 36 still contained the faulting read. The underlying invalid metadata and the reported iPhone 17 Pro Max/iOS 27 case still require matching-device confirmation.
+- **Split-screen interpolation (#127):** identical draws from different cameras no longer share transform history. Regression tests reproduce and verify this specific defect; the reported Mac two-player scene remains a separate acceptance check.
 
-Requires iOS/iPadOS 16 or newer on ARM64. The IPA is unsigned: sign it with your existing compatible identity and install in place to preserve app data. Supply your own supported game image. No game image, saves or signing material are included.
+Existing Retro pack-update save preservation is retained; it is not a new fix for all reported save-loss scenarios. No online-menu latency, general FPS, external-display, or identity-merging fix is claimed.
 
-The accepted executable was compiled from `cf47944d1a841f60e7e774dd44e44dc99341fd92`. Packaging verifies that the release source has identical production inputs and retains the original compilation manifest. See `SOURCE_AND_REBUILD.md` inside the archive for the source and rebuild boundary.
+## Tested
+
+The owner accepted the bounded Original/Retro race-and-relaunch trial on iPhone 14/iOS 26.6.2. An active race was observed. The in-place upgrade preserved saves, Mii, identity and preferences; configuration values were unchanged. No fresh physical iPad trial was performed in this release pass. This evidence does not establish every iPad model, the affected iOS 27 phone, or complete online racing/reconnect behavior.
+
+The unsigned IPA was packaged twice identically and audited again after anonymous download. Requires iOS/iPadOS 16+, ARM64, your own supported game data and re-signing with your existing compatible identity. Replace the app in place; do not uninstall or reset game data.
+
+The accepted executable was compiled from cf47944d1a841f60e7e774dd44e44dc99341fd92. Packaging source1866570a5700e2dec945a8571122e6341bf21cbb verifies identical production inputs and retains the original compilation manifest. See SOURCE_AND_REBUILD.md inside the IPA.

--- a/docs/releases/v0.4.17-macos.1.md
+++ b/docs/releases/v0.4.17-macos.1.md
@@ -1,32 +1,17 @@
-# KartPad v0.4.17 macOS 1
+# KartPad 0.4.17 for Apple Silicon Mac — build 39
 
-This Apple Silicon macOS release includes the reviewed split-screen interpolation
-correction and the compiled REL-report guard, retaining Retro Rewind 6.12.8.
+This is the current recommended Mac download, retaining Retro Rewind 6.12.8.
 
-- Interpolation history stays within each camera viewport. This corrects a
-  reproduced renderer defect; the complete M5 MacBook Air two-player report
-  (#127) still requires the reporter's same-scene comparison.
-- Translated REL diagnostics validate section bounds while preserving loop
-  control flow. This is shared source hardening, not iPhone/iOS 27 acceptance.
-- The personal builder accepts the verified 6.12.8 translation count.
+## Fixed in this update
 
-The separate macOS controller/settings overhaul (#112) is not included.
-Online race completion, reconnect, sustained performance and external-display
-behavior are not newly certified by this release.
+- **Split-screen interpolation (#127):** transform history stays within each camera viewport, preventing identical draws from borrowing another player's history. This corrects a reproduced renderer defect; the exact reported M5 MacBook Air scene still needs comparison.
+- **Compiled REL-report guard:** validates section bounds while preserving loop initialization and cleanup in the aggregate translation. This is shared source hardening, not proof that unrelated crashes are fixed.
+- **Personal builder:** accepts the verified 6.12.8 function count instead of rejecting the supported translation.
 
-Requires Apple Silicon and macOS 14 or newer. Supply your own supported game
-data. The application is ad-hoc signed and is not notarized. Existing saves and
-settings stay in Application Support when replacing the application.
+The separate controller/settings overhaul in PR #112 is not included. No new general performance, tearing, external-display or online reconnect fix is claimed.
 
-## Validation
+## Tested
 
-A fresh dual-runtime Release build and strict app audit passed. Original and
-Retro Rewind 6.12.8 rendered their title and license-selection screens and
-responded to keyboard input in isolated local smoke tests. Host audio playback
-received non-silent PCM. Retro smoke used a separately identified copy of the
-same executable to isolate preferences. No completed race, physical controller,
-split-screen reporter scene or online session is claimed by this smoke test.
+Fresh dual-runtime Release build and strict app audit passed. Original and Retro rendered their title/license screens, accepted keyboard input, and produced non-silent audio in isolated smoke checks. Seven viewport regression cases passed (one inapplicable case skipped), alongside compiled guard regressions. These checks do not establish completed races, physical controllers, or the reporter's split-screen scene.
 
-The compiled REL guard regressions and seven viewport interpolation cases pass
-(one inapplicable parameter case skips). Packaging includes dependency notices
-and excludes game images, extracted assets, saves and signing credentials.
+The ZIP was packaged twice identically, anonymously downloaded and re-audited. Requires Apple Silicon/macOS14+ and your own supported game data. The app is ad-hoc signed, not notarized. Replace only the app to retain existing saves/settings.


### PR DESCRIPTION
Clarify the current Apple release notes with concrete fixed behavior, tested scope and unresolved reports. Record the owner's Android code78 race/touch acceptance separately from uncertain online-menu latency and the requested FPS/editor changes.

Correct the stale maintenance gates: iOS39 is published and awaits its affected reporter; the existing Android signing identity has been located and verified. Preserve both owner licenses and distinguish available touch features from missing or broken UI.

Validation:63 maintenance tests pass; git diff --check passes; live releases, issue comments and the certificate fingerprint were verified. No credentials, device identifiers or game data are included.
