### PR TITLE
Record exact Android online-menu comparison

### DIFF
--- a/docs/artifacts/2026-09-13/android-controls-request-audit.md
+++ b/docs/artifacts/2026-09-13/android-controls-request-audit.md
@@ -28,3 +28,26 @@ clean release provenance, signer, archive and notices checks pass.
 The code78 pre/post inventory checked identical paths, not byte hashes.
 Preserve that distinction in any release notes. Two observed licenses alone do
 not establish a new identity created by this upgrade.
+
+## Menu-latency artifact comparison
+
+The retained exact code77/pixel5 APK has SHA-256
+`f6fa7ac91230f159fc2f1c34e99ff3244d4014df55dd714b5cf9cfbf0650af5c`.
+Its matched native executable contains the private deferred-receive path,
+including pending-receive cancellation and a direct nonblocking receive.
+It is not accurately described as merely a500ms wait variant.
+
+The accepted code78/device.1 APK has SHA-256
+`c0006af78a7c59960f227592f062acda1282912fd53645ed4c0966949404a0fb`.
+Its matched native executable loads5000ms before WaitForReadable for an empty
+logically blocking TCP receive, consistent with reviewed main. This difference
+is a plausible source of perceived menu latency, not a measured regression.
+The prior private experiment lacks demonstrated delayed-response, EOF/error,
+cancellation and descriptor-reuse acceptance; do not silently add it to the
+FPS/editor release.
+
+Next measurement, when the owner is not playing: one same-profile Wi-Fi WFC
+entry, correlating visible frame gaps with receive-wait durations. Preserve
+licenses and saves and do not log network payloads. Only if multi-second waits
+correlate should a narrow lower-wait candidate be compared, including slow-login
+success; keep networking changes separate from HUD sizing.


### PR DESCRIPTION
Record the matched code77 and code78 APK comparison to explain the owner's possible Retro WFC menu slowdown without claiming measured causation. Code77 contains the private deferred-receive experiment; code78 returns to main's5000ms blocking path. Keep networking experiments separate from the FPS/editor release.

Validation: artifact metadata/hashes and matched native disassembly reviewed; no device or network state changed. Documentation only.
