### PR TITLE
Add Android FPS counter sizing

### DIFF
--- a/android/app/src/main/cpp/kartpad_runtime_settings_fixture_jni.cpp
+++ b/android/app/src/main/cpp/kartpad_runtime_settings_fixture_jni.cpp
@@ -7,6 +7,7 @@
 namespace {
 
 std::atomic<bool> g_show_fps{false};
+std::atomic<int> g_fps_size{0};
 std::atomic<int> g_aspect_mode{-1};
 std::atomic<int> g_resolution_milli{-1};
 
@@ -20,9 +21,10 @@ Java_dev_kartpad_android_KartPadActivity_nativeEnableActivityRecreation(
 
 extern "C" JNIEXPORT void JNICALL
 Java_dev_kartpad_android_KartPadActivity_nativeApplyDisplaySettings(
-    JNIEnv*, jobject, jboolean show_fps, jint aspect_mode,
+    JNIEnv*, jobject, jboolean show_fps, jint fps_size, jint aspect_mode,
     jfloat resolution_scale) {
   g_show_fps.store(show_fps == JNI_TRUE, std::memory_order_release);
+  g_fps_size.store(static_cast<int>(fps_size), std::memory_order_release);
   g_aspect_mode.store(static_cast<int>(aspect_mode), std::memory_order_release);
   g_resolution_milli.store(static_cast<int>(resolution_scale * 1000.0F),
                            std::memory_order_release);
@@ -31,9 +33,10 @@ Java_dev_kartpad_android_KartPadActivity_nativeApplyDisplaySettings(
 extern "C" JNIEXPORT jstring JNICALL
 Java_dev_kartpad_android_KartPadActivity_nativeDebugDisplaySettings(
     JNIEnv* env, jobject) {
-  char result[64]{};
-  std::snprintf(result, sizeof(result), "fps=%s aspect=%d scale=%.1f",
+  char result[80]{};
+  std::snprintf(result, sizeof(result), "fps=%s size=%d aspect=%d scale=%.1f",
                 g_show_fps.load(std::memory_order_acquire) ? "true" : "false",
+                g_fps_size.load(std::memory_order_acquire),
                 g_aspect_mode.load(std::memory_order_acquire),
                 g_resolution_milli.load(std::memory_order_acquire) / 1000.0);
   return env->NewStringUTF(result);

--- a/android/app/src/main/cpp/kartpad_runtime_settings_jni.cpp
+++ b/android/app/src/main/cpp/kartpad_runtime_settings_jni.cpp
@@ -12,10 +12,11 @@ Java_dev_kartpad_android_KartPadActivity_nativeEnableActivityRecreation(
 
 extern "C" JNIEXPORT void JNICALL
 Java_dev_kartpad_android_KartPadActivity_nativeApplyDisplaySettings(
-    JNIEnv*, jobject, jboolean show_fps, jint aspect_mode,
+    JNIEnv*, jobject, jboolean show_fps, jint fps_size, jint aspect_mode,
     jfloat resolution_scale) {
   kartpad::android::PublishDisplaySettings({
       .show_fps = show_fps == JNI_TRUE,
+      .fps_size = static_cast<int>(fps_size),
       .aspect_mode = static_cast<int>(aspect_mode),
       .resolution_scale = static_cast<float>(resolution_scale),
   });

--- a/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt
@@ -574,6 +574,9 @@ class KartPadActivity : SDLActivity() {
     private fun showDisplayMenu() = showKartPadMenuPage(
         "Display",
         listOf(
+            MenuRow("FPS Counter Size…", R.drawable.ic_kartpad_speedometer) {
+                closeKartPadMenu(::showFpsSizeSettings)
+            },
             MenuRow("Aspect Ratio…", R.drawable.ic_kartpad_display) {
                 closeKartPadMenu(::showAspectRatioSettings)
             },
@@ -746,6 +749,19 @@ class KartPadActivity : SDLActivity() {
         applyDisplaySettings()
     }
 
+    private fun showFpsSizeSettings() {
+        val labels = arrayOf("Small", "Medium", "Large")
+        AlertDialog.Builder(this)
+            .setTitle("FPS Counter Size")
+            .setSingleChoiceItems(labels, KartPadTouchSettings.fpsSize(this)) { dialog, which ->
+                KartPadTouchSettings.setFpsSize(this, which)
+                applyDisplaySettings()
+                dialog.dismiss()
+            }
+            .setNegativeButton("Back") { _, _ -> showDisplayMenu() }
+            .show()
+    }
+
     private fun confirmSwitchGameVersion() {
         AlertDialog.Builder(this)
             .setTitle("Switch Game Version")
@@ -777,6 +793,7 @@ class KartPadActivity : SDLActivity() {
     private fun applyDisplaySettings() {
         nativeApplyDisplaySettings(
             KartPadTouchSettings.showFps(this),
+            KartPadTouchSettings.fpsSize(this),
             KartPadTouchSettings.aspectMode(this),
             KartPadTouchSettings.resolutionScale(this),
         )
@@ -1757,7 +1774,7 @@ class KartPadActivity : SDLActivity() {
                                     "size=$savedSize hide=$savedHide modern=$savedModern"
                             }
                             check(nativeDebugDisplaySettings() ==
-                                "fps=true aspect=0 scale=1.0"
+                                "fps=true size=0 aspect=0 scale=1.0"
                             ) { "touch settings changed the display resolution" }
                             Log.i(
                                 TAG,
@@ -1793,6 +1810,9 @@ class KartPadActivity : SDLActivity() {
                     check(editorLabel.text == "A size" && editorSize.isEnabled &&
                         editorVisibility.isEnabled && editorVisibility.text == "Hide"
                     ) { "editor did not expose selected A controls" }
+                    check(editorBack.isShown && editorVisibility.isShown &&
+                        editorBack.left >= 0 && editorVisibility.right <= editorBar.width
+                    ) { "editor actions were clipped outside ${editorBar.width}px" }
                     check(editorVisibility.performClick()) { "Hide did not accept click" }
                     check(KartPadTouchSettings.isHidden(this, "A") &&
                         editorVisibility.text == "Show"
@@ -1875,13 +1895,13 @@ class KartPadActivity : SDLActivity() {
                 setStroke(dp(2), Color.rgb(255, 199, 51))
             }
             visibility = View.GONE
-            addView(editorBack, LinearLayout.LayoutParams(dp(100), dp(52)))
-            addView(editorLabel, LinearLayout.LayoutParams(dp(250), dp(52)))
-            addView(editorSize, LinearLayout.LayoutParams(dp(340), dp(52)))
-            addView(editorVisibility, LinearLayout.LayoutParams(dp(110), dp(52)))
+            addView(editorBack, LinearLayout.LayoutParams(dp(88), dp(52)))
+            addView(editorLabel, LinearLayout.LayoutParams(0, dp(52), 0.8f))
+            addView(editorSize, LinearLayout.LayoutParams(0, dp(52), 1.2f))
+            addView(editorVisibility, LinearLayout.LayoutParams(dp(88), dp(52)))
         }
         val params = RelativeLayout.LayoutParams(
-            RelativeLayout.LayoutParams.WRAP_CONTENT,
+            RelativeLayout.LayoutParams.MATCH_PARENT,
             RelativeLayout.LayoutParams.WRAP_CONTENT,
         ).apply {
             addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
@@ -2138,7 +2158,7 @@ class KartPadActivity : SDLActivity() {
     }
 
     private external fun nativeApplyDisplaySettings(
-        showFps: Boolean, aspectMode: Int, resolutionScale: Float,
+        showFps: Boolean, fpsSize: Int, aspectMode: Int, resolutionScale: Float,
     )
 
     private external fun nativeEnableActivityRecreation()

--- a/android/app/src/main/java/dev/kartpad/android/KartPadTouchSettings.kt
+++ b/android/app/src/main/java/dev/kartpad/android/KartPadTouchSettings.kt
@@ -19,6 +19,7 @@ internal object KartPadTouchSettings {
     private const val HIDE_ON_CONTROLLER = "hide_on_controller"
     private const val MODERN_C_STICK = "modern_c_stick_horizontal"
     private const val SHOW_FPS = "show_fps"
+    private const val FPS_SIZE = "fps_size"
     private const val ASPECT_MODE = "aspect_mode"
     private const val RESOLUTION_SCALE = "resolution_scale"
     private const val MOTION_ENABLED = "motion_steering_enabled"
@@ -68,6 +69,13 @@ internal object KartPadTouchSettings {
 
     fun setShowFps(context: Context, value: Boolean) {
         preferences(context).edit().putBoolean(SHOW_FPS, value).apply()
+    }
+
+    fun fpsSize(context: Context): Int = preferences(context)
+        .getInt(FPS_SIZE, 0).coerceIn(0, 2)
+
+    fun setFpsSize(context: Context, value: Int) {
+        preferences(context).edit().putInt(FPS_SIZE, value.coerceIn(0, 2)).apply()
     }
 
     fun aspectMode(context: Context): Int = preferences(context)

--- a/patches/wiicompiled-android-runtime-settings.patch
+++ b/patches/wiicompiled-android-runtime-settings.patch
@@ -14,7 +14,7 @@ diff --git a/src/settings_overlay.cpp b/src/settings_overlay.cpp
  #include "runtime_log.h"
  
  #include <imgui.h>
-@@ -1009,5 +1014,25 @@ void RefreshHostSettings() noexcept {
+@@ -1009,5 +1014,29 @@ void RefreshHostSettings() noexcept {
              RT_LOG(RT_TAG_CONFIG) << "mobile runtime resolutionScale=" << resolutionScale << std::endl;
          }
      }
@@ -22,6 +22,9 @@ diff --git a/src/settings_overlay.cpp b/src/settings_overlay.cpp
 +    kartpad::android::DisplaySettings settings{};
 +    if (kartpad::android::ConsumeDisplaySettings(&settings)) {
 +        g_showFps = settings.show_fps;
++        constexpr float kFpsScales[]{1.0f, 1.5f, 2.0f};
++        const int fpsSize = std::clamp(settings.fps_size, 0, 2);
++        g_androidFpsOverlayScale = kFpsScales[fpsSize];
 +        const int aspectMode = std::clamp(settings.aspect_mode, 0, 2);
 +        uint32_t surfaceWidth = 0;
 +        uint32_t surfaceHeight = 0;
@@ -36,7 +39,8 @@ diff --git a/src/settings_overlay.cpp b/src/settings_overlay.cpp
 +        VISetFrameBufferScale(resolutionScale);
 +        RT_LOG(RT_TAG_CONFIG) << "android runtime aspectMode=" << aspectMode
 +                              << " resolutionScale=" << resolutionScale
-+                              << " showFps=" << g_showFps << std::endl;
++                              << " showFps=" << g_showFps
++                              << " fpsSize=" << fpsSize << std::endl;
 +    }
  #endif
  }

--- a/patches/wiicompiled-present-telemetry.patch
+++ b/patches/wiicompiled-present-telemetry.patch
@@ -1,9 +1,13 @@
 diff --git a/src/settings_overlay.cpp b/src/settings_overlay.cpp
 --- a/src/settings_overlay.cpp
 +++ b/src/settings_overlay.cpp
-@@ -714,8 +714,30 @@ void DrawGraphicsSettings() {
+@@ -714,8 +714,34 @@ void DrawGraphicsSettings() {
  }
  
++#if defined(__ANDROID__)
++float g_androidFpsOverlayScale = 1.0f;
++#endif
++
  void DrawFpsOverlay() {
 +    static uint64_t lastTelemetryPresentCount = 0;
      AuroraPresentTiming presentTiming{};
@@ -32,13 +36,29 @@ diff --git a/src/settings_overlay.cpp b/src/settings_overlay.cpp
      if (!g_showFps) {
          return;
      }
-@@ -737,6 +759,9 @@ void DrawFpsOverlay() {
+@@ -733,12 +757,25 @@ void DrawFpsOverlay() {
+                                          ImGuiWindowFlags_NoNav |
+                                          ImGuiWindowFlags_NoSavedSettings;
+     if (ImGui::Begin("FPS Overlay", nullptr, kFlags)) {
++#if defined(__ANDROID__)
++        ImGui::SetWindowFontScale(g_androidFpsOverlayScale);
++#endif
+         if (presentTiming.sampleCount == 0) {
+             ImGui::TextUnformatted("FPS: --");
+         } else {
              // Present timing includes the additional frames produced by
              // interpolation, so this remains the actual displayed FPS.
              ImGui::Text("FPS: %.1f", presentTiming.framesPerSecond);
++#if defined(__ANDROID__)
++            ImGui::Text("Frame ms: p50 %.1f  p95 %.1f",
++                        presentTiming.p50FrameTimeMs, presentTiming.p95FrameTimeMs);
++            ImGui::Text("p99 %.1f  worst %.1f",
++                        presentTiming.p99FrameTimeMs, presentTiming.worstFrameTimeMs);
++#else
 +            ImGui::Text("Frame ms: p50 %.1f  p95 %.1f  p99 %.1f  worst %.1f",
 +                        presentTiming.p50FrameTimeMs, presentTiming.p95FrameTimeMs,
 +                        presentTiming.p99FrameTimeMs, presentTiming.worstFrameTimeMs);
++#endif
              // Replay-unsafe frames hold the presented cadence with duplicated
              // slots, so the counter alone reads 180 while the motion on screen
              // is 60 Hz. Surface the divergence instead of hiding it.

--- a/runtime/include/kartpad/android/runtime_settings.hpp
+++ b/runtime/include/kartpad/android/runtime_settings.hpp
@@ -4,6 +4,7 @@ namespace kartpad::android {
 
 struct DisplaySettings {
   bool show_fps = true;
+  int fps_size = 0;
   int aspect_mode = 2;
   float resolution_scale = 1.0f;
 };

--- a/scripts/test-android-menu-parity.sh
+++ b/scripts/test-android-menu-parity.sh
@@ -86,6 +86,22 @@ if missing:
 PY
 }
 
+assert_checked_label() {
+  python3 - "$tree" "$1" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+
+tree, expected = sys.argv[1:]
+for node in ET.parse(tree).getroot().iter("node"):
+    if node.attrib.get("text") == expected:
+        if node.attrib.get("checked") != "true":
+            raise SystemExit(f"ERROR: {expected!r} was not selected after relaunch")
+        break
+else:
+    raise SystemExit(f"ERROR: selected label {expected!r} missing after relaunch")
+PY
+}
+
 assert_icon_count() {
   local expected="$1"
   local actual
@@ -175,8 +191,8 @@ start_menu
 tap_label "Display"
 sleep 1
 dump_tree
-assert_labels "Aspect Ratio…" "Render Resolution…"
-assert_icon_count 2
+assert_labels "FPS Counter Size…" "Aspect Ratio…" "Render Resolution…"
+assert_icon_count 3
 
 start_menu
 tap_label "Game Data & Saves"
@@ -246,6 +262,19 @@ assert_labels \
 
 open_submenu_action "Display" "Render Resolution…"
 assert_labels "Render Resolution" "1× (Native)" "2×" "3×" "4×"
+
+open_submenu_action "Display" "FPS Counter Size…"
+assert_labels "FPS Counter Size" "Small" "Medium" "Large"
+tap_label "Large"
+sleep 1
+fps_preferences="$("$adb" exec-out run-as dev.kartpad.android \
+  cat shared_prefs/kartpad_touch_controls.xml)"
+grep -Eq '<int name="fps_size" value="2"[[:space:]]*/>' <<<"$fps_preferences" || {
+  echo "ERROR: FPS counter size did not persist Large" >&2
+  exit 1
+}
+open_submenu_action "Display" "FPS Counter Size…"
+assert_checked_label "Large"
 
 open_submenu_action "Game Data & Saves" "Remove Stored Game Data…"
 assert_labels "Remove Stored Game Data?" "REMOVE" "CANCEL"
@@ -362,4 +391,4 @@ print(
 PY
 fi
 
-echo "Android menu parity passed: lane=$lane top=8 controls=5 display=2 data=6 actions=16 safe-insets=pass"
+echo "Android menu parity passed: lane=$lane top=8 controls=5 display=3 data=6 actions=17 safe-insets=pass"

--- a/scripts/test-android-touch-editor-flow.sh
+++ b/scripts/test-android-touch-editor-flow.sh
@@ -13,9 +13,15 @@ case "$lane" in
   *) echo "ERROR: lane must be phone or tablet" >&2; exit 64 ;;
 esac
 
-device_count="$("$adb" devices | sed -n '2,$p' | grep -c '[[:space:]]device$' || true)"
-[[ "$device_count" == 1 ]] || {
-  echo "ERROR: expected exactly one connected Android emulator/device" >&2
+emulator_targets="$("$adb" devices 2>/dev/null | awk '$1 ~ /^emulator-[0-9]+$/ && $2 == "device" {print $1}')"
+emulator_count="$(printf '%s\n' "$emulator_targets" | awk 'NF {count++} END {print count+0}')"
+[[ "$emulator_count" == 1 ]] || {
+  echo "ERROR: expected exactly one authorized Android emulator; no physical device will be modified" >&2
+  exit 1
+}
+export ANDROID_SERIAL="$emulator_targets"
+[[ "$("$adb" shell getprop ro.kernel.qemu | tr -d '\r')" == 1 ]] || {
+  echo "ERROR: target is not an emulator" >&2
   exit 1
 }
 

--- a/tests/test_android_touch_overlay_contract.py
+++ b/tests/test_android_touch_overlay_contract.py
@@ -256,6 +256,7 @@ class AndroidTouchOverlayContractTests(unittest.TestCase):
         self.assertIn('editorVisibility.text == "Show"', activity)
         self.assertIn('editorVisibility.text == "Hide"', activity)
         self.assertIn("editorBack.performClick()", activity)
+        self.assertIn("editorVisibility.right <= editorBar.width", activity)
         self.assertIn("touchSettingsDialog?.isShowing == true", activity)
         self.assertIn("resetTouchLayoutButton.performClick()", activity)
         self.assertIn("resetDialog.getButton(AlertDialog.BUTTON_POSITIVE).performClick()", activity)
@@ -310,6 +311,7 @@ class AndroidTouchOverlayContractTests(unittest.TestCase):
         for title in (
             '"KartPad"', '"Return to KartPad Menu"', '"Multiplayer…"',
             '"Show FPS Counter"', '"Controls"', '"Display"',
+            '"FPS Counter Size…"', '"Small"', '"Medium"', '"Large"',
             '"Game Data & Saves"', '"Controller Player Setup…"',
             '"Controller Button Mapping…"',
             '"Touch Control Settings…"', '"Motion Steering…"',
@@ -371,6 +373,26 @@ class AndroidTouchOverlayContractTests(unittest.TestCase):
         self.assertIn("ConsumeDisplaySettings", runtime_patch)
         self.assertIn("ConfigureMkwMobileAspectMode", runtime_patch)
         self.assertIn("VISetFrameBufferScale", runtime_patch)
+        settings = (REPO / "android/app/src/main/java/dev/kartpad/android/KartPadTouchSettings.kt").read_text()
+        self.assertIn("fps_size = 0", (REPO / "runtime/include/kartpad/android/runtime_settings.hpp").read_text())
+        self.assertIn("getInt(FPS_SIZE, 0).coerceIn(0, 2)", settings)
+        self.assertIn("putInt(FPS_SIZE, value.coerceIn(0, 2))", settings)
+        self.assertIn("KartPadTouchSettings.fpsSize(this)", activity)
+        self.assertIn("ImGui::SetWindowFontScale(g_androidFpsOverlayScale)",
+                      (REPO / "patches/wiicompiled-present-telemetry.patch").read_text())
+        telemetry_patch = (REPO / "patches/wiicompiled-present-telemetry.patch").read_text()
+        self.assertIn('ImGui::Text("Frame ms: p50 %.1f  p95 %.1f"', telemetry_patch)
+        self.assertIn('ImGui::Text("p99 %.1f  worst %.1f"', telemetry_patch)
+        self.assertIn("constexpr float kFpsScales[]{1.0f, 1.5f, 2.0f}", runtime_patch)
+
+    def test_touch_editor_actions_fit_the_available_landscape_width(self) -> None:
+        activity = (REPO / "android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt").read_text()
+        editor = activity.split("private fun addLayoutEditorBar()", 1)[1].split(
+            "private fun beginLayoutEditing()", 1,
+        )[0]
+        self.assertIn("RelativeLayout.LayoutParams.MATCH_PARENT", editor)
+        self.assertIn("LinearLayout.LayoutParams(dp(88), dp(52))", editor)
+        self.assertEqual(editor.count("LinearLayout.LayoutParams(0, dp(52)"), 2)
 
     def test_display_choice_labels_match_ios_and_mark_experiments(self) -> None:
         android = (REPO / "android/app/src/main/java/dev/kartpad/android/KartPadActivity.kt").read_text()
@@ -482,10 +504,10 @@ class AndroidTouchOverlayContractTests(unittest.TestCase):
         self.assertIn("TEST_MENU", runner)
         self.assertNotIn("shell pm clear dev.kartpad.android", runner)
         self.assertIn("expected_fps_value", runner)
-        self.assertIn("top=8 controls=5 display=2 data=6 actions=16", runner)
+        self.assertIn("top=8 controls=5 display=3 data=6 actions=17", runner)
         self.assertIn("assert_icon_count 7", runner)
         self.assertIn("assert_icon_count 5", runner)
-        self.assertIn("assert_icon_count 2", runner)
+        self.assertIn("assert_icon_count 3", runner)
         self.assertIn("assert_icon_count 6", runner)
         for icon in ("hand", "gyroscope", "antenna", "refresh", "trash", "mii"):
             self.assertIn(f"R.drawable.ic_kartpad_{icon}", activity)
@@ -493,6 +515,8 @@ class AndroidTouchOverlayContractTests(unittest.TestCase):
         self.assertIn('open_top_action "Report a Problem…"', runner)
         self.assertIn('open_submenu_action "Controls" "Touch Control Settings…"', runner)
         self.assertIn('open_submenu_action "Display" "Aspect Ratio…"', runner)
+        self.assertIn('open_submenu_action "Display" "FPS Counter Size…"', runner)
+        self.assertIn('name="fps_size" value="2"', runner)
         self.assertIn('open_submenu_action "Game Data & Saves" "Manage Saves…"', runner)
         self.assertIn('open_submenu_action "Game Data & Saves" "Player Identity…"', runner)
         self.assertIn('open_submenu_action "Game Data & Saves" "Import or Reimport Wii Disc Image…"', runner)


### PR DESCRIPTION
The Android FPS counter was difficult to read on high-density phones, and the landscape touch editor could clip its Show/Hide action beyond the screen. Display now offers persisted Small, Medium, and Large FPS sizes while retaining the existing Show FPS Counter toggle. Small preserves the prior 1.0 scale; Medium and Large use 1.5 and 2.0. The setting moves through the existing mutex-backed UI-to-render-thread snapshot and only scales the FPS ImGui window on Android. At larger sizes, Android splits frame timing across two short rows so the overlay fits without changing other platforms.

The touch editor now fills the available width with flexible label and slider columns plus fixed Back and Show/Hide actions.

Validation:

- Fresh dual-product Android preparation and the full code79 native build passed from the PR source.
- 35 Android touch/settings overlay contracts passed.
- On the physical Pixel at 2244×1008, Large rendered readable FPS and two timing rows without clipping and remained selected after force-stop/relaunch.
- On the same phone, selecting D-pad Up, Hide, Show, Back, and Done all worked. The Show action remained fully visible at `[2023,850][2221,967]` within the 2244-pixel screen, and Show restored the D-pad.
- The in-place code78-to-code79 update preserved the complete touch settings file byte-for-byte. The UI exercise added only `fps_size=2`; the D-pad visibility/layout was restored.
- `git diff --check` passed.

The broader emulator menu fixture could not reach its menu because Dawn aborted while setting up the API 36 emulator Vulkan device. That failure occurred before the changed menu/JNI path, so it is recorded as an environment limitation rather than a passing test.
