### PR TITLE
Clarify Android controls delivery and remaining acceptance

### DIFF
--- a/docs/FUTURE-FEATURES.md
+++ b/docs/FUTURE-FEATURES.md
@@ -7,26 +7,21 @@ pass.
 
 ## Android D-pad and shoulder remapping
 
-**Status:** Requested in [#184](https://github.com/chrissotraidis/kartpad/issues/184),
-10September2026; source scope reviewed, not implemented or released.
-The AYN Thor Max/Odin Controller user wants a physical right bumper to produce
-game D-pad Up for tricks/wheelies. Existing Android settings remap only game
-A/B/X/Y/Z to physical A/B/X/Y/left shoulder; D-pad and right shoulder remain direct.
-No logs are needed to establish the missing setting.
+**Status:** Implemented in [PR #219](https://github.com/chrissotraidis/kartpad/pull/219)
+and included in the current device candidate; public delivery and the affected
+AYN Thor/Odin controller trial remain separate gates.
 
-Start with explicit digital mappings for game D-pad directions and physical
-shoulders, preserving the existing menu/settings style and current defaults.
-Keep source-button and game-action names distinct. Migrate saved mappings without
-changing established controls. Decide conflicts explicitly so a remapped bumper
-does not silently fire both its old action and D-pad Up. Keep analog-trigger
-expansion separately scoped until its threshold/release behavior is tested.
+R and D-pad Up are configurable in Android Controller Button Mapping. Assigning
+Right Shoulder to D-pad Up swaps the old R assignment so actions remain distinct.
+Existing valid custom mappings migrate without a reset. Native mapping and
+Kotlin migration tests passed. Analog-trigger expansion remains separately scoped.
 
 Acceptance: press/release and held input, diagonals, simultaneous buttons,
 conflicts, reset, persistence across restart, disconnect/reconnect and touch
 handoff. Validate trick/wheelie and menus in Original and Retro on the named
 controller; unaffected default mappings must continue working. Android delivery
-does not establish iOS/macOS/tvOS parity. This can be a bounded source task while
-high-priority stability work awaits hardware, not a promise of the next release.
+does not establish iOS/macOS/tvOS parity. The next step is exact-candidate
+controller acceptance, not another implementation of the same mapping.
 
 ## RetroAchievements
 

--- a/docs/INSTALL_ANDROID.md
+++ b/docs/INSTALL_ANDROID.md
@@ -71,6 +71,17 @@ and local reporting tools. Touch controls are movable, resizable and hideable;
 the floating movement stick follows your initial thumb position within its
 pickup area. Existing custom layouts are preserved.
 
+The next 0.4.17 update adds **Display → FPS Counter Size… → Small / Medium /
+Large**. This changes the counter text only; the separate **Show FPS Counter**
+toggle controls visibility. It also keeps the touch editor's **Back** and
+**Show/Hide** actions on screen in narrow landscape layouts. These additions
+are in the current device candidate and are not in public code 65.
+
+The same candidate adds **R** and **D-pad Up** under Controller Button Mapping.
+Assigning Right Shoulder to D-pad Up swaps its former R assignment to avoid
+triggering both actions. Existing valid custom mappings are retained; the
+affected Thor/Odin controller still needs its own trial.
+
 The maintainer accepted Original Grand Prix gameplay using Razer Kishi, with
 touch controls hiding automatically when connected. The default mapping is
 A/B/X/Y directly, left stick to steer, Start to pause, left shoulder to Z,

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -31,6 +31,15 @@ The owner accepted the bounded iPhone 14 trial of **0.4.17/build 39** on
 in-place upgrade. The unsigned IPA delivers that executable with the original compilation
 manifest retained. This does not close the iPhone 17 Pro Max/iOS 27 report. See the [candidate handoff](artifacts/2026-09-13/platform-candidate-handoff.md).
 
+The owner also considers iPad and Mac good to release. That is owner acceptance;
+this pass's recorded physical Apple trial was on iPhone 14. Android code 78
+passed the owner's random Retro single-player race and touch-settings trial.
+A later candidate adds FPS text sizing and a responsive touch editor, which
+need their own UI checks. Two Android licenses are being preserved as requested;
+their presence does not prove that an update created an identity. Possible
+Retro WFC menu slowdown remains under investigation. See the
+[controls and acceptance audit](artifacts/2026-09-13/android-controls-request-audit.md).
+
 ## Established results and remaining limits
 
 - **Android:** the owner accepted Original Grand Prix with Kishi and automatic

--- a/docs/artifacts/2026-09-13/android-controls-request-audit.md
+++ b/docs/artifacts/2026-09-13/android-controls-request-audit.md
@@ -51,3 +51,11 @@ entry, correlating visible frame gaps with receive-wait durations. Preserve
 licenses and saves and do not log network payloads. Only if multi-second waits
 correlate should a narrow lower-wait candidate be compared, including slow-login
 success; keep networking changes separate from HUD sizing.
+
+The next networking candidate also needs stronger host coverage: immediate and
+partial data, delayed data on both sides of the proposed wait, timeout/EAGAIN,
+EOF, readiness followed by error, and preservation of nonblocking/UDP behavior.
+The current blocking-stream tests cover the policy constant and flag combinations
+only. Any deferred receive experiment additionally needs cancellation, descriptor
+generation/reuse and exactly-once completion checks before hardware comparison.
+A shorter timeout that rejects a slow valid response is not a latency fix.


### PR DESCRIPTION
Document which Android controls are already implemented, which are still awaiting public delivery, and which device reports remain open. Record owner acceptance separately from exact-build UI checks, preserve both Android licenses, and define the missing networking regression coverage before a menu-latency change. Validation: documentation diff review and git diff --check.